### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Context
+
+Describe the scenario where the bug occurs.
+
+## Current Behavior
+
+What is going wrong.
+
+## Expected Behavior
+
+What should happen instead.
+
+## Steps to Reproduce
+
+1. Step 1
+2. Step 2
+3. ...
+
+## Evidence
+
+Logs, screenshots, or any relevant output.
+
+## Environment
+
+- scanldr version (`scanldr --version`):
+- OS:
+- Bun version:
+- Manga / source involved (if applicable):
+
+## Additional Information
+
+Anything else that helps diagnose the problem.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,26 @@
+---
+name: Chore
+about: Technical task, maintenance, or tech debt
+labels: chore
+---
+
+## Context
+
+Why this task needs to be done.
+
+## Description
+
+Detail what needs to be done.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Impact
+
+Risks or areas affected by this change.
+
+## Additional Information
+
+Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,26 @@
+---
+name: Documentation
+about: Add, update, or fix documentation
+labels: documentation
+---
+
+## Context
+
+Which document or area is affected and why it needs to change.
+
+## Proposal
+
+What should be added, updated, or removed.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Affected Files
+
+- `docs/...`
+
+## Additional Information
+
+References, links, or supporting material.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,30 @@
+---
+name: Enhancement
+about: Improve or evolve existing functionality
+labels: enhancement
+---
+
+## Context
+
+What exists today and why it needs to evolve.
+
+## Current Situation
+
+How it works now and the limitations to address.
+
+## Proposal
+
+What should change and how it should behave afterwards.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Impact
+
+Which parts of the system are affected by this change.
+
+## Additional Information
+
+References, metrics, or any supporting material.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,30 @@
+---
+name: Feature
+about: Propose a new piece of functionality
+labels: feature
+---
+
+## Context
+
+What problem or need does this feature address?
+
+## Proposal
+
+Describe the proposed solution at a high level.
+
+## Expected Behavior
+
+How the feature should behave from the user's perspective.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Technical Considerations
+
+Implementation notes, dependencies, or impact on other modules.
+
+## Additional Information
+
+Mockups, references, or any supporting material.


### PR DESCRIPTION
## What this PR does

Adds five GitHub issue templates (feature, bug, enhancement, chore, docs) under `.github/ISSUE_TEMPLATE/`, plus a `config.yml` that disables blank issues so every new issue is filed under one of the categories.

## Why it exists

The categories mirror the Conventional Commits types used by release-please. Filing an issue with the right template makes the eventual PR title/category obvious and keeps the changelog clean.

## How it works inside

- One Markdown template per category (feature, bug, enhancement, chore, docs).
- Each has a frontmatter `labels` field so opening an issue auto-applies the matching label.
- `config.yml` sets `blank_issues_enabled: false` to force the picker.
- Templates are in English since the repo is public.

## What did not change

- No code added.
- No workflows touched.
- No branch-protection rules changed.

## Test plan

- [ ] After merge, hitting "New issue" on the repo shows all five templates.
- [ ] Blank-issue option is hidden.
- [ ] Each template applies its expected label.

## Notes for the reviewer

Dropped the `improvement` template from the source set since it overlapped with `enhancement`. Consolidated to a single category.