### PR TITLE
feat(cli): scaffold project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,15 @@ scanldr.db-wal
 scanldr.db-shm
 .scanldr-auth.json
 
+# Build / deps
+node_modules/
+dist/
+coverage/
+*.log
+
+# Environment
+.env
+.env.local
+
 # OS
 .DS_Store

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignore": ["dist/**", "node_modules/**", "coverage/**"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always"
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,43 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "scanldr",
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,5 +2,23 @@
   "name": "scanldr",
   "version": "0.0.0",
   "private": true,
-  "description": "Offline downloader for manga, HQ, manhwa, and webtoon — packages volumes as .cbz/.zip"
+  "description": "Offline downloader for manga, HQ, manhwa, and webtoon — packages volumes as .cbz/.zip",
+  "type": "module",
+  "module": "src/index.ts",
+  "bin": {
+    "scanldr": "src/index.ts"
+  },
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "dev": "bun --watch run src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "check": "biome check .",
+    "format": "biome format --write .",
+    "lint": "biome lint ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+import { parseArgs } from "node:util";
+
+const VERSION = "0.0.0";
+
+const USAGE = `scanldr — offline downloader for manga, HQ, manhwa, and webtoon
+
+Usage:
+  scanldr <command> [args] [flags]
+
+Commands:
+  auth                          Open browser for Cloudflare bypass, save session
+  list <manga>                  List volumes, chapters, languages, groups
+  download <manga> --volume <n> Download volumes (e.g. 1, 1-5, 1,3,7, 1-5,8,10)
+  download <manga> --chapter <n> Download chapters (same range syntax)
+  update <manga>                Download what is missing in history
+  sync                          Run update for every active subscription
+  watch <manga>                 Add to subscription list
+  unwatch <manga>               Remove from subscription list (history is kept)
+  watchlist [--paused]          List subscriptions
+  pause <manga>                 Skip a subscription on sync
+  resume <manga>                Re-enable a paused subscription
+  import <file>                 Bootstrap subscriptions from a flat-text list
+  export [--out <file>]         Dump active subscriptions as plain text
+  history [--manga <m>]         Display download history
+  help                          Show this help
+  version                       Show version
+
+Flags: see docs/overviewer.md §4.3 for the full common-flag table.
+`;
+
+class NotImplementedError extends Error {
+  constructor(command: string) {
+    super(`'${command}' is not implemented yet — scaffold only.`);
+    this.name = "NotImplementedError";
+  }
+}
+
+type Handler = (rest: string[]) => Promise<void> | void;
+
+const handlers: Record<string, Handler> = {
+  auth: () => {
+    throw new NotImplementedError("auth");
+  },
+  list: () => {
+    throw new NotImplementedError("list");
+  },
+  download: () => {
+    throw new NotImplementedError("download");
+  },
+  update: () => {
+    throw new NotImplementedError("update");
+  },
+  sync: () => {
+    throw new NotImplementedError("sync");
+  },
+  watch: () => {
+    throw new NotImplementedError("watch");
+  },
+  unwatch: () => {
+    throw new NotImplementedError("unwatch");
+  },
+  watchlist: () => {
+    throw new NotImplementedError("watchlist");
+  },
+  pause: () => {
+    throw new NotImplementedError("pause");
+  },
+  resume: () => {
+    throw new NotImplementedError("resume");
+  },
+  import: () => {
+    throw new NotImplementedError("import");
+  },
+  export: () => {
+    throw new NotImplementedError("export");
+  },
+  history: () => {
+    throw new NotImplementedError("history");
+  },
+};
+
+function main(argv: string[]): Promise<void> | void {
+  const { positionals, values } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      help: { type: "boolean", short: "h" },
+      version: { type: "boolean", short: "v" },
+    },
+  });
+
+  if (values.version) {
+    process.stdout.write(`scanldr ${VERSION}\n`);
+    return;
+  }
+
+  const [command, ...rest] = positionals;
+
+  if (!command || command === "help" || values.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const handler = handlers[command];
+  if (!handler) {
+    process.stderr.write(`Unknown command: ${command}\n\n${USAGE}`);
+    process.exit(1);
+  }
+
+  return handler(rest);
+}
+
+try {
+  await main(process.argv.slice(2));
+} catch (err) {
+  if (err instanceof NotImplementedError) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(2);
+  }
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,60 @@
+// Shared types — schemas defined in docs/models/*.md.
+
+export interface AuthConfig {
+  cookies: Record<string, string>;
+  userAgent: string;
+  savedAt: number;
+}
+
+export interface ChapterRef {
+  id: string;
+  number: string;
+  numeric: number;
+  url: string;
+  language: string;
+  scanlationGroup?: string;
+}
+
+export interface VolumeRef {
+  number: string;
+  numeric: number;
+  chapters: ChapterRef[];
+}
+
+export interface MangaInfo {
+  id: string;
+  title: string;
+  url: string;
+  volumes: VolumeRef[];
+  source: string;
+}
+
+export interface DownloadOptions {
+  outDir: string;
+  format: "cbz" | "zip";
+  imageConcurrency: number;
+  delayMs: number;
+  force: boolean;
+  dryRun: boolean;
+}
+
+export interface DownloadRecord {
+  id: number;
+  mangaId: string;
+  mangaTitle: string;
+  volume: string;
+  chapterId: string;
+  chapterNum: string;
+  source: string;
+  language: string;
+  downloadedAt: number;
+}
+
+export interface Subscription {
+  source: string;
+  mangaId: string;
+  mangaTitle: string;
+  paused: boolean;
+  addedAt: number;
+  lastSyncedAt: number | null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## What this PR does

Lays down the foundation for the scanldr CLI: build tooling (Bun + TypeScript + Biome), shared types pulled directly from `docs/models/*`, and an `src/index.ts` entrypoint that dispatches every subcommand from `docs/overviewer.md §4` to a stub.

No business logic. Every command exits with code `2` and a `'<cmd>' is not implemented yet — scaffold only.` message. Real handlers land in follow-up PRs, one per feature.

## Why it exists

Without scaffolding, every subsequent feature PR would have to set up tooling on the side. Doing it once, in isolation, keeps later PRs focused on the actual feature being shipped.

## How it works inside

- `package.json`: name, version `0.0.0`, `type: module`, `bin: { scanldr: "src/index.ts" }`, scripts for `start`/`dev`/`typecheck`/`check`/`format`/`lint`. Dev deps only — `@biomejs/biome ^1.9.4`, `@types/bun latest`, `typescript ^5.7`. Runtime deps (`fflate`, `cheerio`, `playwright`) are deliberately deferred to the PR that first needs them.
- `tsconfig.json`: strict + `noUncheckedIndexedAccess` + `noImplicitOverride` + `noFallthroughCasesInSwitch` + `noUnusedLocals` + `noUnusedParameters`. `moduleResolution: bundler`, `verbatimModuleSyntax`, `noEmit` (Bun runs TS directly).
- `biome.json`: respects `.gitignore`, formats at 100 cols with double quotes, semicolons, trailing commas, 2-space indent. `recommended` lint rules.
- `src/types.ts`: literal copy of the interfaces in `docs/models/*.md`. If a doc changes, this file is the place to keep in sync.
- `src/index.ts`: `node:util parseArgs` reads positional command + global `--help`/`--version`. A `Record<string, Handler>` maps each command name to a stub that throws `NotImplementedError` (caught and translated to exit code `2`). Unknown command prints usage and exits `1`.
- `.gitignore`: adds `node_modules/`, `dist/`, `coverage/`, `*.log`, `.env*`.

## What did not change

- No CI workflow changes. `pr-lint.yml` still runs only Conventional title + PR description + branch protection. A follow-up PR will add `typecheck` and `biome check` as required checks.
- No business logic of any kind.
- No new docs — the docs are already authoritative; this PR aligns code to them.
- Branch protection rules unchanged.

## Test plan

- [x] `bun install` succeeds (lockfile committed).
- [x] `bun run typecheck` passes.
- [x] `bun run check` (Biome) passes.
- [x] `bun run src/index.ts --version` prints `scanldr 0.0.0`.
- [x] `bun run src/index.ts help` prints usage.
- [x] `bun run src/index.ts foo` prints `Unknown command: foo` and exits non-zero.
- [x] `bun run src/index.ts auth` exits with code `2` and the not-implemented message.

## Implementation notes

Self-review found no blocking issues. Minor points worth flagging:

- **Biome pinned to `^1.9.4`** while v2 is out. Biome 2 has breaking config changes; I'd rather upgrade in a dedicated PR than bundle it here.
- **`@types/bun: latest`** is a moving target. Acceptable for a CLI that tracks Bun closely; we can pin if it ever bites.
- **`parseArgs` uses `strict: false`** so subcommand-specific flags don't error here. Each handler will validate its own flag set when implemented.
- **`bun install` reports `Blocked 1 postinstall`** for `@biomejs/biome` (Bun's trusted-deps gate). Biome works regardless. If a future install fails, add `"trustedDependencies": ["@biomejs/biome"]`.

## Notes for the reviewer

Once this lands, the natural next PRs (one per issue, in roughly this order):

1. `ci`: add typecheck + biome jobs to `pr-lint.yml` and require them in branch protection.
2. `feat(mangadex)`: read-only client (search + aggregate + feed) + parser → wire `list` subcommand.
3. `feat(history)`: SQLite schema bootstrap + queries → unblock `download`.
4. `feat(downloader)`: image download + CBZ packaging.
5. `feat(download)`: end-to-end MangaDex `download --volume`.
6. `feat(subscriptions)`: schema + watch/unwatch/watchlist/pause/resume/import/export.
7. `feat(update)` and `feat(sync)`.
8. `feat(auth)` + `feat(mangakakalot)` for the fallback path.