### PR TITLE
chore(ci): add typecheck and biome jobs to pr-lint

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -124,3 +124,67 @@ jobs:
         with:
           header: branch-protection
           delete: true
+
+  typecheck:
+    name: TypeScript Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - id: typecheck
+        run: |
+          set -o pipefail
+          bun run typecheck 2>&1 | tee /tmp/typecheck-output.txt
+      - if: failure()
+        run: echo "TYPECHECK_OUTPUT<<EOF" >> "$GITHUB_ENV" && cat /tmp/typecheck-output.txt >> "$GITHUB_ENV" && echo "EOF" >> "$GITHUB_ENV"
+      - if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: typecheck
+          message: |
+            **FALHOU: TypeScript type-check falhou**
+
+            ```
+            ${{ env.TYPECHECK_OUTPUT }}
+            ```
+
+            Rode `bun run typecheck` localmente para corrigir.
+
+      - if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: typecheck
+          delete: true
+
+  biome:
+    name: Biome Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - id: biome
+        run: |
+          set -o pipefail
+          bun run check 2>&1 | tee /tmp/biome-output.txt
+      - if: failure()
+        run: echo "BIOME_OUTPUT<<EOF" >> "$GITHUB_ENV" && cat /tmp/biome-output.txt >> "$GITHUB_ENV" && echo "EOF" >> "$GITHUB_ENV"
+      - if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: biome
+          message: |
+            **FALHOU: Biome check falhou**
+
+            ```
+            ${{ env.BIOME_OUTPUT }}
+            ```
+
+            Rode `bun run check` localmente para corrigir.
+
+      - if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: biome
+          delete: true


### PR DESCRIPTION
## O que esse PR faz

Adiciona dois novos jobs ao workflow `.github/workflows/pr-lint.yml`:

- **`typecheck`** (`TypeScript Type Check`) — roda `bun install --frozen-lockfile` + `bun run typecheck` (que executa `tsc --noEmit`).
- **`biome`** (`Biome Lint`) — roda `bun install --frozen-lockfile` + `bun run check`.

Ambos seguem o mesmo padrão dos jobs existentes: usam `marocchino/sticky-pull-request-comment@v2` para postar um comentário sticky em caso de falha (com a saída da ferramenta inline) e limpá-lo em caso de sucesso.

## Por que existe

Fecha #4. Hoje o `pr-lint.yml` valida apenas título Conventional, descrição da PR e proteção contra push direto na `main`. Com o scaffold de #2 já em produção (TypeScript + Biome configurados), todo PR deveria passar também por typecheck e lint antes de poder mergear.

## Como funciona por dentro

- Trigger herdado do nível do arquivo: `pull_request` em `main`, types `[opened, edited, synchronize, reopened]` — ambos os jobs disparam em qualquer evento de PR.
- Setup uniforme: `actions/checkout@v4` + `oven-sh/setup-bun@v2` + `bun install --frozen-lockfile` (compatível com o `bun.lock` text-format do projeto).
- Captura de saída: `set -o pipefail` + `tee /tmp/<job>-output.txt`. Em caso de `failure()`, o conteúdo é exportado como variável de ambiente multi-line e renderizado dentro de um bloco markdown no sticky comment.
- Headers únicos (`typecheck`, `biome`) garantem que cada job mantém seu próprio sticky sem colidir com `conventional-title`, `pr-description` ou `branch-protection`.

## O que não mudou

- `release-please.yml` — intocado.
- `package.json`, `tsconfig.json`, `biome.json` — intocados.
- Nenhum código de produto/CLI foi alterado.
- Os 3 jobs existentes (`conventional-title`, `pr-description`, `no-direct-push`) ficaram exatamente como estavam.

## Checklist de testes

- [x] `bun run typecheck` passa localmente na branch
- [x] `bun run check` passa localmente na branch
- [ ] Após mergear: atualizar branch protection em `main` para exigir `TypeScript Type Check` e `Biome Lint` como required status checks (passo fora do diff, executado pelo mantenedor via API/UI)
- [ ] Validar com um commit intencionalmente quebrado (TS error ou violação Biome) que o check correspondente falha

## Pontos de atenção pra quem revisar

- Os nomes dos checks que aparecerão no GitHub (e que o branch protection deve referenciar) são `TypeScript Type Check` e `Biome Lint` — esses são os valores do campo `name:` de cada job.
- Não foi adicionado cache de `~/.bun/install/cache` porque o projeto tem apenas 3 devDependencies; o overhead de cache não compensa nesse tamanho.
- Padrão do sticky comment (`tee` + `GITHUB_ENV` multi-line) foi copiado fielmente do repo de referência indicado no contexto, sem trazer nenhum elemento específico daquele projeto (Prisma, DB, env vars).

## Closes

Ref: #4

### ✅ Checklist

- [x] Código testado localmente
- [x] Self-review concluído
- [x] Sem erros no console
- [x] Código segue os padrões do projeto
- [x] Documentação atualizada (se necessário) — N/A, mudança apenas de CI