### PR TITLE
chore(tsconfig): add path aliases to eliminate relative imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,11 @@ export type { Logger, LoggerOptions } from "./types.ts";
 
 ### No flat files in `src/`
 Every new feature lives in its own folder. The only flat files allowed at `src/` root are `index.ts` and `types.ts` (shared domain types).
+
+### Import aliases
+Use aliases for cross-boundary imports:
+- `@plugins/*` → `src/plugins/*`
+- `@modules/*` → `src/modules/*`
+- `@integrations/*` → `src/integrations/*`
+
+Relative imports (`./types.ts`, `./service.ts`) are only allowed within the same plugin/module/integration folder.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_CONFIG, loadConfig, validateAndMerge } from "../plugins/config/index.ts";
-import { ConfigError } from "../plugins/errors/index.ts";
+import { DEFAULT_CONFIG, loadConfig, validateAndMerge } from "@plugins/config/index.ts";
+import { ConfigError } from "@plugins/errors/index.ts";
 
 let workDir: string;
 let homeDir: string;

--- a/src/plugins/config/index.ts
+++ b/src/plugins/config/index.ts
@@ -2,8 +2,8 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { ConfigError } from "../errors/index.ts";
-import { check, isPlainObject } from "../guards/index.ts";
+import { ConfigError } from "@plugins/errors/index.ts";
+import { check, isPlainObject } from "@plugins/guards/index.ts";
 import type { Config, LoadConfigOptions, LoadConfigResult } from "./types.ts";
 
 export type { Config, LoadConfigOptions, LoadConfigResult } from "./types.ts";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,12 @@
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@plugins/*": ["./src/plugins/*"],
+      "@modules/*": ["./src/modules/*"],
+      "@integrations/*": ["./src/integrations/*"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

- Adds `@plugins/*`, `@modules/*`, and `@integrations/*` path aliases to `tsconfig.json`
- Migrates cross-boundary imports in `src/plugins/config/index.ts` and `src/__tests__/config.test.ts` to use aliases
- Intra-plugin relative imports (`./types.ts`) intentionally remain unchanged
- Documents import alias convention in `CLAUDE.md`

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run check` (Biome) — passes
- [x] `bun test` — 43 tests pass

Closes #27