### PR TITLE
feat(auth): Playwright headful Chromium and cookie extraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "scanldr",
       "dependencies": {
         "fflate": "^0.8.2",
+        "playwright": "^1.59.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -40,6 +41,12 @@
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "scanldr",
       "dependencies": {
-        "fflate": "^0.8.2",
         "playwright": "^1.59.1",
       },
       "devDependencies": {
@@ -39,8 +38,6 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "scanldr",
       "dependencies": {
+        "fflate": "^0.8.2",
         "playwright": "^1.59.1",
       },
       "devDependencies": {
@@ -38,6 +39,8 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
+    "fflate": "^0.8.2",
     "playwright": "^1.59.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
-    "fflate": "^0.8.2"
+    "playwright": "^1.59.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { parseArgs } from "node:util";
+import { AuthError, runAuth } from "@integrations/mangakakalot/browser/index.ts";
 import { loadConfig } from "@plugins/config/index.ts";
 import { openDb, runMigrations } from "@plugins/db/index.ts";
 import type { Db } from "@plugins/db/index.ts";
@@ -63,8 +64,16 @@ interface HandlerContext {
 type Handler = (rest: string[], ctx: HandlerContext) => Promise<void> | void;
 
 const handlers: Record<string, Handler> = {
-  auth: () => {
-    throw new NotImplementedError("auth");
+  auth: async (_rest, ctx) => {
+    try {
+      await runAuth({ logger: ctx.logger });
+    } catch (err) {
+      if (err instanceof AuthError) {
+        process.stderr.write(`${err.message}\n`);
+        process.exit(1);
+      }
+      throw err;
+    }
   },
   list: () => {
     throw new NotImplementedError("list");
@@ -175,6 +184,10 @@ if (import.meta.main) {
     if (err instanceof NotImplementedError) {
       process.stderr.write(`${err.message}\n`);
       process.exit(2);
+    }
+    if (err instanceof AuthError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(1);
     }
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -35,7 +35,10 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
   const { logger } = opts;
   const cwd = opts.cwd ?? process.cwd();
 
-  logger.info({}, "Launching Chromium — solve the Cloudflare challenge in the browser window.");
+  logger.info(
+    { event: "auth.launch", context: "browser" },
+    "Launching Chromium — solve the Cloudflare challenge in the browser window.",
+  );
 
   const browser = await chromium.launch({ headless: false });
 
@@ -50,7 +53,10 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
   try {
     await page.goto(SITE_ROOT, { waitUntil: "domcontentloaded" });
 
-    logger.info({}, "Waiting for you to solve the challenge…");
+    logger.info(
+      { event: "auth.waiting", context: "browser" },
+      "Waiting for you to solve the challenge…",
+    );
 
     // Poll until cf_clearance cookie appears — networkidle is unreliable for Turnstile.
     const deadline = Date.now() + CF_COOKIE_TIMEOUT_MS;
@@ -82,7 +88,10 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
       cookies[c.name] = c.value;
     }
 
-    logger.info({}, "Challenge resolved. Verifying session…");
+    logger.info(
+      { event: "auth.challenge_resolved", context: "browser" },
+      "Challenge resolved. Verifying session…",
+    );
 
     // Verify: plain fetch with captured cookies + UA must return 200.
     const cookieHeader = Object.entries(cookies)
@@ -122,7 +131,10 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
     await writeFile(outPath, JSON.stringify(session, null, 2), { encoding: "utf8" });
     await chmod(outPath, 0o600);
 
-    logger.info({}, `Auth saved to ${AUTH_FILE}. Valid for ~30 days.`);
+    logger.info(
+      { event: "auth.saved", context: "browser", path: outPath },
+      `Auth saved to ${AUTH_FILE}. Valid for ~30 days.`,
+    );
   } finally {
     if (!browserClosed) {
       await browser.close();

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -1,0 +1,131 @@
+// Auth command handler for mangakakalot.
+// Opens headful Chromium via Playwright, waits for user to solve Cloudflare Turnstile,
+// captures cookies + User-Agent, verifies the session, writes .scanldr-auth.json.
+// Per ADR-001: no stealth — cookie replay is the strategy.
+
+import { chmod, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { chromium } from "playwright";
+import { AuthError } from "./types.ts";
+import type { AuthSession, RunAuthOptions } from "./types.ts";
+
+export { AuthError } from "./types.ts";
+export type { AuthSession, RunAuthOptions } from "./types.ts";
+
+const AUTH_FILE = ".scanldr-auth.json";
+const SITE_ROOT = "https://mangakakalot.gg";
+const CF_COOKIE_TIMEOUT_MS = 120_000;
+const VERIFY_TIMEOUT_MS = 15_000;
+
+/**
+ * Runs the interactive auth flow:
+ * 1. Opens headful Chromium.
+ * 2. Navigates to SITE_ROOT — user solves the Turnstile.
+ * 3. Polls until cf_clearance cookie is present (up to 120s).
+ * 4. Extracts cookies + UA.
+ * 5. Verifies session via plain fetch.
+ * 6. Writes .scanldr-auth.json with mode 0600.
+ *
+ * Throws (exit non-zero) when:
+ * - User closes the browser before settlement.
+ * - cf_clearance cookie never appears within timeout.
+ * - Session verification fails.
+ */
+export async function runAuth(opts: RunAuthOptions): Promise<void> {
+  const { logger } = opts;
+  const cwd = opts.cwd ?? process.cwd();
+
+  logger.info({}, "Launching Chromium — solve the Cloudflare challenge in the browser window.");
+
+  const browser = await chromium.launch({ headless: false });
+
+  let browserClosed = false;
+  browser.on("disconnected", () => {
+    browserClosed = true;
+  });
+
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto(SITE_ROOT, { waitUntil: "domcontentloaded" });
+
+    logger.info({}, "Waiting for you to solve the challenge…");
+
+    // Poll until cf_clearance cookie appears — networkidle is unreliable for Turnstile.
+    const deadline = Date.now() + CF_COOKIE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (browserClosed) {
+        throw new AuthError("Browser closed before challenge was resolved. No session saved.");
+      }
+      const cookies = await context.cookies();
+      if (cookies.some((c) => c.name === "cf_clearance")) break;
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+
+    if (browserClosed) {
+      throw new AuthError("Browser closed before challenge was resolved. No session saved.");
+    }
+
+    const finalCookies = await context.cookies();
+    if (!finalCookies.some((c) => c.name === "cf_clearance")) {
+      throw new AuthError("Challenge not solved within timeout. No session saved.");
+    }
+
+    // Extract User-Agent from the browser context.
+    const userAgent = await page.evaluate(() => navigator.userAgent);
+
+    // Build cookies map from all cookies for the host.
+    const rawCookies = await context.cookies(SITE_ROOT);
+    const cookies: Record<string, string> = {};
+    for (const c of rawCookies) {
+      cookies[c.name] = c.value;
+    }
+
+    logger.info({}, "Challenge resolved. Verifying session…");
+
+    // Verify: plain fetch with captured cookies + UA must return 200.
+    const cookieHeader = Object.entries(cookies)
+      .map(([k, v]) => `${k}=${v}`)
+      .join("; ");
+
+    const controller = new AbortController();
+    const verifyTimer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+    let verifyOk = false;
+    try {
+      const res = await fetch(SITE_ROOT, {
+        headers: {
+          cookie: cookieHeader,
+          "user-agent": userAgent,
+        },
+        signal: controller.signal,
+      });
+      verifyOk = res.ok;
+    } finally {
+      clearTimeout(verifyTimer);
+    }
+
+    if (!verifyOk) {
+      throw new AuthError(
+        "Session verification failed — server rejected the captured cookies. Re-run scanldr auth.",
+      );
+    }
+
+    const session: AuthSession = {
+      cookies,
+      userAgent,
+      savedAt: Date.now(),
+    };
+
+    const outPath = join(cwd, AUTH_FILE);
+    await writeFile(outPath, JSON.stringify(session, null, 2), { encoding: "utf8" });
+    await chmod(outPath, 0o600);
+
+    logger.info({}, `Auth saved to ${AUTH_FILE}. Valid for ~30 days.`);
+  } finally {
+    if (!browserClosed) {
+      await browser.close();
+    }
+  }
+}

--- a/src/integrations/mangakakalot/browser/types.ts
+++ b/src/integrations/mangakakalot/browser/types.ts
@@ -1,0 +1,23 @@
+// Types for the mangakakalot auth browser handler.
+// Schema mirrors docs/models/auth_model.md.
+
+export interface AuthSession {
+  /** All cookies captured for the target host. Must include cf_clearance. */
+  cookies: Record<string, string>;
+  /** User-Agent string used when the cookies were generated. */
+  userAgent: string;
+  /** Unix timestamp (ms) of when the session was saved. */
+  savedAt: number;
+}
+
+export interface RunAuthOptions {
+  logger: import("@plugins/logger/index.ts").Logger;
+  cwd?: string;
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthError";
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `scanldr auth` command: launches headful Chromium via Playwright, waits for user to solve Cloudflare Turnstile, captures full cookie store + User-Agent, verifies session, writes `.scanldr-auth.json` with mode `0600`.
- Per ADR-001: no stealth plugin — cookie replay is the strategy. Playwright is used only for this one-time auth capture.
- Adds `playwright` as a runtime dependency.

## Files

- `src/integrations/mangakakalot/browser/types.ts` — `AuthSession` interface (mirrors `docs/models/auth_model.md`)
- `src/integrations/mangakakalot/browser/index.ts` — `runAuth()` handler + `AuthError`
- `src/index.ts` — wires `auth` command handler, handles `AuthError` with exit code 1

## Manual Test Plan

Automated tests are not feasible for this command (requires a real browser + Cloudflare challenge). Test manually as follows:

### 1. First run (happy path)

```sh
bun run src/index.ts auth
```

**Expected:**
- Chromium window opens and navigates to `https://mangakakalot.gg`
- Terminal prints: `Launching Chromium — solve the Cloudflare challenge in the browser window.`
- User solves the Turnstile in the browser window
- Terminal prints: `Waiting for you to solve the challenge… (networkidle)`
- After networkidle settles: `Challenge resolved. Verifying session…`
- Terminal prints: `Auth saved to .scanldr-auth.json. Valid for ~30 days.`
- `.scanldr-auth.json` created in cwd with permissions `0600`
- File contains `cookies` (with `cf_clearance` key), `userAgent`, `savedAt`
- Cookie values are NOT printed to the terminal

### 2. Re-run (file already exists)

```sh
bun run src/index.ts auth
```

**Expected:** Same as first run — file is overwritten with a fresh session, new `savedAt` timestamp, permissions reset to `0600`.

### 3. Browser closed early

```sh
bun run src/index.ts auth
# Immediately close the Chromium window before solving the challenge
```

**Expected:**
- CLI exits with non-zero exit code (`echo $?` → `1`)
- Terminal prints: `Browser closed before challenge was resolved. No session saved.`
- `.scanldr-auth.json` is NOT created (or not modified if it already existed)

## Gates

- [x] `bun run typecheck` — passes (exit 0)
- [x] `bun run check` — no new errors introduced (pre-existing organizeImports errors in unrelated files)

Closes #20