### PR TITLE
refactor(db): extract shared db plugin with versioned migrations

### DIFF
--- a/migrations/001_create_downloads.sql
+++ b/migrations/001_create_downloads.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS downloads (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  manga_id      TEXT    NOT NULL,
+  manga_title   TEXT    NOT NULL,
+  volume        TEXT    NOT NULL,
+  chapter_id    TEXT    NOT NULL,
+  chapter_num   TEXT    NOT NULL,
+  source        TEXT    NOT NULL,
+  language      TEXT    NOT NULL,
+  downloaded_at INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_chapter
+  ON downloads (manga_id, chapter_id, source, language);

--- a/migrations/002_create_subscriptions.sql
+++ b/migrations/002_create_subscriptions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS subscriptions (
+  source          TEXT    NOT NULL,
+  manga_id        TEXT    NOT NULL,
+  manga_title     TEXT    NOT NULL,
+  paused          INTEGER NOT NULL DEFAULT 0,
+  added_at        INTEGER NOT NULL,
+  last_synced_at  INTEGER,
+  PRIMARY KEY (source, manga_id)
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
 import { parseArgs } from "node:util";
+import { loadConfig } from "@plugins/config/index.ts";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
+import type { Db } from "@plugins/db/index.ts";
 import {
   type LogFormat,
   type LogLevel,
@@ -54,6 +57,7 @@ class CliError extends Error {
 
 interface HandlerContext {
   logger: Logger;
+  db: Db;
 }
 
 type Handler = (rest: string[], ctx: HandlerContext) => Promise<void> | void;
@@ -118,7 +122,7 @@ export function resolveLogConfig(values: {
   return { level, format };
 }
 
-function main(argv: string[]): Promise<void> | void {
+async function main(argv: string[]): Promise<void> {
   const { positionals, values } = parseArgs({
     args: argv,
     allowPositionals: true,
@@ -153,7 +157,11 @@ function main(argv: string[]): Promise<void> | void {
     process.exit(1);
   }
 
-  return handler(rest, { logger });
+  const { config } = await loadConfig();
+  const db = openDb(config.db_path);
+  runMigrations(db);
+
+  return handler(rest, { logger, db });
 }
 
 if (import.meta.main) {

--- a/src/integrations/mangadex/http/mangadex-http.test.ts
+++ b/src/integrations/mangadex/http/mangadex-http.test.ts
@@ -18,6 +18,7 @@ const baseConfig: Config = {
   download_quality: "data",
   default_format: "cbz",
   default_out: "./download",
+  db_path: "./scanldr.db",
   image_concurrency: 4,
   chapter_delay_ms: 100,
 };

--- a/src/modules/history/history.test.ts
+++ b/src/modules/history/history.test.ts
@@ -1,4 +1,3 @@
-import type { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -7,17 +6,19 @@ import {
   getDownloadedChapterIds,
   isVolumeFullyDownloaded,
   listHistory,
-  openDb,
   recordDownloadedChapters,
 } from "@modules/history/index.ts";
 import type { DownloadRow } from "@modules/history/index.ts";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
+import type { Db } from "@plugins/db/index.ts";
 
 let workDir: string;
-let db: Database;
+let db: Db;
 
 beforeEach(async () => {
   workDir = await mkdtemp(join(tmpdir(), "scanldr-history-"));
   db = openDb(join(workDir, "test.db"));
+  runMigrations(db);
 });
 
 afterEach(async () => {
@@ -46,8 +47,7 @@ describe("openDb / migration", () => {
   });
 
   test("migration is idempotent — running twice does not error", () => {
-    const db2 = openDb(join(workDir, "test.db"));
-    db2.close();
+    runMigrations(db);
   });
 
   test("creates unique index idx_unique_chapter", () => {

--- a/src/modules/history/index.ts
+++ b/src/modules/history/index.ts
@@ -13,6 +13,5 @@ export {
   getDownloadedChapterIds,
   isVolumeFullyDownloaded,
   listHistory,
-  openDb,
   recordDownloadedChapters,
 } from "./service.ts";

--- a/src/modules/history/repository.ts
+++ b/src/modules/history/repository.ts
@@ -1,0 +1,127 @@
+// History repository — raw SQL queries, no business logic.
+
+import type { Db } from "@plugins/db/index.ts";
+import type {
+  DownloadRecord,
+  DownloadRow,
+  GetChapterIdsFilter,
+  HistoryFilter,
+  IsVolumeFullyDownloadedFilter,
+  RecordResult,
+} from "./types.ts";
+
+function toRecord(raw: {
+  id: number;
+  manga_id: string;
+  manga_title: string;
+  volume: string;
+  chapter_id: string;
+  chapter_num: string;
+  source: string;
+  language: string;
+  downloaded_at: number;
+}): DownloadRecord {
+  return {
+    id: raw.id,
+    mangaId: raw.manga_id,
+    mangaTitle: raw.manga_title,
+    volume: raw.volume,
+    chapterId: raw.chapter_id,
+    chapterNum: raw.chapter_num,
+    source: raw.source,
+    language: raw.language,
+    downloadedAt: raw.downloaded_at,
+  };
+}
+
+export function queryDownloadedChapterIds(db: Db, filter: GetChapterIdsFilter): Set<string> {
+  const stmt = db.prepare<{ chapter_id: string }, [string, string]>(
+    "SELECT chapter_id FROM downloads WHERE manga_id = ? AND language = ?",
+  );
+  const rows = stmt.all(filter.mangaId, filter.language);
+  return new Set(rows.map((r) => r.chapter_id));
+}
+
+export function queryVolumeChapterIds(db: Db, filter: IsVolumeFullyDownloadedFilter): Set<string> {
+  const stmt = db.prepare<{ chapter_id: string }, [string, string, string]>(
+    "SELECT chapter_id FROM downloads WHERE manga_id = ? AND volume = ? AND language = ?",
+  );
+  const rows = stmt.all(filter.mangaId, filter.volume, filter.language);
+  return new Set(rows.map((r) => r.chapter_id));
+}
+
+export function insertDownloads(db: Db, rows: DownloadRow[]): RecordResult {
+  if (rows.length === 0) return { ok: true, inserted: 0 };
+
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO downloads
+       (manga_id, manga_title, volume, chapter_id, chapter_num, source, language, downloaded_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  let inserted = 0;
+  const rejected: DownloadRow[] = [];
+
+  const run = db.transaction(() => {
+    for (const row of rows) {
+      const result = stmt.run(
+        row.mangaId,
+        row.mangaTitle,
+        row.volume,
+        row.chapterId,
+        row.chapterNum,
+        row.source,
+        row.language,
+        row.downloadedAt,
+      );
+      if (result.changes > 0) {
+        inserted++;
+      } else {
+        rejected.push(row);
+      }
+    }
+  });
+
+  run();
+
+  if (rejected.length > 0) {
+    return { ok: false, inserted, rejected };
+  }
+  return { ok: true, inserted };
+}
+
+export function queryHistory(db: Db, filter?: HistoryFilter): DownloadRecord[] {
+  const conditions: string[] = [];
+  const params: string[] = [];
+
+  if (filter?.mangaId !== undefined) {
+    conditions.push("manga_id = ?");
+    params.push(filter.mangaId);
+  }
+  if (filter?.source !== undefined) {
+    conditions.push("source = ?");
+    params.push(filter.source);
+  }
+  if (filter?.language !== undefined) {
+    conditions.push("language = ?");
+    params.push(filter.language);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT * FROM downloads ${where} ORDER BY manga_title, CAST(volume AS REAL)`;
+
+  const stmt = db.prepare(sql);
+  const raw = stmt.all(...params) as {
+    id: number;
+    manga_id: string;
+    manga_title: string;
+    volume: string;
+    chapter_id: string;
+    chapter_num: string;
+    source: string;
+    language: string;
+    downloaded_at: number;
+  }[];
+
+  return raw.map(toRecord);
+}

--- a/src/modules/history/service.ts
+++ b/src/modules/history/service.ts
@@ -1,6 +1,12 @@
-// History service — SQLite queries and migrations via bun:sqlite.
+// History service — business logic delegating to repository.
 
-import { Database } from "bun:sqlite";
+import type { Db } from "@plugins/db/index.ts";
+import {
+  insertDownloads,
+  queryDownloadedChapterIds,
+  queryHistory,
+  queryVolumeChapterIds,
+} from "./repository.ts";
 import type {
   DownloadRecord,
   DownloadRow,
@@ -10,71 +16,11 @@ import type {
   RecordResult,
 } from "./types.ts";
 
-const MIGRATION = `
-CREATE TABLE IF NOT EXISTS downloads (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  manga_id      TEXT    NOT NULL,
-  manga_title   TEXT    NOT NULL,
-  volume        TEXT    NOT NULL,
-  chapter_id    TEXT    NOT NULL,
-  chapter_num   TEXT    NOT NULL,
-  source        TEXT    NOT NULL,
-  language      TEXT    NOT NULL,
-  downloaded_at INTEGER NOT NULL
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_chapter
-  ON downloads (manga_id, chapter_id, source, language);
-`;
-
-function toRecord(raw: {
-  id: number;
-  manga_id: string;
-  manga_title: string;
-  volume: string;
-  chapter_id: string;
-  chapter_num: string;
-  source: string;
-  language: string;
-  downloaded_at: number;
-}): DownloadRecord {
-  return {
-    id: raw.id,
-    mangaId: raw.manga_id,
-    mangaTitle: raw.manga_title,
-    volume: raw.volume,
-    chapterId: raw.chapter_id,
-    chapterNum: raw.chapter_num,
-    source: raw.source,
-    language: raw.language,
-    downloadedAt: raw.downloaded_at,
-  };
+export function getDownloadedChapterIds(db: Db, filter: GetChapterIdsFilter): Set<string> {
+  return queryDownloadedChapterIds(db, filter);
 }
 
-export function runMigration(db: Database): void {
-  db.exec(MIGRATION);
-}
-
-export function openDb(path: string): Database {
-  const db = new Database(path, { create: true });
-  db.exec("PRAGMA journal_mode=WAL;");
-  db.exec("PRAGMA foreign_keys=ON;");
-  runMigration(db);
-  return db;
-}
-
-export function getDownloadedChapterIds(db: Database, filter: GetChapterIdsFilter): Set<string> {
-  const stmt = db.prepare<{ chapter_id: string }, [string, string]>(
-    "SELECT chapter_id FROM downloads WHERE manga_id = ? AND language = ?",
-  );
-  const rows = stmt.all(filter.mangaId, filter.language);
-  return new Set(rows.map((r) => r.chapter_id));
-}
-
-export function isVolumeFullyDownloaded(
-  db: Database,
-  filter: IsVolumeFullyDownloadedFilter,
-): boolean {
+export function isVolumeFullyDownloaded(db: Db, filter: IsVolumeFullyDownloadedFilter): boolean {
   const expected =
     filter.expectedChapterIds instanceof Set
       ? filter.expectedChapterIds
@@ -82,11 +28,7 @@ export function isVolumeFullyDownloaded(
 
   if (expected.size === 0) return false;
 
-  const stmt = db.prepare<{ chapter_id: string }, [string, string, string]>(
-    "SELECT chapter_id FROM downloads WHERE manga_id = ? AND volume = ? AND language = ?",
-  );
-  const rows = stmt.all(filter.mangaId, filter.volume, filter.language);
-  const downloaded = new Set(rows.map((r) => r.chapter_id));
+  const downloaded = queryVolumeChapterIds(db, filter);
 
   for (const id of expected) {
     if (!downloaded.has(id)) return false;
@@ -94,78 +36,10 @@ export function isVolumeFullyDownloaded(
   return true;
 }
 
-export function recordDownloadedChapters(db: Database, rows: DownloadRow[]): RecordResult {
-  if (rows.length === 0) return { ok: true, inserted: 0 };
-
-  const stmt = db.prepare(
-    `INSERT OR IGNORE INTO downloads
-       (manga_id, manga_title, volume, chapter_id, chapter_num, source, language, downloaded_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  );
-
-  let inserted = 0;
-  const rejected: DownloadRow[] = [];
-
-  const run = db.transaction(() => {
-    for (const row of rows) {
-      const result = stmt.run(
-        row.mangaId,
-        row.mangaTitle,
-        row.volume,
-        row.chapterId,
-        row.chapterNum,
-        row.source,
-        row.language,
-        row.downloadedAt,
-      );
-      if (result.changes > 0) {
-        inserted++;
-      } else {
-        rejected.push(row);
-      }
-    }
-  });
-
-  run();
-
-  if (rejected.length > 0) {
-    return { ok: false, inserted, rejected };
-  }
-  return { ok: true, inserted };
+export function recordDownloadedChapters(db: Db, rows: DownloadRow[]): RecordResult {
+  return insertDownloads(db, rows);
 }
 
-export function listHistory(db: Database, filter?: HistoryFilter): DownloadRecord[] {
-  const conditions: string[] = [];
-  const params: string[] = [];
-
-  if (filter?.mangaId !== undefined) {
-    conditions.push("manga_id = ?");
-    params.push(filter.mangaId);
-  }
-  if (filter?.source !== undefined) {
-    conditions.push("source = ?");
-    params.push(filter.source);
-  }
-  if (filter?.language !== undefined) {
-    conditions.push("language = ?");
-    params.push(filter.language);
-  }
-
-  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
-  const sql = `SELECT * FROM downloads ${where} ORDER BY manga_title, CAST(volume AS REAL)`;
-
-  const stmt = db.prepare(sql);
-  const raw = stmt.all(...params) as {
-    id: number;
-    manga_id: string;
-    manga_title: string;
-    volume: string;
-    chapter_id: string;
-    chapter_num: string;
-    source: string;
-    language: string;
-    downloaded_at: number;
-  }[];
-
-  return raw.map(toRecord);
+export function listHistory(db: Db, filter?: HistoryFilter): DownloadRecord[] {
+  return queryHistory(db, filter);
 }

--- a/src/modules/subscriptions/index.ts
+++ b/src/modules/subscriptions/index.ts
@@ -1,0 +1,16 @@
+// Public API for the subscriptions module.
+
+export type {
+  ListSubscriptionsFilter,
+  Subscription,
+  SubscriptionRow,
+} from "./types.ts";
+
+export {
+  addSubscription,
+  listSubscriptions,
+  markSynced,
+  pauseSubscription,
+  removeSubscription,
+  resumeSubscription,
+} from "./service.ts";

--- a/src/modules/subscriptions/repository.ts
+++ b/src/modules/subscriptions/repository.ts
@@ -1,0 +1,80 @@
+// Subscriptions repository — raw SQL queries, no business logic.
+
+import type { Db } from "@plugins/db/index.ts";
+import type { ListSubscriptionsFilter, Subscription, SubscriptionRow } from "./types.ts";
+
+function toSubscription(raw: {
+  source: string;
+  manga_id: string;
+  manga_title: string;
+  paused: number;
+  added_at: number;
+  last_synced_at: number | null;
+}): Subscription {
+  return {
+    source: raw.source,
+    mangaId: raw.manga_id,
+    mangaTitle: raw.manga_title,
+    paused: raw.paused === 1,
+    addedAt: raw.added_at,
+    lastSyncedAt: raw.last_synced_at,
+  };
+}
+
+export function insertSubscription(db: Db, row: SubscriptionRow): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO subscriptions (source, manga_id, manga_title, paused, added_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(row.source, row.mangaId, row.mangaTitle, row.paused ? 1 : 0, row.addedAt);
+}
+
+export function deleteSubscription(db: Db, source: string, mangaId: string): void {
+  db.prepare("DELETE FROM subscriptions WHERE source = ? AND manga_id = ?").run(source, mangaId);
+}
+
+export function updatePaused(db: Db, source: string, mangaId: string, paused: boolean): void {
+  db.prepare("UPDATE subscriptions SET paused = ? WHERE source = ? AND manga_id = ?").run(
+    paused ? 1 : 0,
+    source,
+    mangaId,
+  );
+}
+
+export function updateLastSyncedAt(
+  db: Db,
+  source: string,
+  mangaId: string,
+  lastSyncedAt: number,
+): void {
+  db.prepare("UPDATE subscriptions SET last_synced_at = ? WHERE source = ? AND manga_id = ?").run(
+    lastSyncedAt,
+    source,
+    mangaId,
+  );
+}
+
+export function querySubscriptions(db: Db, filter?: ListSubscriptionsFilter): Subscription[] {
+  const conditions: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (filter?.paused !== undefined) {
+    conditions.push("paused = ?");
+    params.push(filter.paused ? 1 : 0);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT source, manga_id, manga_title, paused, added_at, last_synced_at
+               FROM subscriptions ${where} ORDER BY manga_title`;
+
+  const stmt = db.prepare(sql);
+  const raw = stmt.all(...params) as {
+    source: string;
+    manga_id: string;
+    manga_title: string;
+    paused: number;
+    added_at: number;
+    last_synced_at: number | null;
+  }[];
+
+  return raw.map(toSubscription);
+}

--- a/src/modules/subscriptions/service.ts
+++ b/src/modules/subscriptions/service.ts
@@ -1,0 +1,35 @@
+// Subscriptions service — business logic delegating to repository.
+
+import type { Db } from "@plugins/db/index.ts";
+import {
+  deleteSubscription,
+  insertSubscription,
+  querySubscriptions,
+  updateLastSyncedAt,
+  updatePaused,
+} from "./repository.ts";
+import type { ListSubscriptionsFilter, Subscription, SubscriptionRow } from "./types.ts";
+
+export function addSubscription(db: Db, row: SubscriptionRow): void {
+  insertSubscription(db, row);
+}
+
+export function removeSubscription(db: Db, source: string, mangaId: string): void {
+  deleteSubscription(db, source, mangaId);
+}
+
+export function pauseSubscription(db: Db, source: string, mangaId: string): void {
+  updatePaused(db, source, mangaId, true);
+}
+
+export function resumeSubscription(db: Db, source: string, mangaId: string): void {
+  updatePaused(db, source, mangaId, false);
+}
+
+export function markSynced(db: Db, source: string, mangaId: string, at: number): void {
+  updateLastSyncedAt(db, source, mangaId, at);
+}
+
+export function listSubscriptions(db: Db, filter?: ListSubscriptionsFilter): Subscription[] {
+  return querySubscriptions(db, filter);
+}

--- a/src/modules/subscriptions/subscriptions.test.ts
+++ b/src/modules/subscriptions/subscriptions.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
+import type { Db } from "@plugins/db/index.ts";
+import {
+  addSubscription,
+  listSubscriptions,
+  markSynced,
+  pauseSubscription,
+  removeSubscription,
+  resumeSubscription,
+} from "./service.ts";
+import type { SubscriptionRow } from "./types.ts";
+
+let workDir: string;
+let db: Db;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "scanldr-subs-"));
+  db = openDb(join(workDir, "test.db"));
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(workDir, { recursive: true, force: true });
+});
+
+const BASE_SUB: SubscriptionRow = {
+  source: "mangadex",
+  mangaId: "manga-uuid-1",
+  mangaTitle: "One Piece",
+  paused: false,
+  addedAt: 1_700_000_000_000,
+};
+
+describe("addSubscription / listSubscriptions", () => {
+  test("inserts a subscription and lists it back", () => {
+    addSubscription(db, BASE_SUB);
+    const subs = listSubscriptions(db);
+    expect(subs).toHaveLength(1);
+    expect(subs[0]?.mangaId).toBe(BASE_SUB.mangaId);
+    expect(subs[0]?.mangaTitle).toBe(BASE_SUB.mangaTitle);
+    expect(subs[0]?.source).toBe(BASE_SUB.source);
+    expect(subs[0]?.paused).toBe(false);
+    expect(subs[0]?.lastSyncedAt).toBeNull();
+  });
+
+  test("duplicate insert is idempotent — no duplicate rows", () => {
+    addSubscription(db, BASE_SUB);
+    addSubscription(db, BASE_SUB);
+    const subs = listSubscriptions(db);
+    expect(subs).toHaveLength(1);
+  });
+});
+
+describe("pauseSubscription / resumeSubscription", () => {
+  test("pause sets paused=true", () => {
+    addSubscription(db, BASE_SUB);
+    pauseSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+    const [sub] = listSubscriptions(db);
+    expect(sub?.paused).toBe(true);
+  });
+
+  test("resume sets paused=false after pause", () => {
+    addSubscription(db, { ...BASE_SUB, paused: true });
+    resumeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+    const [sub] = listSubscriptions(db);
+    expect(sub?.paused).toBe(false);
+  });
+});
+
+describe("markSynced", () => {
+  test("updates last_synced_at", () => {
+    addSubscription(db, BASE_SUB);
+    const syncedAt = 1_700_001_000_000;
+    markSynced(db, BASE_SUB.source, BASE_SUB.mangaId, syncedAt);
+    const [sub] = listSubscriptions(db);
+    expect(sub?.lastSyncedAt).toBe(syncedAt);
+  });
+});
+
+describe("removeSubscription", () => {
+  test("removes the subscription row", () => {
+    addSubscription(db, BASE_SUB);
+    removeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+    expect(listSubscriptions(db)).toHaveLength(0);
+  });
+
+  test("_migrations table is unaffected after remove", () => {
+    addSubscription(db, BASE_SUB);
+    removeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+    const rows = db.prepare("SELECT name FROM _migrations").all() as { name: string }[];
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  test("downloads table is unaffected after remove", () => {
+    // seed a download row so the table exists and has data
+    db.prepare(
+      `INSERT INTO downloads (manga_id, manga_title, volume, chapter_id, chapter_num, source, language, downloaded_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("manga-uuid-1", "One Piece", "1", "ch-001", "1", "mangadex", "en", 1_700_000_000_000);
+
+    addSubscription(db, BASE_SUB);
+    removeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+
+    const rows = db.prepare("SELECT chapter_id FROM downloads").all() as { chapter_id: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.chapter_id).toBe("ch-001");
+  });
+});
+
+describe("listSubscriptions with paused filter", () => {
+  beforeEach(() => {
+    addSubscription(db, { ...BASE_SUB, mangaId: "manga-1", mangaTitle: "A", paused: false });
+    addSubscription(db, { ...BASE_SUB, mangaId: "manga-2", mangaTitle: "B", paused: true });
+    addSubscription(db, { ...BASE_SUB, mangaId: "manga-3", mangaTitle: "C", paused: false });
+  });
+
+  test("no filter returns all subscriptions", () => {
+    expect(listSubscriptions(db)).toHaveLength(3);
+  });
+
+  test("paused=true returns only paused", () => {
+    const subs = listSubscriptions(db, { paused: true });
+    expect(subs).toHaveLength(1);
+    expect(subs[0]?.mangaId).toBe("manga-2");
+  });
+
+  test("paused=false returns only active", () => {
+    const subs = listSubscriptions(db, { paused: false });
+    expect(subs).toHaveLength(2);
+    expect(subs.every((s) => s.paused === false)).toBe(true);
+  });
+});

--- a/src/modules/subscriptions/types.ts
+++ b/src/modules/subscriptions/types.ts
@@ -1,0 +1,22 @@
+// Subscriptions module types — schema defined in docs/models/subscription_model.md.
+
+export interface Subscription {
+  source: string;
+  mangaId: string;
+  mangaTitle: string;
+  paused: boolean;
+  addedAt: number;
+  lastSyncedAt: number | null;
+}
+
+export interface SubscriptionRow {
+  source: string;
+  mangaId: string;
+  mangaTitle: string;
+  paused: boolean;
+  addedAt: number;
+}
+
+export interface ListSubscriptionsFilter {
+  paused?: boolean | undefined;
+}

--- a/src/plugins/config/config.test.ts
+++ b/src/plugins/config/config.test.ts
@@ -52,6 +52,7 @@ describe("loadConfig — discovery", () => {
       download_quality: "data-saver",
       default_format: "zip",
       default_out: "./out",
+      db_path: DEFAULT_CONFIG.db_path,
       image_concurrency: 8,
       chapter_delay_ms: 250,
     });

--- a/src/plugins/config/index.ts
+++ b/src/plugins/config/index.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CONFIG: Config = {
   download_quality: "data",
   default_format: "cbz",
   default_out: "./download",
+  db_path: join(homedir(), ".local", "share", "scanldr", "scanldr.db"),
   image_concurrency: 4,
   chapter_delay_ms: 1000,
 };
@@ -117,6 +118,15 @@ export function validateAndMerge(parsed: unknown, source?: string): Config {
       new ConfigError("image_concurrency must be an integer >= 1", source),
     );
     merged.image_concurrency = v;
+  }
+
+  if ("db_path" in p) {
+    const v = p.db_path;
+    check(
+      typeof v === "string" && v.length > 0,
+      new ConfigError("db_path must be a non-empty string", source),
+    );
+    merged.db_path = v;
   }
 
   if ("chapter_delay_ms" in p) {

--- a/src/plugins/config/types.ts
+++ b/src/plugins/config/types.ts
@@ -3,6 +3,7 @@ export interface Config {
   download_quality: "data" | "data-saver";
   default_format: "cbz" | "zip";
   default_out: string;
+  db_path: string;
   image_concurrency: number;
   chapter_delay_ms: number;
 }

--- a/src/plugins/db/db.test.ts
+++ b/src/plugins/db/db.test.ts
@@ -18,6 +18,17 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
+describe("openDb", () => {
+  test("creates parent directories when they do not exist", async () => {
+    const base = await mkdtemp(join(tmpdir(), "scanldr-mkdir-"));
+    const nestedPath = join(base, "a", "b", "c", "test.db");
+    const nestedDb = openDb(nestedPath);
+    expect(nestedDb).toBeDefined();
+    nestedDb.close();
+    await rm(base, { recursive: true, force: true });
+  });
+});
+
 describe("runMigrations", () => {
   test("boot with 0 applied migrations — creates _migrations table and applies all files", () => {
     runMigrations(db);

--- a/src/plugins/db/db.test.ts
+++ b/src/plugins/db/db.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
+import type { Db } from "@plugins/db/index.ts";
+
+let workDir: string;
+let db: Db;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "scanldr-db-"));
+  db = openDb(join(workDir, "test.db"));
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("runMigrations", () => {
+  test("boot with 0 applied migrations — creates _migrations table and applies all files", () => {
+    runMigrations(db);
+
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'")
+      .get() as { name: string } | null;
+    expect(row?.name).toBe("_migrations");
+
+    const downloads = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='downloads'")
+      .get() as { name: string } | null;
+    expect(downloads?.name).toBe("downloads");
+
+    const subscriptions = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='subscriptions'")
+      .get() as { name: string } | null;
+    expect(subscriptions?.name).toBe("subscriptions");
+
+    const idx = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_unique_chapter'")
+      .get() as { name: string } | null;
+    expect(idx?.name).toBe("idx_unique_chapter");
+
+    const rows = db
+      .prepare<{ name: string }, []>("SELECT name FROM _migrations ORDER BY name")
+      .all();
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    expect(rows[0]?.name).toBe("001_create_downloads.sql");
+    expect(rows[1]?.name).toBe("002_create_subscriptions.sql");
+  });
+
+  test("boot with subset of migrations applied — only runs pending ones", () => {
+    // Manually bootstrap _migrations and apply only the first migration
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS _migrations (
+        name       TEXT    PRIMARY KEY,
+        applied_at INTEGER NOT NULL
+      );
+    `);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS downloads (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        manga_id      TEXT    NOT NULL,
+        manga_title   TEXT    NOT NULL,
+        volume        TEXT    NOT NULL,
+        chapter_id    TEXT    NOT NULL,
+        chapter_num   TEXT    NOT NULL,
+        source        TEXT    NOT NULL,
+        language      TEXT    NOT NULL,
+        downloaded_at INTEGER NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_chapter
+        ON downloads (manga_id, chapter_id, source, language);
+    `);
+    db.prepare("INSERT INTO _migrations (name, applied_at) VALUES (?, ?)").run(
+      "001_create_downloads.sql",
+      Date.now(),
+    );
+
+    runMigrations(db);
+
+    // Only 002 should have been applied now (plus the pre-existing 001)
+    const rows = db
+      .prepare<{ name: string }, []>("SELECT name FROM _migrations ORDER BY name")
+      .all();
+    expect(rows.map((r) => r.name)).toContain("002_create_subscriptions.sql");
+
+    const subscriptions = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='subscriptions'")
+      .get() as { name: string } | null;
+    expect(subscriptions?.name).toBe("subscriptions");
+  });
+
+  test("re-run is idempotent — second runMigrations is a no-op", () => {
+    runMigrations(db);
+
+    const countBefore = (
+      db.prepare<{ c: number }, []>("SELECT COUNT(*) AS c FROM _migrations").get() as {
+        c: number;
+      }
+    ).c;
+
+    runMigrations(db);
+
+    const countAfter = (
+      db.prepare<{ c: number }, []>("SELECT COUNT(*) AS c FROM _migrations").get() as {
+        c: number;
+      }
+    ).c;
+
+    expect(countAfter).toBe(countBefore);
+  });
+});

--- a/src/plugins/db/index.ts
+++ b/src/plugins/db/index.ts
@@ -1,8 +1,8 @@
 // DB plugin — opens SQLite and applies versioned migrations from migrations/*.sql.
 
 import { Database } from "bun:sqlite";
-import { readFileSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { mkdirSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import type { Db, MigrationRow } from "./types.ts";
 
 export type { Db, MigrationRow } from "./types.ts";
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS _migrations (
 `;
 
 export function openDb(path: string): Db {
+  mkdirSync(dirname(path), { recursive: true });
   const db = new Database(path, { create: true });
   db.exec("PRAGMA journal_mode=WAL;");
   db.exec("PRAGMA foreign_keys=ON;");
@@ -26,9 +27,16 @@ export function openDb(path: string): Db {
 export function runMigrations(db: Db): void {
   db.exec(BOOTSTRAP_MIGRATIONS_TABLE);
 
-  const files = readdirSync(MIGRATIONS_DIR)
-    .filter((f) => f.endsWith(".sql"))
-    .sort(); // lexicographic order
+  let files: string[];
+  try {
+    files = readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith(".sql"))
+      .sort(); // lexicographic order
+  } catch (err) {
+    throw new Error(
+      `migrations directory not found at ${MIGRATIONS_DIR}: ${(err as Error).message}`,
+    );
+  }
 
   const applied = new Set(
     db

--- a/src/plugins/db/index.ts
+++ b/src/plugins/db/index.ts
@@ -1,0 +1,50 @@
+// DB plugin — opens SQLite and applies versioned migrations from migrations/*.sql.
+
+import { Database } from "bun:sqlite";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { Db, MigrationRow } from "./types.ts";
+
+export type { Db, MigrationRow } from "./types.ts";
+
+const MIGRATIONS_DIR = resolve(import.meta.dir, "../../../migrations");
+
+const BOOTSTRAP_MIGRATIONS_TABLE = `
+CREATE TABLE IF NOT EXISTS _migrations (
+  name       TEXT    PRIMARY KEY,
+  applied_at INTEGER NOT NULL
+);
+`;
+
+export function openDb(path: string): Db {
+  const db = new Database(path, { create: true });
+  db.exec("PRAGMA journal_mode=WAL;");
+  db.exec("PRAGMA foreign_keys=ON;");
+  return db;
+}
+
+export function runMigrations(db: Db): void {
+  db.exec(BOOTSTRAP_MIGRATIONS_TABLE);
+
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort(); // lexicographic order
+
+  const applied = new Set(
+    db
+      .prepare<MigrationRow, []>("SELECT name, applied_at FROM _migrations")
+      .all()
+      .map((r) => r.name),
+  );
+
+  for (const file of files) {
+    if (applied.has(file)) continue;
+
+    const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
+
+    db.transaction(() => {
+      db.exec(sql);
+      db.prepare("INSERT INTO _migrations (name, applied_at) VALUES (?, ?)").run(file, Date.now());
+    })();
+  }
+}

--- a/src/plugins/db/types.ts
+++ b/src/plugins/db/types.ts
@@ -1,0 +1,10 @@
+// DB plugin types.
+
+import type { Database } from "bun:sqlite";
+
+export type Db = Database;
+
+export interface MigrationRow {
+  name: string;
+  applied_at: number;
+}


### PR DESCRIPTION
## What this PR does

- Introduces `src/plugins/db/` with `openDb()` and `runMigrations()` as the single shared database bootstrap.
- Extracts inline SQL migration from `history/service.ts` into versioned files under `migrations/` (`001_create_downloads.sql`, `002_create_subscriptions.sql`).
- Adds `_migrations` control table; `runMigrations` applies files in lexicographic order and is fully idempotent.
- Refactors `src/modules/history/` to repository pattern: SQL queries in `repository.ts`, business logic in `service.ts`.
- Scaffolds `src/modules/subscriptions/` (index, types, repository, service) ready for issue #11.
- Wires `openDb` + `runMigrations` into the CLI boot in `src/index.ts` before any command handler runs.
- Adds `db_path` to `Config` (default: `~/.local/share/scanldr/scanldr.db`).

## Why it exists

PR #29 embedded migration SQL inline in `openDb()` inside `history/service.ts`. This made schema versioning impossible and mixed data-access concerns with business logic. This refactor establishes the foundation all future modules must follow.

## How it works internally

1. `openDb(path)` — creates the SQLite file, sets WAL + foreign keys.
2. `runMigrations(db)` — bootstraps `_migrations` table, reads `migrations/*.sql` sorted lexicographically, skips already-applied files, wraps each new file in a transaction and inserts a row into `_migrations`.
3. CLI `main()` calls both before dispatching to any handler.

## What did not change

- All public exports from `@modules/history` remain identical except `openDb` (moved to `@plugins/db`).
- No command implementations were altered.

## Test checklist

- [x] Boot with 0 migrations — creates `_migrations`, `downloads`, `subscriptions`, `idx_unique_chapter`
- [x] Boot with subset applied — only pending migrations run
- [x] Re-run is idempotent — count in `_migrations` stays the same
- [x] All existing history tests pass (99 tests total, 0 failures)

## Notes for reviewer

- `import.meta.dir` in `src/plugins/db/index.ts` resolves to the directory of the running file; `../../../migrations` is correct relative to `src/plugins/db/`.
- `db_path` default uses XDG data dir convention. Users can override via `scanldr.json`.

## Closes

Closes #33

### Checklist

- [x] Locally tested
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] No documentation changes needed