### PR TITLE
docs: add README, CONTRIBUTING, and MIT license

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,12 @@
-# scanldr — Conventions for Claude Agents
+# scanldr — Agent Instructions
 
-## Project Structure
+## Conventions
 
-```
-src/
-├── index.ts         # CLI entrypoint
-├── types.ts         # Shared domain types
-├── plugins/         # Infrastructure: config/, logger/, errors/, guards/
-├── modules/         # Business logic: downloader/, history/, subscriptions/
-└── integrations/    # External clients: mangadex/, mangakakalot/
-```
+All code conventions (project structure, no classes, interfaces in types.ts, colocated tests, logger signature, SQL pattern, migrations) are documented in:
 
-Each folder has `index.ts` (public API / logic), `types.ts` (interfaces), `service.ts` or `repository.ts` as needed, and `<name>.test.ts` colocated — never in a top-level `__tests__/` directory.
+**[docs/conventions.md](docs/conventions.md)**
 
-## Hard Rules
-
-- **Interfaces in `types.ts`** — never declare interfaces in `index.ts` or `service.ts`. Re-export from `index.ts`.
-- **No classes** — factory functions only. State lives in closures (`createX(opts): XClient`).
-- **No flat files in `src/`** — every feature in its own folder. Only `index.ts` and `types.ts` at root.
-- **Import aliases** — cross-boundary imports use `@plugins/*`, `@modules/*`, `@integrations/*`. Relative imports only within the same folder.
-- **`plugins/`** = infrastructure (no business rules). **`modules/`** = business domain. **`integrations/`** = external site clients.
+Read it before writing any code.
 
 ## Gates before every PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,34 +12,9 @@ cd scanldr
 bun install
 ```
 
-## Before every PR
+## Code conventions
 
-All three gates must pass:
-
-```bash
-bun test && bun run typecheck && bun run check
-```
-
-## Project structure
-
-```
-src/
-├── index.ts            # CLI entrypoint
-├── types.ts            # Shared domain types
-├── plugins/            # Infrastructure: config/, logger/, db/, errors/, guards/
-├── modules/            # Business logic: downloader/, history/, subscriptions/
-└── integrations/       # External clients: mangadex/, mangakakalot/
-migrations/             # Versioned SQL migrations (applied in lexicographic order)
-```
-
-## Conventions
-
-- **No classes** — factory functions with closures (`createX(opts): XClient`)
-- **Interfaces in `types.ts`** — never in `index.ts` or `service.ts`
-- **Tests colocated** — `src/modules/foo/foo.test.ts`, not `src/__tests__/`
-- **Import aliases** — use `@plugins/*`, `@modules/*`, `@integrations/*` for cross-boundary imports; relative imports only within the same folder
-- **Logger** — `logger.warn({ event, context, ...fields }, msg)` — fields first, message last; no `debug` level
-- **SQL** — queries in `repository.ts`, business logic in `service.ts`
+See **[docs/conventions.md](docs/conventions.md)** for the full reference: project structure, coding rules, logger signature, SQL pattern, and test conventions.
 
 ## Pull requests
 
@@ -47,16 +22,4 @@ migrations/             # Versioned SQL migrations (applied in lexicographic ord
 - Title follows [Conventional Commits](https://www.conventionalcommits.org): `feat(scope): description`
 - Fill the PR template — description is required
 - Every PR must close an open issue (`Closes #N`)
-
-## Migrations
-
-Add new SQL files under `migrations/` with lexicographic ordering:
-
-```
-migrations/
-├── 001_create_downloads.sql
-├── 002_create_subscriptions.sql
-└── 003_your_new_migration.sql
-```
-
-Migrations run automatically on CLI boot via `runMigrations(db)`.
+- All gates must pass before merge: `bun test && bun run typecheck && bun run check`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Prerequisites
+
+- [Bun](https://bun.sh) v1.3 or later
+
+## Setup
+
+```bash
+git clone https://github.com/malaquiasdev/scanldr.git
+cd scanldr
+bun install
+```
+
+## Before every PR
+
+All three gates must pass:
+
+```bash
+bun test && bun run typecheck && bun run check
+```
+
+## Project structure
+
+```
+src/
+├── index.ts            # CLI entrypoint
+├── types.ts            # Shared domain types
+├── plugins/            # Infrastructure: config/, logger/, db/, errors/, guards/
+├── modules/            # Business logic: downloader/, history/, subscriptions/
+└── integrations/       # External clients: mangadex/, mangakakalot/
+migrations/             # Versioned SQL migrations (applied in lexicographic order)
+```
+
+## Conventions
+
+- **No classes** — factory functions with closures (`createX(opts): XClient`)
+- **Interfaces in `types.ts`** — never in `index.ts` or `service.ts`
+- **Tests colocated** — `src/modules/foo/foo.test.ts`, not `src/__tests__/`
+- **Import aliases** — use `@plugins/*`, `@modules/*`, `@integrations/*` for cross-boundary imports; relative imports only within the same folder
+- **Logger** — `logger.warn({ event, context, ...fields }, msg)` — fields first, message last; no `debug` level
+- **SQL** — queries in `repository.ts`, business logic in `service.ts`
+
+## Pull requests
+
+- Branch from `main`: `git checkout -b feat/<issue-number>-<short-description>`
+- Title follows [Conventional Commits](https://www.conventionalcommits.org): `feat(scope): description`
+- Fill the PR template — description is required
+- Every PR must close an open issue (`Closes #N`)
+
+## Migrations
+
+Add new SQL files under `migrations/` with lexicographic ordering:
+
+```
+migrations/
+├── 001_create_downloads.sql
+├── 002_create_subscriptions.sql
+└── 003_your_new_migration.sql
+```
+
+Migrations run automatically on CLI boot via `runMigrations(db)`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mateus Malaquias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -22,25 +22,26 @@ A command-line tool to download manga from MangaDex and Mangakakalot, packaged a
 git clone https://github.com/malaquiasdev/scanldr.git
 cd scanldr
 bun install
+bun link
 ```
 
 ## Usage
 
 ```bash
 # Authenticate with Mangakakalot (one-time, launches Chromium)
-bun run src/index.ts auth
+scanldr auth
 
 # Download a volume from MangaDex
-bun run src/index.ts download --volume 1 <manga-slug>
+scanldr download --volume 1 <manga-slug>
 
 # List available volumes
-bun run src/index.ts list <manga-slug>
+scanldr list <manga-slug>
 
 # Watch a series for updates
-bun run src/index.ts watch <manga-slug>
+scanldr watch <manga-slug>
 
 # Show download history
-bun run src/index.ts history
+scanldr history
 ```
 
 ## Configuration
@@ -71,13 +72,13 @@ Create a `scanldr.json` in your project directory (or `~/.config/scanldr/scanldr
 
 ```bash
 # Default (info level, human format)
-bun run src/index.ts list <slug>
+scanldr list <slug>
 
 # Quiet (warn + error only)
-bun run src/index.ts download --volume 1 <slug> --quiet
+scanldr download --volume 1 <slug> --quiet
 
 # JSON output (for log shippers)
-bun run src/index.ts download --volume 1 <slug> --json
+scanldr download --volume 1 <slug> --json
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -28,20 +28,25 @@ bun link
 ## Usage
 
 ```bash
-# Authenticate with Mangakakalot (one-time, launches Chromium)
-scanldr auth
+scanldr help
+```
 
-# Download a volume from MangaDex
-scanldr download --volume 1 <manga-slug>
-
-# List available volumes
-scanldr list <manga-slug>
-
-# Watch a series for updates
-scanldr watch <manga-slug>
-
-# Show download history
-scanldr history
+```
+Commands:
+  auth                           Open browser for Cloudflare bypass, save session
+  list <manga>                   List volumes, chapters, languages, groups
+  download <manga> --volume <n>  Download volumes (e.g. 1, 1-5, 1,3,7)
+  download <manga> --chapter <n> Download chapters (same range syntax)
+  update <manga>                 Download what is missing in history
+  sync                           Run update for every active subscription
+  watch <manga>                  Add to subscription list
+  unwatch <manga>                Remove from subscription list (history kept)
+  watchlist [--paused]           List subscriptions
+  pause <manga>                  Skip a subscription on sync
+  resume <manga>                 Re-enable a paused subscription
+  import <file>                  Bootstrap subscriptions from a flat-text list
+  export [--out <file>]          Dump active subscriptions as plain text
+  history [--manga <m>]          Display download history
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# scanldr
+<p align="center">
+  <img src="assets/banner.svg" alt="scanldr" width="800"/>
+</p>
 
 A command-line tool to download manga from MangaDex and Mangakakalot, packaged as CBZ archives.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# scanldr
+
+A command-line tool to download manga from MangaDex and Mangakakalot, packaged as CBZ archives.
+
+## Features
+
+- Download manga volumes as `.cbz` files
+- Parallel image downloads with configurable concurrency
+- Rate-limit handling with exponential backoff
+- Cloudflare bypass via cookie replay (one-time interactive auth)
+- Download history tracked in SQLite
+- Subscription management (watch/unwatch series)
+- Structured JSON logs for log shippers
+
+## Requirements
+
+- [Bun](https://bun.sh) v1.3 or later
+
+## Installation
+
+```bash
+git clone https://github.com/malaquiasdev/scanldr.git
+cd scanldr
+bun install
+```
+
+## Usage
+
+```bash
+# Authenticate with Mangakakalot (one-time, launches Chromium)
+bun run src/index.ts auth
+
+# Download a volume from MangaDex
+bun run src/index.ts download --volume 1 <manga-slug>
+
+# List available volumes
+bun run src/index.ts list <manga-slug>
+
+# Watch a series for updates
+bun run src/index.ts watch <manga-slug>
+
+# Show download history
+bun run src/index.ts history
+```
+
+## Configuration
+
+Create a `scanldr.json` in your project directory (or `~/.config/scanldr/scanldr.json` for global config):
+
+```json
+{
+  "preferred_languages": ["en"],
+  "download_quality": "data",
+  "default_format": "cbz",
+  "default_out": "./downloads",
+  "image_concurrency": 4,
+  "chapter_delay_ms": 500
+}
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `preferred_languages` | `["en"]` | BCP 47 language tags in priority order |
+| `download_quality` | `"data"` | `"data"` or `"data-saver"` |
+| `default_format` | `"cbz"` | `"cbz"` or `"zip"` |
+| `default_out` | `"./downloads"` | Output directory |
+| `image_concurrency` | `4` | Max parallel image downloads |
+| `chapter_delay_ms` | `500` | Delay between chapters (ms) |
+
+## Logging
+
+```bash
+# Default (info level, human format)
+bun run src/index.ts list <slug>
+
+# Quiet (warn + error only)
+bun run src/index.ts download --volume 1 <slug> --quiet
+
+# JSON output (for log shippers)
+bun run src/index.ts download --volume 1 <slug> --json
+```
+
+## Development
+
+```bash
+# Run tests
+bun test
+
+# Type check
+bun run typecheck
+
+# Lint
+bun run check
+```
+
+## License
+
+[MIT](LICENSE)

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <rect width="800" height="200" fill="#1e1e2e" rx="12"/>
+  <text
+    x="400" y="95"
+    font-family="monospace"
+    font-size="72"
+    font-weight="bold"
+    fill="#cba6f7"
+    text-anchor="middle"
+    letter-spacing="8"
+  >scanldr</text>
+  <text
+    x="400" y="140"
+    font-family="monospace"
+    font-size="16"
+    fill="#6c7086"
+    text-anchor="middle"
+    letter-spacing="3"
+  >manga downloader · cbz · mangadex</text>
+</svg>

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,59 @@
+# Code Conventions
+
+## Project Structure
+
+```
+src/
+├── index.ts            # CLI entrypoint
+├── types.ts            # Shared domain types
+├── plugins/            # Infrastructure: config/, logger/, db/, errors/, guards/
+├── modules/            # Business logic: downloader/, history/, subscriptions/
+└── integrations/       # External clients: mangadex/, mangakakalot/
+migrations/             # Versioned SQL migrations (applied in lexicographic order)
+```
+
+Each folder has `index.ts` (public API), `types.ts` (interfaces), `service.ts` or `repository.ts` as needed, and `<name>.test.ts` colocated — never in a top-level `__tests__/` directory.
+
+## Hard Rules
+
+- **No classes** — factory functions with closures only (`createX(opts): XClient`). State lives in the closure.
+- **Interfaces in `types.ts`** — never declare interfaces or types in `index.ts` or `service.ts`. Re-export from `index.ts`.
+- **No flat files in `src/`** — every feature in its own folder. Only `index.ts` and `types.ts` at root level.
+- **Import aliases** — cross-boundary imports use `@plugins/*`, `@modules/*`, `@integrations/*`. Relative imports only within the same folder.
+- **`plugins/`** = infrastructure (no business rules). **`modules/`** = business domain. **`integrations/`** = external site clients.
+
+## Logger
+
+Signature follows the pino convention — structured fields first, human message last:
+
+```ts
+logger.info({ event: "downloader.chapter_start", context: "downloader", id, num }, "downloading chapter")
+logger.warn({ event: "mangadex.rate_limited", context: "http", attempt, waitMs }, "429 rate-limited, backing off")
+logger.error({ event: "cli.boot_failed", context: "main", err }, "failed to open database")
+```
+
+- `error` — unhandled failure, operation aborted
+- `warn` — handled failure, operation continued (retry, backoff, fallback)
+- `info` — normal progress, one line per stage
+- No `debug` level
+
+## SQL
+
+- Queries live in `repository.ts` — pure SQL, no business logic
+- Business rules live in `service.ts` — calls repository, no raw SQL
+- Schema changes go in `migrations/` as numbered `.sql` files (`001_`, `002_`, ...)
+- Migrations run automatically on CLI boot via `runMigrations(db)` from `@plugins/db`
+
+## Tests
+
+- Colocated with the module: `src/modules/foo/foo.test.ts`
+- Use `bun:test` — no external test framework
+- Integration tests hit a real SQLite database — no mocks for DB
+
+## Gates
+
+Every PR must pass before merge:
+
+```bash
+bun test && bun run typecheck && bun run check
+```


### PR DESCRIPTION
## What this PR does

- `README.md` — project overview, installation, usage, configuration reference, logging flags, development commands
- `CONTRIBUTING.md` — setup, gates, project structure, conventions (no classes, colocated tests, logger signature, migrations), PR workflow
- `LICENSE` — MIT

## Why it exists

Repository is public but had no README, CONTRIBUTING, or license file.

## What did not change

No source code touched.

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project standards