### PR TITLE
feat(cli): wire list subcommand end-to-end

### DIFF
--- a/src/commands/list/formatter.ts
+++ b/src/commands/list/formatter.ts
@@ -1,0 +1,124 @@
+// Pure formatting functions — no I/O, no side effects.
+
+import type { ChapterRef, MangaCandidate, VolumeRef } from "./types.ts";
+
+/** Format full manga listing (all volumes). */
+export function formatMangaList(
+  candidate: MangaCandidate,
+  volumes: VolumeRef[],
+  chapters: ChapterRef[],
+): string {
+  const lines: string[] = [];
+
+  lines.push(`${candidate.title} (id: ${candidate.id})`);
+
+  // Collect unique languages
+  const langs = [...new Set(chapters.map((c) => c.translatedLanguage))].sort();
+  lines.push(`Languages available: ${langs.join(", ")}`);
+  lines.push("");
+
+  // Build a map of chapterId → ChapterRef for quick lookup
+  const chapterById = new Map<string, ChapterRef>(chapters.map((c) => [c.id, c]));
+
+  for (const vol of volumes) {
+    const label = vol.volume === "none" ? "none" : `Volume ${vol.volume}`;
+    lines.push(label);
+
+    // Collect unique chapters by chapter number from chapterIds
+    const seen = new Set<string>();
+    const volChapters: ChapterRef[] = [];
+    for (const id of vol.chapterIds) {
+      const ch = chapterById.get(id);
+      if (!ch) continue;
+      const key = `${ch.chapter ?? "?"}:${ch.translatedLanguage}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        volChapters.push(ch);
+      }
+    }
+
+    // Sort by chapter number
+    volChapters.sort((a, b) => {
+      const an = Number(a.chapter ?? "NaN");
+      const bn = Number(b.chapter ?? "NaN");
+      if (Number.isNaN(an) && Number.isNaN(bn)) return 0;
+      if (Number.isNaN(an)) return 1;
+      if (Number.isNaN(bn)) return -1;
+      return an - bn;
+    });
+
+    for (const ch of volChapters) {
+      const num = ch.chapter ?? "?";
+      const title = ch.title ? ` — ${ch.title}` : "";
+      lines.push(`  Chapter ${num}${title}`);
+    }
+
+    lines.push("");
+  }
+
+  // Collect all unique scanlation groups
+  const groups = [
+    ...new Set(chapters.map((c) => c.scanlationGroup).filter((g): g is string => g !== null)),
+  ].sort();
+
+  if (groups.length > 0) {
+    lines.push(`Groups: ${groups.map((g) => `[${g}]`).join(" ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+/** Format chapters for a single volume. */
+export function formatVolumeList(
+  candidate: MangaCandidate,
+  volumeLabel: string,
+  chapters: ChapterRef[],
+): string {
+  const lines: string[] = [];
+
+  lines.push(`${candidate.title} — Volume ${volumeLabel}`);
+
+  const sorted = [...chapters].sort((a, b) => {
+    const an = Number(a.chapter ?? "NaN");
+    const bn = Number(b.chapter ?? "NaN");
+    if (Number.isNaN(an) && Number.isNaN(bn)) return 0;
+    if (Number.isNaN(an)) return 1;
+    if (Number.isNaN(bn)) return -1;
+    return an - bn;
+  });
+
+  for (const ch of sorted) {
+    const num = ch.chapter ?? "?";
+    const title = ch.title ? ` — ${ch.title}` : "";
+    lines.push(`  Chapter ${num}${title}`);
+  }
+
+  return lines.join("\n");
+}
+
+/** Format details of a single chapter. */
+export function formatChapterDetail(
+  candidate: MangaCandidate,
+  chapter: ChapterRef,
+  pages?: number,
+): string {
+  const lines: string[] = [];
+  const chNum = chapter.chapter ?? "?";
+  const titleSuffix = chapter.title ? `: ${chapter.title}` : "";
+  lines.push(`${candidate.title} — Chapter ${chNum}${titleSuffix}`);
+  lines.push(`Volume:    ${chapter.volume ?? "none"}`);
+  if (pages !== undefined) {
+    lines.push(`Pages:     ${pages}`);
+  }
+  lines.push(`Language:  ${chapter.translatedLanguage}`);
+  lines.push(`Group:     ${chapter.scanlationGroup ?? "—"}`);
+  lines.push(`Published: ${chapter.publishAt.slice(0, 10)}`);
+  return lines.join("\n");
+}
+
+/** Format a list of candidates for interactive / non-tty selection. */
+export function formatCandidateList(candidates: MangaCandidate[]): string {
+  return candidates
+    .map((c, i) => `  [${i + 1}] ${c.title}${c.year ? ` (${c.year})` : ""} — id: ${c.id}`)
+    .join("\n");
+}

--- a/src/commands/list/index.ts
+++ b/src/commands/list/index.ts
@@ -1,0 +1,108 @@
+import { createInterface } from "node:readline";
+import {
+  formatCandidateList,
+  formatChapterDetail,
+  formatMangaList,
+  formatVolumeList,
+} from "./formatter.ts";
+import type { ChapterRef, ListArgs, ListContext, MangaDexClientLike } from "./types.ts";
+
+export type { ListArgs, ListContext } from "./types.ts";
+
+/** Prompt the user to pick one candidate interactively. Resolves to the index chosen (0-based). */
+function promptPick(candidates: { title: string }[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
+    process.stderr.write(`Multiple results found:\n${list}\nPick one: `);
+    rl.once("line", (line) => {
+      rl.close();
+      const n = Number.parseInt(line.trim(), 10);
+      if (Number.isNaN(n) || n < 1 || n > candidates.length) {
+        reject(new Error(`Invalid selection: "${line.trim()}"`));
+      } else {
+        resolve(n - 1);
+      }
+    });
+  });
+}
+
+export async function runList(
+  args: ListArgs,
+  ctx: ListContext,
+  client: MangaDexClientLike,
+): Promise<void> {
+  const { manga, volume, chapter, nonTty } = args;
+  const { logger, languages } = ctx;
+
+  // --volume and --chapter are mutually exclusive
+  if (volume !== undefined && chapter !== undefined) {
+    throw new Error("--volume and --chapter are mutually exclusive");
+  }
+
+  logger.info({ event: "list.search_start", context: "list", title: manga }, "searching manga");
+
+  const candidates = await client.resolveTitleToId(manga);
+
+  // Candidate resolution
+  let chosenIndex = 0;
+  if (candidates.length > 1) {
+    if (nonTty) {
+      // Non-interactive: fail with readable list
+      const list = formatCandidateList(candidates);
+      throw new Error(
+        `Multiple results found for "${manga}". Re-run in a terminal to pick one:\n${list}`,
+      );
+    }
+    chosenIndex = await promptPick(candidates);
+  }
+
+  const chosen = candidates[chosenIndex];
+  if (!chosen) throw new Error("No candidate selected");
+
+  logger.info(
+    { event: "list.manga_resolved", context: "list", id: chosen.id, title: chosen.title },
+    "manga resolved",
+  );
+
+  // --- single chapter detail ---
+  if (chapter !== undefined) {
+    const chapters = await client.feedChapters(chosen.id, languages);
+    const match = chapters.find((c) => c.chapter === chapter);
+    if (!match) {
+      throw new Error(
+        `Chapter ${chapter} not found for "${chosen.title}" in languages: ${languages.join(", ")}`,
+      );
+    }
+    process.stdout.write(`${formatChapterDetail(chosen, match)}\n`);
+    return;
+  }
+
+  // --- volume or full listing ---
+  const volumes = await client.aggregateVolumes(chosen.id, languages);
+
+  if (volume !== undefined) {
+    // Find the requested volume
+    const volRef = volumes.find((v) => v.volume === volume);
+    if (!volRef) {
+      throw new Error(
+        `Volume ${volume} not found for "${chosen.title}" in languages: ${languages.join(", ")}`,
+      );
+    }
+
+    // Fetch full chapter feed to get titles
+    const allChapters = await client.feedChapters(chosen.id, languages);
+    const chapterById = new Map<string, ChapterRef>(allChapters.map((c) => [c.id, c]));
+
+    const volChapters: ChapterRef[] = volRef.chapterIds
+      .map((id) => chapterById.get(id))
+      .filter((c): c is ChapterRef => c !== undefined);
+
+    process.stdout.write(`${formatVolumeList(chosen, volume, volChapters)}\n`);
+    return;
+  }
+
+  // Full listing
+  const allChapters = await client.feedChapters(chosen.id, languages);
+  process.stdout.write(`${formatMangaList(chosen, volumes, allChapters)}\n`);
+}

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatCandidateList,
+  formatChapterDetail,
+  formatMangaList,
+  formatVolumeList,
+} from "./formatter.ts";
+import { runList } from "./index.ts";
+import type {
+  ChapterRef,
+  ListContext,
+  MangaCandidate,
+  MangaDexClientLike,
+  VolumeRef,
+} from "./types.ts";
+
+// --- Fixtures ---
+
+const candidate: MangaCandidate = {
+  id: "a1c7c817-4e59-43b7-9365-09675a149a6f",
+  title: "One Piece",
+  originalLanguage: "ja",
+  year: 1997,
+};
+
+const volumes: VolumeRef[] = [
+  { volume: "1", numeric: 1, chapterIds: ["ch-001", "ch-002", "ch-003"] },
+  { volume: "2", numeric: 2, chapterIds: ["ch-009", "ch-010"] },
+];
+
+const chapters: ChapterRef[] = [
+  {
+    id: "ch-001",
+    volume: "1",
+    chapter: "1",
+    title: "Romance Dawn",
+    translatedLanguage: "en",
+    scanlationGroup: "TCB Scans",
+    publishAt: "1997-07-22T00:00:00+00:00",
+  },
+  {
+    id: "ch-002",
+    volume: "1",
+    chapter: "2",
+    title: "They Call Him",
+    translatedLanguage: "en",
+    scanlationGroup: "TCB Scans",
+    publishAt: "1997-07-29T00:00:00+00:00",
+  },
+  {
+    id: "ch-003",
+    volume: "1",
+    chapter: "3",
+    title: "Morgan versus Luffy",
+    translatedLanguage: "en",
+    scanlationGroup: "TCB Scans",
+    publishAt: "1997-08-05T00:00:00+00:00",
+  },
+  {
+    id: "ch-009",
+    volume: "2",
+    chapter: "9",
+    title: "Versus Cabaji!!",
+    translatedLanguage: "en",
+    scanlationGroup: "Manga Plus",
+    publishAt: "1997-10-14T00:00:00+00:00",
+  },
+  {
+    id: "ch-010",
+    volume: "2",
+    chapter: "10",
+    title: "Incident at the Bar",
+    translatedLanguage: "en",
+    scanlationGroup: "Manga Plus",
+    publishAt: "1997-10-21T00:00:00+00:00",
+  },
+];
+
+const ctx: ListContext = {
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+  languages: ["en"],
+};
+
+// --- formatter tests ---
+
+describe("formatMangaList", () => {
+  it("includes manga title and id", () => {
+    const output = formatMangaList(candidate, volumes, chapters);
+    expect(output).toContain("One Piece (id: a1c7c817-4e59-43b7-9365-09675a149a6f)");
+  });
+
+  it("includes languages available", () => {
+    const output = formatMangaList(candidate, volumes, chapters);
+    expect(output).toContain("Languages available: en");
+  });
+
+  it("includes volume headers", () => {
+    const output = formatMangaList(candidate, volumes, chapters);
+    expect(output).toContain("Volume 1");
+    expect(output).toContain("Volume 2");
+  });
+
+  it("includes chapter lines with titles", () => {
+    const output = formatMangaList(candidate, volumes, chapters);
+    expect(output).toContain("Chapter 1 — Romance Dawn");
+    expect(output).toContain("Chapter 9 — Versus Cabaji!!");
+  });
+
+  it("includes groups section", () => {
+    const output = formatMangaList(candidate, volumes, chapters);
+    expect(output).toContain("Groups: [Manga Plus] [TCB Scans]");
+  });
+});
+
+describe("formatVolumeList", () => {
+  it("shows volume header", () => {
+    const out = formatVolumeList(candidate, "1", chapters.slice(0, 3));
+    expect(out).toContain("One Piece — Volume 1");
+  });
+
+  it("lists chapters in order", () => {
+    const out = formatVolumeList(candidate, "1", chapters.slice(0, 3));
+    expect(out).toContain("Chapter 1 — Romance Dawn");
+    expect(out).toContain("Chapter 3 — Morgan versus Luffy");
+  });
+});
+
+// chapter 0 is always defined — it's a module-level constant array literal above
+const ch0 = chapters[0] ?? {
+  id: "",
+  volume: null,
+  chapter: null,
+  title: null,
+  translatedLanguage: "en",
+  scanlationGroup: null,
+  publishAt: "",
+};
+
+describe("formatChapterDetail", () => {
+  it("shows chapter header with title", () => {
+    const out = formatChapterDetail(candidate, ch0);
+    expect(out).toContain("One Piece — Chapter 1: Romance Dawn");
+  });
+
+  it("shows volume, language, group, published", () => {
+    const out = formatChapterDetail(candidate, ch0);
+    expect(out).toContain("Volume:    1");
+    expect(out).toContain("Language:  en");
+    expect(out).toContain("Group:     TCB Scans");
+    expect(out).toContain("Published: 1997-07-22");
+  });
+
+  it("shows pages when provided", () => {
+    const out = formatChapterDetail(candidate, ch0, 53);
+    expect(out).toContain("Pages:     53");
+  });
+});
+
+describe("formatCandidateList", () => {
+  it("numbers candidates starting at 1", () => {
+    const out = formatCandidateList([candidate]);
+    expect(out).toContain("[1] One Piece");
+  });
+});
+
+// --- runList tests ---
+
+function makeClient(overrides: Partial<MangaDexClientLike> = {}): MangaDexClientLike {
+  return {
+    resolveTitleToId: async (_title) => [candidate],
+    aggregateVolumes: async (_id, _langs) => volumes,
+    feedChapters: async (_id, _langs, _offset) => chapters,
+    ...overrides,
+  };
+}
+
+describe("runList", () => {
+  it("throws CliError when --volume and --chapter are both set", async () => {
+    const client = makeClient();
+    await expect(
+      runList({ manga: "One Piece", volume: "1", chapter: "1", nonTty: true }, ctx, client),
+    ).rejects.toThrow("--volume and --chapter are mutually exclusive");
+  });
+
+  it("non-tty: throws with candidate list when multiple results", async () => {
+    const client = makeClient({
+      resolveTitleToId: async () => [
+        candidate,
+        { id: "other-id", title: "One Piece: Romance Dawn", originalLanguage: "ja", year: 2000 },
+      ],
+    });
+    await expect(runList({ manga: "One Piece", nonTty: true }, ctx, client)).rejects.toThrow(
+      "Multiple results found",
+    );
+  });
+
+  it("single result: writes full listing to stdout", async () => {
+    const written: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: test interception
+    process.stdout.write = (chunk: any) => {
+      written.push(chunk);
+      return true;
+    };
+    try {
+      await runList({ manga: "One Piece", nonTty: true }, ctx, makeClient());
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const output = written.join("");
+    expect(output).toContain("One Piece (id:");
+    expect(output).toContain("Volume 1");
+    expect(output).toContain("Chapter 1 — Romance Dawn");
+  });
+
+  it("--volume: writes volume listing", async () => {
+    const written: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: test interception
+    process.stdout.write = (chunk: any) => {
+      written.push(chunk);
+      return true;
+    };
+    try {
+      await runList({ manga: "One Piece", volume: "1", nonTty: true }, ctx, makeClient());
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const output = written.join("");
+    expect(output).toContain("One Piece — Volume 1");
+  });
+
+  it("--volume: throws when volume not found", async () => {
+    await expect(
+      runList({ manga: "One Piece", volume: "99", nonTty: true }, ctx, makeClient()),
+    ).rejects.toThrow("Volume 99 not found");
+  });
+
+  it("--chapter: writes chapter detail", async () => {
+    const written: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // biome-ignore lint/suspicious/noExplicitAny: test interception
+    process.stdout.write = (chunk: any) => {
+      written.push(chunk);
+      return true;
+    };
+    try {
+      await runList({ manga: "One Piece", chapter: "1", nonTty: true }, ctx, makeClient());
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const output = written.join("");
+    expect(output).toContain("One Piece — Chapter 1: Romance Dawn");
+    expect(output).toContain("Published: 1997-07-22");
+  });
+
+  it("--chapter: throws when chapter not found", async () => {
+    await expect(
+      runList({ manga: "One Piece", chapter: "999", nonTty: true }, ctx, makeClient()),
+    ).rejects.toThrow("Chapter 999 not found");
+  });
+});

--- a/src/commands/list/types.ts
+++ b/src/commands/list/types.ts
@@ -1,0 +1,34 @@
+import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/mangadex/client/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+
+export type { ChapterRef, MangaCandidate, VolumeRef };
+
+export interface ListArgs {
+  manga: string;
+  volume?: string;
+  chapter?: string;
+  /** When true the process is not attached to a TTY (e.g. CI, pipes). */
+  nonTty: boolean;
+}
+
+export interface ListContext {
+  logger: Logger;
+  /** BCP-47 language codes from config.preferred_languages */
+  languages: string[];
+}
+
+export interface ChapterPageCount {
+  id: string;
+  pages: number;
+}
+
+// Minimal shape of what feedChapters returns but enriched with page count.
+export interface ResolvedChapter extends ChapterRef {
+  pages?: number;
+}
+
+export interface MangaDexClientLike {
+  resolveTitleToId: (title: string) => Promise<MangaCandidate[]>;
+  aggregateVolumes: (mangaId: string, languages: string[]) => Promise<VolumeRef[]>;
+  feedChapters: (mangaId: string, languages: string[], offset?: number) => Promise<ChapterRef[]>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env bun
 import { parseArgs } from "node:util";
+import { runList } from "@commands/list/index.ts";
+import { createMangaDexClient } from "@integrations/mangadex/client/index.ts";
+import { createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
 import { AuthError, runAuth } from "@integrations/mangakakalot/browser/index.ts";
 import { loadConfig } from "@plugins/config/index.ts";
+import type { Config } from "@plugins/config/index.ts";
 import { openDb, runMigrations } from "@plugins/db/index.ts";
 import type { Db } from "@plugins/db/index.ts";
 import { type LogFormat, type LogLevel, type Logger, createLogger } from "@plugins/logger/index.ts";
@@ -54,6 +58,7 @@ class CliError extends Error {
 interface HandlerContext {
   logger: Logger;
   db: Db;
+  config: Config;
 }
 
 type Handler = (rest: string[], ctx: HandlerContext) => Promise<void> | void;
@@ -62,8 +67,38 @@ const handlers: Record<string, Handler> = {
   auth: async (_rest, ctx) => {
     await runAuth({ logger: ctx.logger });
   },
-  list: () => {
-    throw new NotImplementedError("list");
+  list: async (rest, ctx) => {
+    const { values: listValues, positionals: listPos } = parseArgs({
+      args: rest,
+      allowPositionals: true,
+      strict: false,
+      options: {
+        volume: { type: "string" },
+        chapter: { type: "string" },
+        "non-tty": { type: "boolean" },
+      },
+    });
+
+    const manga = listPos[0];
+    if (!manga) {
+      throw new CliError("Usage: scanldr list <manga> [--volume <n>] [--chapter <n>]", 2);
+    }
+
+    const nonTty = listValues["non-tty"] === true || !process.stdout.isTTY;
+
+    const http = createMangaDexHttp({ logger: ctx.logger, config: ctx.config });
+    const client = createMangaDexClient(http);
+
+    await runList(
+      {
+        manga,
+        volume: typeof listValues.volume === "string" ? listValues.volume : undefined,
+        chapter: typeof listValues.chapter === "string" ? listValues.chapter : undefined,
+        nonTty,
+      },
+      { logger: ctx.logger, languages: ctx.config.preferred_languages },
+      client,
+    );
   },
   download: () => {
     throw new NotImplementedError("download");
@@ -157,7 +192,7 @@ async function main(argv: string[]): Promise<void> {
   const db = openDb(config.db_path);
   runMigrations(db);
 
-  return handler(rest, { logger, db });
+  return handler(rest, { logger, db, config });
 }
 
 if (import.meta.main) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "paths": {
       "@plugins/*": ["./src/plugins/*"],
       "@modules/*": ["./src/modules/*"],
-      "@integrations/*": ["./src/integrations/*"]
+      "@integrations/*": ["./src/integrations/*"],
+      "@commands/*": ["./src/commands/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## O que esse PR faz

- Adds `src/commands/list/` with `types.ts`, `formatter.ts`, `index.ts` (handler), and `list.test.ts` (colocated tests).
- Wires `scanldr list <manga> [--volume <n>] [--chapter <n>]` in `src/index.ts`.
- Adds the `@commands/*` TypeScript path alias in `tsconfig.json`.

## Por que existe

Implements the `list` discovery command (issue #9) — the simplest end-to-end flow from `parseArgs` → config → logger → MangaDex client → stdout table. Proves the full stack before `download`.

## Como funciona por dentro

1. `src/index.ts` list handler parses `--volume`, `--chapter`, `--non-tty`, then builds `MangaDexHttpClient` + `MangaDexClient` from context config and calls `runList`.
2. `runList` (`src/commands/list/index.ts`) resolves the title to one candidate (interactive picker on TTY, readable error on non-TTY for multiple results), then dispatches to one of three formatters.
3. `formatter.ts` contains pure, side-effect-free functions: `formatMangaList`, `formatVolumeList`, `formatChapterDetail`, `formatCandidateList`. All output goes to `process.stdout`; logs go to `process.stderr` via the injected logger.

## O que não mudou

- No SQLite reads or writes.
- No files are created on disk.
- No changes to the MangaDex client or HTTP layer.

## Checklist de testes

- [x] `formatMangaList` — title, id, languages, volume headers, chapter lines, groups
- [x] `formatVolumeList` — header and ordered chapter lines
- [x] `formatChapterDetail` — header, volume, language, group, published date, optional pages
- [x] `formatCandidateList` — numbered list starting at 1
- [x] `runList` — mutual exclusion of `--volume`/`--chapter`
- [x] `runList` — non-TTY multiple results throws with candidate list
- [x] `runList` — single result full listing written to stdout
- [x] `runList` — `--volume` listing
- [x] `runList` — `--volume` not found error
- [x] `runList` — `--chapter` detail written to stdout
- [x] `runList` — `--chapter` not found error

## Pontos de atenção pra quem revisar

- Page count (`Pages:`) is omitted from `--chapter` output because the `/at-home/server/:id` page-count endpoint is outside this issue's scope. The field renders only when a `pages` number is explicitly passed to `formatChapterDetail`.
- Interactive TTY picker uses `readline` from `node:util` and writes the prompt to `stderr`, keeping `stdout` clean for piping.

## Closes

Closes #9

### ✅ Checklist

- [x] Código testado localmente
- [x] Self-review concluído
- [x] Sem erros no console
- [x] Código segue os padrões do projeto
- [x] Documentação atualizada em `docs/` (se necessário)