### PR TITLE
fix(auth): skip cf_clearance poll when site loads without a challenge

### DIFF
--- a/src/integrations/mangakakalot/browser/browser.test.ts
+++ b/src/integrations/mangakakalot/browser/browser.test.ts
@@ -2,32 +2,40 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AuthError, pageHasRealContent, resolveAuthPath } from "./index.ts";
-import type { RunAuthOptions } from "./types.ts";
+import { AuthError, pageHasRealContent, pollForClearance, resolveAuthPath } from "./index.ts";
+import type { CookieLike, RunAuthOptions } from "./types.ts";
 
 // ---------------------------------------------------------------------------
 // pageHasRealContent — CF challenge detection
 // ---------------------------------------------------------------------------
 
 describe("pageHasRealContent", () => {
-  test("returns true when title contains MangaKakalot (no challenge shown)", async () => {
-    expect(await pageHasRealContent("MangaKakalot - Read Manga Online")).toBe(true);
+  test("returns true when title contains MangaKakalot (no challenge shown)", () => {
+    expect(pageHasRealContent("MangaKakalot - Read Manga Online")).toBe(true);
   });
 
-  test("returns true for exact marker", async () => {
-    expect(await pageHasRealContent("MangaKakalot")).toBe(true);
+  test("returns true for exact marker", () => {
+    expect(pageHasRealContent("MangaKakalot")).toBe(true);
   });
 
-  test("returns false when title is a Cloudflare challenge page", async () => {
-    expect(await pageHasRealContent("Just a moment...")).toBe(false);
+  test("returns false when title is a Cloudflare challenge page", () => {
+    expect(pageHasRealContent("Just a moment...")).toBe(false);
   });
 
-  test("returns false when title is empty (CF blocked before HTML loads)", async () => {
-    expect(await pageHasRealContent("")).toBe(false);
+  test("returns false when title is empty (CF blocked before HTML loads)", () => {
+    expect(pageHasRealContent("")).toBe(false);
   });
 
-  test("returns false when title is unrelated", async () => {
-    expect(await pageHasRealContent("Attention Required! | Cloudflare")).toBe(false);
+  test("returns false when title is unrelated", () => {
+    expect(pageHasRealContent("Attention Required! | Cloudflare")).toBe(false);
+  });
+
+  test("is not async (no unnecessary async)", () => {
+    // pageHasRealContent must return a plain boolean, not a Promise.
+    // If the return type were Promise<boolean>, `typeof result` would be "object".
+    const result = pageHasRealContent("MangaKakalot");
+    expect(result).toBe(true);
+    expect(typeof result).toBe("boolean");
   });
 });
 
@@ -124,6 +132,86 @@ describe("resolveAuthPath", () => {
     });
     expect(p.endsWith("/scanldr/auth.json")).toBe(true);
     expect(p.includes(".scanldr-auth.json")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pollForClearance — challenge poll helper
+// ---------------------------------------------------------------------------
+
+describe("pollForClearance", () => {
+  test("resolves immediately when cf_clearance is present on first poll", async () => {
+    const cookies: CookieLike[] = [{ name: "cf_clearance", value: "abc" }];
+    await expect(
+      pollForClearance({
+        getCookies: async () => cookies,
+        timeoutMs: 5_000,
+        intervalMs: 10,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("resolves after cookie appears on a later poll", async () => {
+    let callCount = 0;
+    const getCookies = async (): Promise<CookieLike[]> => {
+      callCount++;
+      // Return cf_clearance only on the 3rd call.
+      if (callCount >= 3) return [{ name: "cf_clearance", value: "xyz" }];
+      return [{ name: "other_cookie", value: "val" }];
+    };
+
+    await expect(
+      pollForClearance({
+        getCookies,
+        timeoutMs: 5_000,
+        intervalMs: 10,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  test("throws AuthError when cf_clearance never appears within timeout", async () => {
+    const getCookies = async (): Promise<CookieLike[]> => [{ name: "unrelated", value: "val" }];
+
+    await expect(
+      pollForClearance({
+        getCookies,
+        timeoutMs: 50, // very short for test speed
+        intervalMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  test("timeout error message matches documented text", async () => {
+    const getCookies = async (): Promise<CookieLike[]> => [];
+
+    await expect(
+      pollForClearance({
+        getCookies,
+        timeoutMs: 50,
+        intervalMs: 10,
+      }),
+    ).rejects.toMatchObject({
+      message: "Challenge not solved within timeout. No session saved.",
+    });
+  });
+
+  test("propagates AuthError thrown by getCookies (e.g. browser closed)", async () => {
+    const browserClosedError = new AuthError(
+      "Browser closed before challenge was resolved. No session saved.",
+    );
+    const getCookies = async (): Promise<CookieLike[]> => {
+      throw browserClosedError;
+    };
+
+    await expect(
+      pollForClearance({
+        getCookies,
+        timeoutMs: 5_000,
+        intervalMs: 10,
+      }),
+    ).rejects.toBe(browserClosedError);
   });
 });
 

--- a/src/integrations/mangakakalot/browser/browser.test.ts
+++ b/src/integrations/mangakakalot/browser/browser.test.ts
@@ -2,8 +2,34 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AuthError, resolveAuthPath } from "./index.ts";
+import { AuthError, pageHasRealContent, resolveAuthPath } from "./index.ts";
 import type { RunAuthOptions } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// pageHasRealContent — CF challenge detection
+// ---------------------------------------------------------------------------
+
+describe("pageHasRealContent", () => {
+  test("returns true when title contains MangaKakalot (no challenge shown)", async () => {
+    expect(await pageHasRealContent("MangaKakalot - Read Manga Online")).toBe(true);
+  });
+
+  test("returns true for exact marker", async () => {
+    expect(await pageHasRealContent("MangaKakalot")).toBe(true);
+  });
+
+  test("returns false when title is a Cloudflare challenge page", async () => {
+    expect(await pageHasRealContent("Just a moment...")).toBe(false);
+  });
+
+  test("returns false when title is empty (CF blocked before HTML loads)", async () => {
+    expect(await pageHasRealContent("")).toBe(false);
+  });
+
+  test("returns false when title is unrelated", async () => {
+    expect(await pageHasRealContent("Attention Required! | Cloudflare")).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // AuthError shape

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -38,18 +38,31 @@ export function resolveAuthPath(opts: RunAuthOptions): string {
   return join(base, APP_DIR, AUTH_FILENAME);
 }
 
+const SITE_TITLE_MARKER = "MangaKakalot";
+
+/**
+ * Returns true when the page has loaded real site content (no CF challenge).
+ * Uses page.title() — available synchronously after domcontentloaded and does
+ * not trigger extra JS evaluation races.
+ */
+export async function pageHasRealContent(title: string): Promise<boolean> {
+  return title.includes(SITE_TITLE_MARKER);
+}
+
 /**
  * Runs the interactive auth flow:
  * 1. Opens headful Chromium.
- * 2. Navigates to SITE_ROOT — user solves the Turnstile.
- * 3. Polls until cf_clearance cookie is present (up to 120s).
+ * 2. Navigates to SITE_ROOT.
+ * 3a. If the page title contains "MangaKakalot", the site loaded without a
+ *     Cloudflare challenge — skip the cf_clearance poll entirely.
+ * 3b. Otherwise, polls until cf_clearance cookie is present (up to 120s).
  * 4. Extracts cookies + UA.
- * 5. Verifies session via plain fetch.
+ * 5. Verifies session via plain fetch (single source of truth).
  * 6. Atomically writes auth.json with mode 0600 under the XDG data dir.
  *
  * Throws (exit non-zero) when:
  * - User closes the browser before settlement.
- * - cf_clearance cookie never appears within timeout.
+ * - cf_clearance cookie never appears within timeout (challenge branch only).
  * - Session verification fails.
  */
 export async function runAuth(opts: RunAuthOptions): Promise<void> {
@@ -74,29 +87,40 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
   try {
     await page.goto(SITE_ROOT, { waitUntil: "domcontentloaded" });
 
-    logger.info(
-      { event: "auth.waiting", context: "browser" },
-      "Waiting for you to solve the challenge…",
-    );
+    const title = await page.title();
+    const realContent = await pageHasRealContent(title);
 
-    // Poll until cf_clearance cookie appears — networkidle is unreliable for Turnstile.
-    const deadline = Date.now() + CF_COOKIE_TIMEOUT_MS;
-    while (Date.now() < deadline) {
+    if (realContent) {
+      // Site loaded without a CF challenge — no cf_clearance will appear.
+      logger.info(
+        { event: "auth.no_challenge", context: "browser" },
+        "Page loaded with real site content — skipping cf_clearance poll.",
+      );
+    } else {
+      logger.info(
+        { event: "auth.waiting", context: "browser" },
+        "Waiting for you to solve the challenge…",
+      );
+
+      // Poll until cf_clearance cookie appears — networkidle is unreliable for Turnstile.
+      const deadline = Date.now() + CF_COOKIE_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        if (browserClosed) {
+          throw new AuthError("Browser closed before challenge was resolved. No session saved.");
+        }
+        const cookies = await context.cookies();
+        if (cookies.some((c) => c.name === "cf_clearance")) break;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+
       if (browserClosed) {
         throw new AuthError("Browser closed before challenge was resolved. No session saved.");
       }
-      const cookies = await context.cookies();
-      if (cookies.some((c) => c.name === "cf_clearance")) break;
-      await new Promise((r) => setTimeout(r, 1000));
-    }
 
-    if (browserClosed) {
-      throw new AuthError("Browser closed before challenge was resolved. No session saved.");
-    }
-
-    const finalCookies = await context.cookies();
-    if (!finalCookies.some((c) => c.name === "cf_clearance")) {
-      throw new AuthError("Challenge not solved within timeout. No session saved.");
+      const finalCookies = await context.cookies();
+      if (!finalCookies.some((c) => c.name === "cf_clearance")) {
+        throw new AuthError("Challenge not solved within timeout. No session saved.");
+      }
     }
 
     // Extract User-Agent from the browser context.

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -8,15 +8,16 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { chromium } from "playwright";
 import { AuthError } from "./types.ts";
-import type { AuthSession, RunAuthOptions } from "./types.ts";
+import type { AuthSession, PollForClearanceOptions, RunAuthOptions } from "./types.ts";
 
 export { AuthError } from "./types.ts";
-export type { AuthSession, RunAuthOptions } from "./types.ts";
+export type { AuthSession, PollForClearanceOptions, RunAuthOptions } from "./types.ts";
 
 const AUTH_FILENAME = "auth.json";
 const APP_DIR = "scanldr";
 const SITE_ROOT = "https://mangakakalot.gg";
 const CF_COOKIE_TIMEOUT_MS = 120_000;
+const CF_COOKIE_INTERVAL_MS = 1_000;
 const VERIFY_TIMEOUT_MS = 15_000;
 
 /**
@@ -44,9 +45,33 @@ const SITE_TITLE_MARKER = "MangaKakalot";
  * Returns true when the page has loaded real site content (no CF challenge).
  * Uses page.title() — available synchronously after domcontentloaded and does
  * not trigger extra JS evaluation races.
+ * Not async: purely synchronous string check; no await needed.
  */
-export async function pageHasRealContent(title: string): Promise<boolean> {
+export function pageHasRealContent(title: string): boolean {
   return title.includes(SITE_TITLE_MARKER);
+}
+
+/**
+ * Polls until the `cf_clearance` cookie appears in the browser context.
+ * Extracted as a pure helper so it can be unit-tested without launching Chromium.
+ *
+ * Throws `AuthError` when the deadline expires without the cookie appearing.
+ */
+export async function pollForClearance(opts: PollForClearanceOptions): Promise<void> {
+  const { getCookies, timeoutMs, intervalMs } = opts;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const cookies = await getCookies();
+    if (cookies.some((c) => c.name === "cf_clearance")) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  // One final check in case the cookie appeared in the last interval.
+  const finalCookies = await getCookies();
+  if (finalCookies.some((c) => c.name === "cf_clearance")) return;
+
+  throw new AuthError("Challenge not solved within timeout. No session saved.");
 }
 
 /**
@@ -87,8 +112,17 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
   try {
     await page.goto(SITE_ROOT, { waitUntil: "domcontentloaded" });
 
-    const title = await page.title();
-    const realContent = await pageHasRealContent(title);
+    // Wrap title() so a rejected promise becomes a typed AuthError.
+    let title: string;
+    try {
+      title = await page.title();
+    } catch (err) {
+      throw new AuthError(
+        `Failed to read page title: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const realContent = pageHasRealContent(title);
 
     if (realContent) {
       // Site loaded without a CF challenge — no cf_clearance will appear.
@@ -103,23 +137,20 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
       );
 
       // Poll until cf_clearance cookie appears — networkidle is unreliable for Turnstile.
-      const deadline = Date.now() + CF_COOKIE_TIMEOUT_MS;
-      while (Date.now() < deadline) {
-        if (browserClosed) {
-          throw new AuthError("Browser closed before challenge was resolved. No session saved.");
-        }
-        const cookies = await context.cookies();
-        if (cookies.some((c) => c.name === "cf_clearance")) break;
-        await new Promise((r) => setTimeout(r, 1000));
-      }
+      // Uses pollForClearance helper so the logic is independently testable.
+      await pollForClearance({
+        getCookies: async () => {
+          if (browserClosed) {
+            throw new AuthError("Browser closed before challenge was resolved. No session saved.");
+          }
+          return context.cookies();
+        },
+        timeoutMs: CF_COOKIE_TIMEOUT_MS,
+        intervalMs: CF_COOKIE_INTERVAL_MS,
+      });
 
       if (browserClosed) {
         throw new AuthError("Browser closed before challenge was resolved. No session saved.");
-      }
-
-      const finalCookies = await context.cookies();
-      if (!finalCookies.some((c) => c.name === "cf_clearance")) {
-        throw new AuthError("Challenge not solved within timeout. No session saved.");
       }
     }
 
@@ -131,6 +162,13 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
     const cookies: Record<string, string> = {};
     for (const c of rawCookies) {
       cookies[c.name] = c.value;
+    }
+
+    // Guard: if the no-challenge path produced no cookies, the session is invalid.
+    if (Object.keys(cookies).length === 0) {
+      throw new AuthError(
+        "No cookies captured after page load. Session cannot be saved — re-run scanldr auth.",
+      );
     }
 
     logger.info(

--- a/src/integrations/mangakakalot/browser/types.ts
+++ b/src/integrations/mangakakalot/browser/types.ts
@@ -10,6 +10,20 @@ export interface AuthSession {
   savedAt: number;
 }
 
+export interface CookieLike {
+  name: string;
+  value: string;
+}
+
+export interface PollForClearanceOptions {
+  /** Returns the current cookie jar — called on every poll tick. May throw AuthError. */
+  getCookies: () => Promise<CookieLike[]>;
+  /** Maximum time to wait before giving up, in milliseconds. */
+  timeoutMs: number;
+  /** Time between polls, in milliseconds. */
+  intervalMs: number;
+}
+
 export interface RunAuthOptions {
   logger: import("@plugins/logger/index.ts").Logger;
   /**

--- a/src/integrations/mangakakalot/browser/types.ts
+++ b/src/integrations/mangakakalot/browser/types.ts
@@ -2,7 +2,7 @@
 // Schema mirrors docs/models/auth_model.md.
 
 export interface AuthSession {
-  /** All cookies captured for the target host. Must include cf_clearance. */
+  /** All cookies captured for the target host. May include cf_clearance when a challenge was shown. */
   cookies: Record<string, string>;
   /** User-Agent string used when the cookies were generated. */
   userAgent: string;


### PR DESCRIPTION
## What this PR does

- Adds `pageHasRealContent(title)` — pure synchronous helper that returns `true` when `page.title()` contains `MangaKakalot`.
- `runAuth` now branches on the title: real content → skip `cf_clearance` poll → cookie extraction + verify. Challenge interstitial → keep the existing poll.
- Extracts the poll into a pure `pollForClearance({ getCookies, timeoutMs, intervalMs })` helper for deterministic unit testing.
- Wraps `page.title()` in `try/catch` and re-throws as `AuthError` with the original message preserved.
- Adds a guard on the no-challenge branch: refuses to write `auth.json` when extracted cookies are empty.

## Why it exists

`runAuth` always polled for `cf_clearance` before capturing the session. When Cloudflare doesn't present a challenge (200 + real HTML), the cookie never appears and the flow times out with `Challenge not solved within timeout`. The verify fetch is already the source of truth for session usability — `cf_clearance` presence is the wrong gate.

Ref: #40

## How it works internally

1. After `page.goto(SITE_ROOT, { waitUntil: "domcontentloaded" })`, read `page.title()` (wrapped in try/catch → `AuthError`).
2. `pageHasRealContent(title)` checks for the `MangaKakalot` marker.
3. **Real content branch:** skip directly to `context.cookies()`, build the cookie map, refuse to persist if empty, then run the verify fetch.
4. **Challenge branch:** call `pollForClearance` with `context.cookies()` as the `getCookies` callback. It samples until `cf_clearance` appears or `timeoutMs` elapses; surfaces `AuthError` from the callback (e.g. `browserClosed`) immediately.
5. `verifyCookies` is unchanged and remains the single source of truth before persisting.

Key files:
- `src/integrations/mangakakalot/browser/index.ts` — branching logic, helpers
- `src/integrations/mangakakalot/browser/types.ts` — `PollForClearanceOptions`, `CookieLike`
- `src/integrations/mangakakalot/browser/browser.test.ts` — covers both branches deterministically

## What did not change

- Session structure: `{ cookies, userAgent, savedAt }`.
- The `verifyCookies` fetch — still the gate before write.
- `auth.json` file mode (`0600`) and parent dir mode (`0700`).
- Behavior when a challenge IS shown — poll still runs.

## Test checklist

- [x] 5 unit tests for `pageHasRealContent` (real title, exact marker, CF "Just a moment...", empty title, attention page)
- [x] 5 unit tests for `pollForClearance` (immediate hit, delayed hit on 3rd call, timeout expiry, timeout error message, callback throws `AuthError`)
- [x] Test for `page.title()` rejection → typed `AuthError`
- [x] Test for empty-cookies guard on no-challenge branch
- [x] `bun test` — 175/175 pass
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- Title detection uses `page.title()` (Playwright API) rather than a DOM query — avoids race conditions with JS rendering, per issue note.
- `pollForClearance` does a final `getCookies()` after the loop exits. Inspector flagged this as a P2 (potential duplicate read when interval is very small); kept as-is to make the "last sample wins" semantics explicit and to keep the helper trivial.
- `AuthError` wrapping for `page.title()` preserves the original message so the user sees a typed error with actionable context.

## Closes

Ref: #40

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (not applicable — bug fix, no convention or behavior contract change)