### PR TITLE
feat(subscriptions): reshape API to object-args and add refreshTitle

### DIFF
--- a/src/modules/subscriptions/index.ts
+++ b/src/modules/subscriptions/index.ts
@@ -1,16 +1,20 @@
 // Public API for the subscriptions module.
 
 export type {
+  AddSubscriptionInput,
   ListSubscriptionsFilter,
+  MarkSyncedInput,
+  RefreshTitleInput,
+  RemoveSubscriptionInput,
+  SetPausedInput,
   Subscription,
-  SubscriptionRow,
 } from "./types.ts";
 
 export {
   addSubscription,
   listSubscriptions,
   markSynced,
-  pauseSubscription,
+  refreshTitle,
   removeSubscription,
-  resumeSubscription,
+  setPaused,
 } from "./service.ts";

--- a/src/modules/subscriptions/repository.ts
+++ b/src/modules/subscriptions/repository.ts
@@ -1,7 +1,7 @@
 // Subscriptions repository — raw SQL queries, no business logic.
 
 import type { Db } from "@plugins/db/index.ts";
-import type { ListSubscriptionsFilter, Subscription, SubscriptionRow } from "./types.ts";
+import type { AddSubscriptionInput, ListSubscriptionsFilter, Subscription } from "./types.ts";
 
 function toSubscription(raw: {
   source: string;
@@ -21,23 +21,25 @@ function toSubscription(raw: {
   };
 }
 
-export function insertSubscription(db: Db, row: SubscriptionRow): void {
+export function insertSubscription(db: Db, input: AddSubscriptionInput, addedAt: number): void {
   db.prepare(
     `INSERT OR IGNORE INTO subscriptions (source, manga_id, manga_title, paused, added_at)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(row.source, row.mangaId, row.mangaTitle, row.paused ? 1 : 0, row.addedAt);
+     VALUES (?, ?, ?, 0, ?)`,
+  ).run(input.source, input.mangaId, input.mangaTitle, addedAt);
 }
 
-export function deleteSubscription(db: Db, source: string, mangaId: string): void {
-  db.prepare("DELETE FROM subscriptions WHERE source = ? AND manga_id = ?").run(source, mangaId);
+export function deleteSubscription(db: Db, source: string, mangaId: string): boolean {
+  const info = db
+    .prepare("DELETE FROM subscriptions WHERE source = ? AND manga_id = ?")
+    .run(source, mangaId);
+  return info.changes > 0;
 }
 
-export function updatePaused(db: Db, source: string, mangaId: string, paused: boolean): void {
-  db.prepare("UPDATE subscriptions SET paused = ? WHERE source = ? AND manga_id = ?").run(
-    paused ? 1 : 0,
-    source,
-    mangaId,
-  );
+export function updatePaused(db: Db, source: string, mangaId: string, paused: boolean): boolean {
+  const info = db
+    .prepare("UPDATE subscriptions SET paused = ? WHERE source = ? AND manga_id = ?")
+    .run(paused ? 1 : 0, source, mangaId);
+  return info.changes > 0;
 }
 
 export function updateLastSyncedAt(
@@ -53,13 +55,21 @@ export function updateLastSyncedAt(
   );
 }
 
+export function updateMangaTitle(db: Db, source: string, mangaId: string, title: string): void {
+  db.prepare("UPDATE subscriptions SET manga_title = ? WHERE source = ? AND manga_id = ?").run(
+    title,
+    source,
+    mangaId,
+  );
+}
+
 export function querySubscriptions(db: Db, filter?: ListSubscriptionsFilter): Subscription[] {
   const conditions: string[] = [];
   const params: (string | number)[] = [];
 
-  if (filter?.paused !== undefined) {
-    conditions.push("paused = ?");
-    params.push(filter.paused ? 1 : 0);
+  // default: active only unless includePaused is explicitly true
+  if (!filter?.includePaused) {
+    conditions.push("paused = 0");
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";

--- a/src/modules/subscriptions/service.ts
+++ b/src/modules/subscriptions/service.ts
@@ -6,28 +6,37 @@ import {
   insertSubscription,
   querySubscriptions,
   updateLastSyncedAt,
+  updateMangaTitle,
   updatePaused,
 } from "./repository.ts";
-import type { ListSubscriptionsFilter, Subscription, SubscriptionRow } from "./types.ts";
+import type {
+  AddSubscriptionInput,
+  ListSubscriptionsFilter,
+  MarkSyncedInput,
+  RefreshTitleInput,
+  RemoveSubscriptionInput,
+  SetPausedInput,
+  Subscription,
+} from "./types.ts";
 
-export function addSubscription(db: Db, row: SubscriptionRow): void {
-  insertSubscription(db, row);
+export function addSubscription(db: Db, input: AddSubscriptionInput): void {
+  insertSubscription(db, input, Date.now());
 }
 
-export function removeSubscription(db: Db, source: string, mangaId: string): void {
-  deleteSubscription(db, source, mangaId);
+export function removeSubscription(db: Db, input: RemoveSubscriptionInput): boolean {
+  return deleteSubscription(db, input.source, input.mangaId);
 }
 
-export function pauseSubscription(db: Db, source: string, mangaId: string): void {
-  updatePaused(db, source, mangaId, true);
+export function setPaused(db: Db, input: SetPausedInput): boolean {
+  return updatePaused(db, input.source, input.mangaId, input.paused);
 }
 
-export function resumeSubscription(db: Db, source: string, mangaId: string): void {
-  updatePaused(db, source, mangaId, false);
+export function markSynced(db: Db, input: MarkSyncedInput): void {
+  updateLastSyncedAt(db, input.source, input.mangaId, input.at);
 }
 
-export function markSynced(db: Db, source: string, mangaId: string, at: number): void {
-  updateLastSyncedAt(db, source, mangaId, at);
+export function refreshTitle(db: Db, input: RefreshTitleInput): void {
+  updateMangaTitle(db, input.source, input.mangaId, input.title);
 }
 
 export function listSubscriptions(db: Db, filter?: ListSubscriptionsFilter): Subscription[] {

--- a/src/modules/subscriptions/subscriptions.test.ts
+++ b/src/modules/subscriptions/subscriptions.test.ts
@@ -8,14 +8,17 @@ import {
   addSubscription,
   listSubscriptions,
   markSynced,
-  pauseSubscription,
+  refreshTitle,
   removeSubscription,
-  resumeSubscription,
+  setPaused,
 } from "./service.ts";
-import type { SubscriptionRow } from "./types.ts";
 
 let workDir: string;
 let db: Db;
+
+const SOURCE = "mangadex";
+const MANGA_ID = "manga-uuid-1";
+const MANGA_TITLE = "One Piece";
 
 beforeEach(async () => {
   workDir = await mkdtemp(join(tmpdir(), "scanldr-subs-"));
@@ -28,83 +31,64 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
-const BASE_SUB: SubscriptionRow = {
-  source: "mangadex",
-  mangaId: "manga-uuid-1",
-  mangaTitle: "One Piece",
-  paused: false,
-  addedAt: 1_700_000_000_000,
-};
-
 describe("addSubscription / listSubscriptions", () => {
   test("inserts a subscription and lists it back", () => {
-    addSubscription(db, BASE_SUB);
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
     const subs = listSubscriptions(db);
     expect(subs).toHaveLength(1);
-    expect(subs[0]?.mangaId).toBe(BASE_SUB.mangaId);
-    expect(subs[0]?.mangaTitle).toBe(BASE_SUB.mangaTitle);
-    expect(subs[0]?.source).toBe(BASE_SUB.source);
+    expect(subs[0]?.mangaId).toBe(MANGA_ID);
+    expect(subs[0]?.mangaTitle).toBe(MANGA_TITLE);
+    expect(subs[0]?.source).toBe(SOURCE);
     expect(subs[0]?.paused).toBe(false);
     expect(subs[0]?.lastSyncedAt).toBeNull();
   });
 
+  test("addedAt is set close to Date.now() and paused is false", () => {
+    const before = Date.now();
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const after = Date.now();
+    const [sub] = listSubscriptions(db);
+    expect(sub?.paused).toBe(false);
+    expect(sub?.addedAt).toBeGreaterThanOrEqual(before);
+    expect(sub?.addedAt).toBeLessThanOrEqual(after + 1000);
+  });
+
   test("duplicate insert is idempotent — no duplicate rows", () => {
-    addSubscription(db, BASE_SUB);
-    addSubscription(db, BASE_SUB);
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
     const subs = listSubscriptions(db);
     expect(subs).toHaveLength(1);
   });
 });
 
-describe("pauseSubscription / resumeSubscription", () => {
-  test("pause sets paused=true", () => {
-    addSubscription(db, BASE_SUB);
-    pauseSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
-    const [sub] = listSubscriptions(db);
-    expect(sub?.paused).toBe(true);
-  });
-
-  test("resume sets paused=false after pause", () => {
-    addSubscription(db, { ...BASE_SUB, paused: true });
-    resumeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
-    const [sub] = listSubscriptions(db);
-    expect(sub?.paused).toBe(false);
-  });
-});
-
-describe("markSynced", () => {
-  test("updates last_synced_at", () => {
-    addSubscription(db, BASE_SUB);
-    const syncedAt = 1_700_001_000_000;
-    markSynced(db, BASE_SUB.source, BASE_SUB.mangaId, syncedAt);
-    const [sub] = listSubscriptions(db);
-    expect(sub?.lastSyncedAt).toBe(syncedAt);
-  });
-});
-
 describe("removeSubscription", () => {
-  test("removes the subscription row", () => {
-    addSubscription(db, BASE_SUB);
-    removeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+  test("returns true when row existed", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const result = removeSubscription(db, { source: SOURCE, mangaId: MANGA_ID });
+    expect(result).toBe(true);
     expect(listSubscriptions(db)).toHaveLength(0);
   });
 
+  test("returns false when row does not exist", () => {
+    const result = removeSubscription(db, { source: SOURCE, mangaId: "nonexistent" });
+    expect(result).toBe(false);
+  });
+
   test("_migrations table is unaffected after remove", () => {
-    addSubscription(db, BASE_SUB);
-    removeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    removeSubscription(db, { source: SOURCE, mangaId: MANGA_ID });
     const rows = db.prepare("SELECT name FROM _migrations").all() as { name: string }[];
     expect(rows.length).toBeGreaterThan(0);
   });
 
   test("downloads table is unaffected after remove", () => {
-    // seed a download row so the table exists and has data
     db.prepare(
       `INSERT INTO downloads (manga_id, manga_title, volume, chapter_id, chapter_num, source, language, downloaded_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run("manga-uuid-1", "One Piece", "1", "ch-001", "1", "mangadex", "en", 1_700_000_000_000);
+    ).run(MANGA_ID, MANGA_TITLE, "1", "ch-001", "1", SOURCE, "en", 1_700_000_000_000);
 
-    addSubscription(db, BASE_SUB);
-    removeSubscription(db, BASE_SUB.source, BASE_SUB.mangaId);
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    removeSubscription(db, { source: SOURCE, mangaId: MANGA_ID });
 
     const rows = db.prepare("SELECT chapter_id FROM downloads").all() as { chapter_id: string }[];
     expect(rows).toHaveLength(1);
@@ -112,26 +96,108 @@ describe("removeSubscription", () => {
   });
 });
 
-describe("listSubscriptions with paused filter", () => {
+describe("setPaused", () => {
+  test("returns true when row was updated", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const result = setPaused(db, { source: SOURCE, mangaId: MANGA_ID, paused: true });
+    expect(result).toBe(true);
+  });
+
+  test("returns false when row does not exist", () => {
+    const result = setPaused(db, { source: SOURCE, mangaId: "nonexistent", paused: true });
+    expect(result).toBe(false);
+  });
+
+  test("toggles paused correctly from false to true", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    setPaused(db, { source: SOURCE, mangaId: MANGA_ID, paused: true });
+    // need includePaused to see it
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs[0]?.paused).toBe(true);
+  });
+
+  test("toggles paused correctly from true to false", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    setPaused(db, { source: SOURCE, mangaId: MANGA_ID, paused: true });
+    setPaused(db, { source: SOURCE, mangaId: MANGA_ID, paused: false });
+    const [sub] = listSubscriptions(db);
+    expect(sub?.paused).toBe(false);
+  });
+
+  test("preserves mangaTitle, addedAt, lastSyncedAt after setPaused", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const syncedAt = 1_700_001_000_000;
+    markSynced(db, { source: SOURCE, mangaId: MANGA_ID, at: syncedAt });
+
+    setPaused(db, { source: SOURCE, mangaId: MANGA_ID, paused: true });
+    const [sub] = listSubscriptions(db, { includePaused: true });
+
+    expect(sub?.mangaTitle).toBe(MANGA_TITLE);
+    expect(sub?.lastSyncedAt).toBe(syncedAt);
+    expect(typeof sub?.addedAt).toBe("number");
+  });
+});
+
+describe("markSynced", () => {
+  test("updates last_synced_at", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const syncedAt = 1_700_001_000_000;
+    markSynced(db, { source: SOURCE, mangaId: MANGA_ID, at: syncedAt });
+    const [sub] = listSubscriptions(db);
+    expect(sub?.lastSyncedAt).toBe(syncedAt);
+  });
+
+  test("does not change paused, mangaTitle, or addedAt", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const [before] = listSubscriptions(db);
+    const syncedAt = 1_700_001_000_000;
+    markSynced(db, { source: SOURCE, mangaId: MANGA_ID, at: syncedAt });
+    const [after] = listSubscriptions(db);
+    expect(after?.paused).toBe(false);
+    expect(after?.mangaTitle).toBe(MANGA_TITLE);
+    expect(after?.addedAt).toBe(before?.addedAt);
+    expect(after?.lastSyncedAt).toBe(syncedAt);
+  });
+});
+
+describe("refreshTitle", () => {
+  test("updates only manga_title", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const syncedAt = 1_700_001_000_000;
+    markSynced(db, { source: SOURCE, mangaId: MANGA_ID, at: syncedAt });
+    const [before] = listSubscriptions(db);
+
+    refreshTitle(db, { source: SOURCE, mangaId: MANGA_ID, title: "One Piece (Revised)" });
+    const [after] = listSubscriptions(db);
+
+    expect(after?.mangaTitle).toBe("One Piece (Revised)");
+    expect(after?.paused).toBe(before?.paused);
+    expect(after?.addedAt).toBe(before?.addedAt);
+    expect(after?.lastSyncedAt).toBe(syncedAt);
+  });
+});
+
+describe("listSubscriptions", () => {
   beforeEach(() => {
-    addSubscription(db, { ...BASE_SUB, mangaId: "manga-1", mangaTitle: "A", paused: false });
-    addSubscription(db, { ...BASE_SUB, mangaId: "manga-2", mangaTitle: "B", paused: true });
-    addSubscription(db, { ...BASE_SUB, mangaId: "manga-3", mangaTitle: "C", paused: false });
+    addSubscription(db, { source: SOURCE, mangaId: "manga-1", mangaTitle: "A" });
+    addSubscription(db, { source: SOURCE, mangaId: "manga-2", mangaTitle: "B" });
+    addSubscription(db, { source: SOURCE, mangaId: "manga-3", mangaTitle: "C" });
+    setPaused(db, { source: SOURCE, mangaId: "manga-2", paused: true });
   });
 
-  test("no filter returns all subscriptions", () => {
-    expect(listSubscriptions(db)).toHaveLength(3);
-  });
-
-  test("paused=true returns only paused", () => {
-    const subs = listSubscriptions(db, { paused: true });
-    expect(subs).toHaveLength(1);
-    expect(subs[0]?.mangaId).toBe("manga-2");
-  });
-
-  test("paused=false returns only active", () => {
-    const subs = listSubscriptions(db, { paused: false });
+  test("default returns only active (non-paused)", () => {
+    const subs = listSubscriptions(db);
     expect(subs).toHaveLength(2);
     expect(subs.every((s) => s.paused === false)).toBe(true);
+  });
+
+  test("includePaused: true returns all", () => {
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs).toHaveLength(3);
+  });
+
+  test("ordering by manga_title is stable", () => {
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs.map((s) => s.mangaTitle)).toEqual(["A", "B", "C"]);
   });
 });

--- a/src/modules/subscriptions/subscriptions.test.ts
+++ b/src/modules/subscriptions/subscriptions.test.ts
@@ -177,6 +177,69 @@ describe("refreshTitle", () => {
   });
 });
 
+describe("addSubscription idempotency — addedAt preserved", () => {
+  test("second insert does not change addedAt or mangaTitle", () => {
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: MANGA_TITLE });
+    const [first] = listSubscriptions(db);
+    addSubscription(db, { source: SOURCE, mangaId: MANGA_ID, mangaTitle: "Different Title" });
+    const [second] = listSubscriptions(db);
+    expect(second?.addedAt).toBe(first?.addedAt);
+    expect(second?.mangaTitle).toBe(MANGA_TITLE);
+  });
+});
+
+describe("markSynced on missing row", () => {
+  test("does not throw and does not create a row", () => {
+    expect(() =>
+      markSynced(db, { source: SOURCE, mangaId: "ghost-id", at: 1_700_000_000_000 }),
+    ).not.toThrow();
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs).toHaveLength(0);
+  });
+});
+
+describe("refreshTitle on missing row", () => {
+  test("does not throw and does not create a row", () => {
+    expect(() =>
+      refreshTitle(db, { source: SOURCE, mangaId: "ghost-id", title: "Phantom" }),
+    ).not.toThrow();
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs).toHaveLength(0);
+  });
+});
+
+describe("composite PK isolation", () => {
+  const OTHER_SOURCE = "mangakakalot";
+
+  test("same mangaId under two sources coexist", () => {
+    addSubscription(db, { source: SOURCE, mangaId: "x-1", mangaTitle: "Title A" });
+    addSubscription(db, { source: OTHER_SOURCE, mangaId: "x-1", mangaTitle: "Title B" });
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs).toHaveLength(2);
+  });
+
+  test("removeSubscription removes only the targeted source row", () => {
+    addSubscription(db, { source: SOURCE, mangaId: "x-1", mangaTitle: "Title A" });
+    addSubscription(db, { source: OTHER_SOURCE, mangaId: "x-1", mangaTitle: "Title B" });
+    removeSubscription(db, { source: SOURCE, mangaId: "x-1" });
+    const subs = listSubscriptions(db, { includePaused: true });
+    expect(subs).toHaveLength(1);
+    expect(subs[0]?.source).toBe(OTHER_SOURCE);
+    expect(subs[0]?.mangaTitle).toBe("Title B");
+  });
+
+  test("setPaused flips only the targeted source row", () => {
+    addSubscription(db, { source: SOURCE, mangaId: "x-1", mangaTitle: "Title A" });
+    addSubscription(db, { source: OTHER_SOURCE, mangaId: "x-1", mangaTitle: "Title B" });
+    setPaused(db, { source: SOURCE, mangaId: "x-1", paused: true });
+    const subs = listSubscriptions(db, { includePaused: true });
+    const mdex = subs.find((s) => s.source === SOURCE);
+    const mkal = subs.find((s) => s.source === OTHER_SOURCE);
+    expect(mdex?.paused).toBe(true);
+    expect(mkal?.paused).toBe(false);
+  });
+});
+
 describe("listSubscriptions", () => {
   beforeEach(() => {
     addSubscription(db, { source: SOURCE, mangaId: "manga-1", mangaTitle: "A" });

--- a/src/modules/subscriptions/types.ts
+++ b/src/modules/subscriptions/types.ts
@@ -9,14 +9,35 @@ export interface Subscription {
   lastSyncedAt: number | null;
 }
 
-export interface SubscriptionRow {
+export interface AddSubscriptionInput {
   source: string;
   mangaId: string;
   mangaTitle: string;
+}
+
+export interface RemoveSubscriptionInput {
+  source: string;
+  mangaId: string;
+}
+
+export interface SetPausedInput {
+  source: string;
+  mangaId: string;
   paused: boolean;
-  addedAt: number;
+}
+
+export interface MarkSyncedInput {
+  source: string;
+  mangaId: string;
+  at: number;
+}
+
+export interface RefreshTitleInput {
+  source: string;
+  mangaId: string;
+  title: string;
 }
 
 export interface ListSubscriptionsFilter {
-  paused?: boolean | undefined;
+  includePaused?: boolean;
 }


### PR DESCRIPTION
## What this PR does

- Reshapes the subscriptions module to the API shape defined in issue #11: every public function now takes `db` + a single options object (`{ source, mangaId, ... }`) — no more positional args.
- Replaces `pauseSubscription` / `resumeSubscription` with a single `setPaused(db, { source, mangaId, paused }): boolean`.
- Adds `refreshTitle(db, { source, mangaId, title }): void` (new — used by `sync` to propagate upstream renames after every successful run).
- Returns `boolean` from `removeSubscription` and `setPaused` (`true` when a row was affected).
- Narrows `addSubscription` input to `{ source, mangaId, mangaTitle }`. Internally sets `addedAt = Date.now()` and `paused = 0`. Idempotent via `INSERT OR IGNORE`.
- `listSubscriptions` default now returns active subscriptions only; pass `{ includePaused: true }` to include paused entries.

## Why it exists

`sync` (issue #17) and the subscription CLI commands (#18, #19) all read from the same module. The pre-existing scaffolding had positional args, no `refreshTitle`, and `void` returns where booleans were needed. Aligning the API now unblocks every downstream issue without breaking changes later.

Ref: #11

## How it works internally

- **Layering:** `service.ts` (public API) → `repository.ts` (raw SQL) → `bun:sqlite`. Pure functions, no classes.
- **`addSubscription`** uses `INSERT OR IGNORE` so a second insert with the same `(source, mangaId)` is a true no-op — preserves the original `addedAt` and `mangaTitle`. Test asserts both are unchanged after a duplicate insert with a different title.
- **`setPaused` / `removeSubscription`** read `info.changes` from the prepared statement to return `true` only when a row was actually affected.
- **`markSynced` / `refreshTitle`** have explicit column lists in the UPDATE — never `SET *`. Field-isolation tests assert the other fields stay intact.
- **`listSubscriptions`** filters via a `WHERE paused = 0` clause when `includePaused` is omitted/false; orders by `manga_title`.
- **Composite PK** `(source, manga_id)` lets the same `mangaId` exist under different `source` values. Test inserts the same id under `mangadex` and `mangakakalot` and confirms isolation across remove and `setPaused`.

Key files:
- `src/modules/subscriptions/types.ts` — adds `AddSubscriptionInput`, `RemoveSubscriptionInput`, `SetPausedInput`, `MarkSyncedInput`, `RefreshTitleInput`. Drops `SubscriptionRow`. `ListSubscriptionsFilter` is now `{ includePaused?: boolean }`.
- `src/modules/subscriptions/repository.ts` — prepared statements only (`?` placeholders), no string concatenation.
- `src/modules/subscriptions/service.ts` — thin wrappers; `addSubscription` is the only caller of `Date.now()`.
- `src/modules/subscriptions/index.ts` — public re-exports.
- `src/modules/subscriptions/subscriptions.test.ts` — 18 test cases.

## What did not change

- Schema and migration (`migrations/002_create_subscriptions.sql`) — untouched.
- `_migrations` bookkeeping table.
- `downloads` table and history module.
- The "subscription removed but history preserved" invariant — preserved with its original test.

## Test checklist

- [x] `addSubscription` is idempotent and preserves original `addedAt` / `mangaTitle` on duplicate insert
- [x] `removeSubscription` returns `true` on hit, `false` on miss
- [x] `setPaused` returns `true` when row updated, toggles correctly, preserves other fields
- [x] `markSynced` writes only `last_synced_at` (asserted: `mangaTitle`, `paused`, `addedAt` unchanged)
- [x] `refreshTitle` writes only `manga_title` (asserted: other fields unchanged)
- [x] `listSubscriptions` default = active only; `includePaused: true` returns all; ordered by `manga_title`
- [x] `markSynced` / `refreshTitle` on missing rows: silent no-op, no phantom rows
- [x] Composite PK isolation: same `mangaId` under two `source` values coexist; remove/setPaused affect only the targeted source
- [x] Downloads table is untouched after `removeSubscription`
- [x] `bun test` — 177 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- Inspector flagged `querySubscriptions` keeping a dead `params: (string | number)[]` array (only `paused = 0` is hardcoded into the WHERE clause — no params are pushed). Kept as-is to leave the param-builder shape in place for the next filter (e.g., `source`, `search`) that #18/#19 will likely add. If you'd rather drop it, happy to in this PR.
- `addSubscription` calls `Date.now()` directly rather than accepting `addedAt` from the caller. Considered making it injectable for symmetry with `markSynced.at`, but the current contract (`{ source, mangaId, mangaTitle }`) matches the issue spec verbatim and tests assert the bracket. Open to changing if you want clock injection.
- `addSubscription` returns `void`, so callers can't tell "inserted" vs. "already existed". Issue spec mandates `: void`. If `watch` (CLI) needs to print "added" vs. "already watching", we can add `existsSubscription` later or change the return type — flag here for visibility.

## Closes

Ref: #11

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (not applicable — schema and contract already documented in `docs/models/subscription_model.md` and `docs/adr/004-subscriptions-in-sqlite.md`; this PR aligns the JS API with those docs)