### PR TITLE
fix(list): use readableAt instead of publishAt for chapter date

### DIFF
--- a/src/commands/list/formatter.ts
+++ b/src/commands/list/formatter.ts
@@ -112,7 +112,7 @@ export function formatChapterDetail(
   }
   lines.push(`Language:  ${chapter.translatedLanguage}`);
   lines.push(`Group:     ${chapter.scanlationGroup ?? "—"}`);
-  lines.push(`Published: ${chapter.publishAt.slice(0, 10)}`);
+  lines.push(`Published: ${chapter.readableAt.slice(0, 10)}`);
   return lines.join("\n");
 }
 

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -36,7 +36,7 @@ const chapters: ChapterRef[] = [
     title: "Romance Dawn",
     translatedLanguage: "en",
     scanlationGroup: "TCB Scans",
-    publishAt: "1997-07-22T00:00:00+00:00",
+    readableAt: "1997-07-22T00:00:00+00:00",
   },
   {
     id: "ch-002",
@@ -45,7 +45,7 @@ const chapters: ChapterRef[] = [
     title: "They Call Him",
     translatedLanguage: "en",
     scanlationGroup: "TCB Scans",
-    publishAt: "1997-07-29T00:00:00+00:00",
+    readableAt: "1997-07-29T00:00:00+00:00",
   },
   {
     id: "ch-003",
@@ -54,7 +54,7 @@ const chapters: ChapterRef[] = [
     title: "Morgan versus Luffy",
     translatedLanguage: "en",
     scanlationGroup: "TCB Scans",
-    publishAt: "1997-08-05T00:00:00+00:00",
+    readableAt: "1997-08-05T00:00:00+00:00",
   },
   {
     id: "ch-009",
@@ -63,7 +63,7 @@ const chapters: ChapterRef[] = [
     title: "Versus Cabaji!!",
     translatedLanguage: "en",
     scanlationGroup: "Manga Plus",
-    publishAt: "1997-10-14T00:00:00+00:00",
+    readableAt: "1997-10-14T00:00:00+00:00",
   },
   {
     id: "ch-010",
@@ -72,7 +72,7 @@ const chapters: ChapterRef[] = [
     title: "Incident at the Bar",
     translatedLanguage: "en",
     scanlationGroup: "Manga Plus",
-    publishAt: "1997-10-21T00:00:00+00:00",
+    readableAt: "1997-10-21T00:00:00+00:00",
   },
 ];
 
@@ -137,7 +137,7 @@ const ch0 = chapters[0] ?? {
   title: null,
   translatedLanguage: "en",
   scanlationGroup: null,
-  publishAt: "",
+  readableAt: "",
 };
 
 describe("formatChapterDetail", () => {

--- a/src/integrations/mangadex/client/mocks/chapter-feed.json
+++ b/src/integrations/mangadex/client/mocks/chapter-feed.json
@@ -10,7 +10,7 @@
         "chapter": "1",
         "title": "Prologue",
         "translatedLanguage": "en",
-        "publishAt": "2021-01-01T00:00:00+00:00"
+        "readableAt": "2021-01-01T00:00:00+00:00"
       },
       "relationships": [
         {
@@ -30,7 +30,7 @@
         "chapter": null,
         "title": "Oneshot",
         "translatedLanguage": "pt-br",
-        "publishAt": "2021-02-01T00:00:00+00:00"
+        "readableAt": "2021-02-01T00:00:00+00:00"
       },
       "relationships": []
     }

--- a/src/integrations/mangadex/client/parser.ts
+++ b/src/integrations/mangadex/client/parser.ts
@@ -76,7 +76,7 @@ export function parseChapterFeed(raw: MdxChapterListResponse): ChapterRef[] {
       title: item.attributes.title,
       translatedLanguage: normalizeLang(item.attributes.translatedLanguage),
       scanlationGroup: typeof scanlationGroup === "string" ? scanlationGroup : null,
-      publishAt: item.attributes.publishAt,
+      readableAt: item.attributes.readableAt,
     };
   });
 }

--- a/src/integrations/mangadex/client/types.ts
+++ b/src/integrations/mangadex/client/types.ts
@@ -21,7 +21,7 @@ export interface ChapterRef {
   title: string | null;
   translatedLanguage: string;
   scanlationGroup: string | null;
-  publishAt: string;
+  readableAt: string;
 }
 
 // --- MangaDex REST response shapes ---
@@ -79,7 +79,7 @@ export interface MdxChapterAttributes {
   chapter: string | null;
   title: string | null;
   translatedLanguage: string;
-  publishAt: string;
+  readableAt: string;
 }
 
 export interface MdxChapterData {


### PR DESCRIPTION
## What this PR does

Pure rename: `publishAt` → `readableAt` across the MangaDex client and the `list` command. No new fields, no behavior change, no new tests beyond fixture updates.

## Why it exists

`scanldr list <manga> --chapter <n>` was rendering `Published: 2037-12-31` for any chapter served by an official partner (MangaPlus, Comikey, …). The placeholder comes from MangaDex's `attributes.publishAt`, which for partner-served chapters is a far-future date marking when the chapter would become "free". The actual release date lives in `attributes.readableAt`.

Verified against the live API:

| chapter | publishAt | readableAt |
|---|---|---|
| Kagurabachi ch.1 | `2037-12-31T15:00:00+00:00` | `2023-09-18T01:00:27+00:00` |
| Kagurabachi ch.2 | `2037-12-31T15:00:00+00:00` | `2023-09-24T15:10:04+00:00` |
| Kagurabachi ch.3 | `2037-12-31T15:00:00+00:00` | `2023-10-01T15:08:34+00:00` |

Ref: #47

## How it works internally

Strict rename in 5 files (+12/-12):

- `src/integrations/mangadex/client/types.ts` — `MdxChapterAttributes.readableAt: string` and `ChapterRef.readableAt: string` (both non-optional).
- `src/integrations/mangadex/client/parser.ts` — `parseChapterFeed` reads `item.attributes.readableAt`.
- `src/integrations/mangadex/client/mocks/chapter-feed.json` — fixture attribute key updated.
- `src/commands/list/formatter.ts:115` — `formatChapterDetail` reads `chapter.readableAt.slice(0, 10)`.
- `src/commands/list/list.test.ts` — five `ChapterRef` fixtures + the `ch0` fallback all carry `readableAt`.

The `formatChapterDetail` test still asserts `Published: 1997-07-22`, exercising the new field end-to-end.

## What did not change

- Public CLI surface — the user-visible label is still `Published:`. (Inspector flagged the label as a P3 follow-up: now that the source field is "release-to-readers", the label is technically a slight misnomer. Out of scope for this rename.)
- `attributes.createdAt` is left untouched — `readableAt` is the right field for "when can the user read this".
- No defensive null-guard was added in `formatChapterDetail`. The type is `string` (non-optional), and MangaDex always returns `readableAt` per the API contract.
- No drive-by refactors, no dead code, no commented-out blocks.

## Test checklist

- [x] `grep -rn "publishAt" src/ docs/` → no matches
- [x] `formatChapterDetail` test renders the date from `readableAt`
- [x] Parser fixture uses `readableAt`
- [x] `bun test` — 188 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- This is a strict rename. If you'd prefer to also rename the user-visible label `Published:` → `Released:` (or similar) to match the new semantics, happy to do it here — flag in review.
- A previous QA pass during the agent pipeline mistakenly read a stale worktree from issue #40 and reported the rename "not applied"; verified directly against `fix/47-readable-at` HEAD that the rename is complete.

## Closes

Ref: #47

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (not applicable — no doc references the old field name; `docs/models/manga_model.md` documents the SQLite schema, not the MangaDex API shape)