### PR TITLE
feat(mangadex): handle external chapters gracefully

### DIFF
--- a/docs/adr/002-mangadex-primary-source.md
+++ b/docs/adr/002-mangadex-primary-source.md
@@ -62,3 +62,18 @@ When MangaDex has the volume metadata but the user prefers to download from a fa
 - Two-source architecture adds complexity (MangaDex client + fallback clients).
 - For titles not on MangaDex, the user must pass `--chapter` manually if volume metadata is also unavailable from the fallback site.
 - MangaDex API rate limits apply (~5 req/s). The downloader must respect them.
+
+## Partner-Hosted vs. CDN-Hosted Chapters
+
+MangaDex distinguishes two categories of chapters:
+
+- **CDN-hosted** — images served via MangaDex's own at-home CDN network. `attributes.externalUrl` is `null`. These chapters are fully downloadable through `/at-home/server/:chapterId`.
+- **Partner-hosted** — images live on a publisher's platform (MangaPlus, Comikey, Cubari, etc.). `attributes.externalUrl` is set to the partner URL. The `/at-home/server/:chapterId` endpoint returns HTTP 404 for these chapters.
+
+Most ongoing weekly Shueisha titles (One Piece, Jujutsu Kaisen, Kagurabachi, etc.) are partner-hosted via MangaPlus.
+
+**scanldr behaviour per command:**
+- `list` — annotates external chapters with `[external: <host>]` so the user knows at a glance.
+- `download` — refuses early with a typed `ExternalChapterError` carrying the URL (implemented in #14/#15).
+- `sync` / `update` — skips external chapters with an `info` log (implemented in #16/#17).
+- `getAtHomeServer` — throws a typed `AtHomeError` with a 404-specific message hinting at external hosting, even if the caller forgets the upstream check.

--- a/src/commands/list/formatter.ts
+++ b/src/commands/list/formatter.ts
@@ -6,10 +6,15 @@ import type { ChapterRef, MangaCandidate, VolumeRef } from "./types.ts";
  * Returns a short human-readable label for an external chapter URL.
  * e.g. "https://mangaplus.shueisha.co.jp/..." → "mangaplus"
  *      "https://comikey.com/..." → "comikey"
+ * Returns empty string when the URL cannot be parsed (malformed / no scheme).
  */
 export function formatExternalTag(url: string): string {
-  const host = new URL(url).hostname;
-  return host.split(".")[0] ?? host;
+  try {
+    const host = new URL(url).hostname;
+    return host.split(".")[0] ?? host;
+  } catch {
+    return "";
+  }
 }
 
 /** Format full manga listing (all volumes). */
@@ -60,8 +65,8 @@ export function formatMangaList(
     for (const ch of volChapters) {
       const num = ch.chapter ?? "?";
       const title = ch.title ? ` — ${ch.title}` : "";
-      const ext =
-        ch.externalUrl !== null ? ` [external: ${formatExternalTag(ch.externalUrl)}]` : "";
+      const extTag = ch.externalUrl !== null ? formatExternalTag(ch.externalUrl) : null;
+      const ext = extTag === null ? "" : extTag ? ` [external: ${extTag}]` : " [external]";
       lines.push(`  Chapter ${num}${title}${ext}`);
     }
 
@@ -102,7 +107,8 @@ export function formatVolumeList(
   for (const ch of sorted) {
     const num = ch.chapter ?? "?";
     const title = ch.title ? ` — ${ch.title}` : "";
-    const ext = ch.externalUrl !== null ? ` [external: ${formatExternalTag(ch.externalUrl)}]` : "";
+    const extTag = ch.externalUrl !== null ? formatExternalTag(ch.externalUrl) : null;
+    const ext = extTag === null ? "" : extTag ? ` [external: ${extTag}]` : " [external]";
     lines.push(`  Chapter ${num}${title}${ext}`);
   }
 

--- a/src/commands/list/formatter.ts
+++ b/src/commands/list/formatter.ts
@@ -3,18 +3,29 @@
 import type { ChapterRef, MangaCandidate, VolumeRef } from "./types.ts";
 
 /**
- * Returns a short human-readable label for an external chapter URL.
- * e.g. "https://mangaplus.shueisha.co.jp/..." → "mangaplus"
- *      "https://comikey.com/..." → "comikey"
- * Returns empty string when the URL cannot be parsed (malformed / no scheme).
+ * Parses the hostname from a URL and returns the first label (e.g. "mangaplus").
+ * Returns `null` when the URL is malformed so callers can distinguish "bad URL"
+ * from "valid URL with no useful label" (empty host), instead of silently swallowing
+ * the parse error.
  */
-export function formatExternalTag(url: string): string {
+export function parseExternalHost(url: string): string | null {
   try {
     const host = new URL(url).hostname;
     return host.split(".")[0] ?? host;
   } catch {
-    return "";
+    return null;
   }
+}
+
+/**
+ * Returns a short human-readable label for an external chapter URL.
+ * e.g. "https://mangaplus.shueisha.co.jp/..." → "mangaplus"
+ *      "https://comikey.com/..." → "comikey"
+ * Returns empty string when the URL cannot be parsed (malformed / no scheme).
+ * @deprecated prefer parseExternalHost which returns null for malformed URLs.
+ */
+export function formatExternalTag(url: string): string {
+  return parseExternalHost(url) ?? "";
 }
 
 /** Format full manga listing (all volumes). */

--- a/src/commands/list/formatter.ts
+++ b/src/commands/list/formatter.ts
@@ -17,17 +17,6 @@ export function parseExternalHost(url: string): string | null {
   }
 }
 
-/**
- * Returns a short human-readable label for an external chapter URL.
- * e.g. "https://mangaplus.shueisha.co.jp/..." → "mangaplus"
- *      "https://comikey.com/..." → "comikey"
- * Returns empty string when the URL cannot be parsed (malformed / no scheme).
- * @deprecated prefer parseExternalHost which returns null for malformed URLs.
- */
-export function formatExternalTag(url: string): string {
-  return parseExternalHost(url) ?? "";
-}
-
 /** Format full manga listing (all volumes). */
 export function formatMangaList(
   candidate: MangaCandidate,
@@ -76,8 +65,8 @@ export function formatMangaList(
     for (const ch of volChapters) {
       const num = ch.chapter ?? "?";
       const title = ch.title ? ` — ${ch.title}` : "";
-      const extTag = ch.externalUrl !== null ? formatExternalTag(ch.externalUrl) : null;
-      const ext = extTag === null ? "" : extTag ? ` [external: ${extTag}]` : " [external]";
+      const extTag = ch.externalUrl !== null ? parseExternalHost(ch.externalUrl) : undefined;
+      const ext = extTag === undefined ? "" : extTag ? ` [external: ${extTag}]` : " [external]";
       lines.push(`  Chapter ${num}${title}${ext}`);
     }
 
@@ -118,8 +107,8 @@ export function formatVolumeList(
   for (const ch of sorted) {
     const num = ch.chapter ?? "?";
     const title = ch.title ? ` — ${ch.title}` : "";
-    const extTag = ch.externalUrl !== null ? formatExternalTag(ch.externalUrl) : null;
-    const ext = extTag === null ? "" : extTag ? ` [external: ${extTag}]` : " [external]";
+    const extTag = ch.externalUrl !== null ? parseExternalHost(ch.externalUrl) : undefined;
+    const ext = extTag === undefined ? "" : extTag ? ` [external: ${extTag}]` : " [external]";
     lines.push(`  Chapter ${num}${title}${ext}`);
   }
 

--- a/src/commands/list/formatter.ts
+++ b/src/commands/list/formatter.ts
@@ -2,6 +2,16 @@
 
 import type { ChapterRef, MangaCandidate, VolumeRef } from "./types.ts";
 
+/**
+ * Returns a short human-readable label for an external chapter URL.
+ * e.g. "https://mangaplus.shueisha.co.jp/..." → "mangaplus"
+ *      "https://comikey.com/..." → "comikey"
+ */
+export function formatExternalTag(url: string): string {
+  const host = new URL(url).hostname;
+  return host.split(".")[0] ?? host;
+}
+
 /** Format full manga listing (all volumes). */
 export function formatMangaList(
   candidate: MangaCandidate,
@@ -50,7 +60,9 @@ export function formatMangaList(
     for (const ch of volChapters) {
       const num = ch.chapter ?? "?";
       const title = ch.title ? ` — ${ch.title}` : "";
-      lines.push(`  Chapter ${num}${title}`);
+      const ext =
+        ch.externalUrl !== null ? ` [external: ${formatExternalTag(ch.externalUrl)}]` : "";
+      lines.push(`  Chapter ${num}${title}${ext}`);
     }
 
     lines.push("");
@@ -90,7 +102,8 @@ export function formatVolumeList(
   for (const ch of sorted) {
     const num = ch.chapter ?? "?";
     const title = ch.title ? ` — ${ch.title}` : "";
-    lines.push(`  Chapter ${num}${title}`);
+    const ext = ch.externalUrl !== null ? ` [external: ${formatExternalTag(ch.externalUrl)}]` : "";
+    lines.push(`  Chapter ${num}${title}${ext}`);
   }
 
   return lines.join("\n");
@@ -112,6 +125,9 @@ export function formatChapterDetail(
   }
   lines.push(`Language:  ${chapter.translatedLanguage}`);
   lines.push(`Group:     ${chapter.scanlationGroup ?? "—"}`);
+  if (chapter.externalUrl !== null) {
+    lines.push(`External:  ${chapter.externalUrl}`);
+  }
   lines.push(`Published: ${chapter.readableAt.slice(0, 10)}`);
   return lines.join("\n");
 }

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -5,6 +5,7 @@ import {
   formatExternalTag,
   formatMangaList,
   formatVolumeList,
+  parseExternalHost,
 } from "./formatter.ts";
 import { runList } from "./index.ts";
 import type {
@@ -297,6 +298,30 @@ describe("formatExternalTag", () => {
 
   it("returns empty string for non-URL string", () => {
     expect(formatExternalTag("not a url at all")).toBe("");
+  });
+});
+
+// --- parseExternalHost tests ---
+
+describe("parseExternalHost", () => {
+  it("returns 'mangaplus' for mangaplus.shueisha.co.jp", () => {
+    expect(parseExternalHost("https://mangaplus.shueisha.co.jp/viewer/1010633")).toBe("mangaplus");
+  });
+
+  it("returns 'comikey' for comikey.com", () => {
+    expect(parseExternalHost("https://comikey.com/read/example/1")).toBe("comikey");
+  });
+
+  it("returns null for malformed URL (no scheme)", () => {
+    expect(parseExternalHost("mangaplus")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseExternalHost("")).toBeNull();
+  });
+
+  it("returns null for non-URL string", () => {
+    expect(parseExternalHost("not a url at all")).toBeNull();
   });
 });
 

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   formatCandidateList,
   formatChapterDetail,
+  formatExternalTag,
   formatMangaList,
   formatVolumeList,
 } from "./formatter.ts";
@@ -37,6 +38,7 @@ const chapters: ChapterRef[] = [
     translatedLanguage: "en",
     scanlationGroup: "TCB Scans",
     readableAt: "1997-07-22T00:00:00+00:00",
+    externalUrl: null,
   },
   {
     id: "ch-002",
@@ -46,6 +48,7 @@ const chapters: ChapterRef[] = [
     translatedLanguage: "en",
     scanlationGroup: "TCB Scans",
     readableAt: "1997-07-29T00:00:00+00:00",
+    externalUrl: null,
   },
   {
     id: "ch-003",
@@ -55,6 +58,7 @@ const chapters: ChapterRef[] = [
     translatedLanguage: "en",
     scanlationGroup: "TCB Scans",
     readableAt: "1997-08-05T00:00:00+00:00",
+    externalUrl: "https://mangaplus.shueisha.co.jp/viewer/1000001",
   },
   {
     id: "ch-009",
@@ -64,6 +68,7 @@ const chapters: ChapterRef[] = [
     translatedLanguage: "en",
     scanlationGroup: "Manga Plus",
     readableAt: "1997-10-14T00:00:00+00:00",
+    externalUrl: null,
   },
   {
     id: "ch-010",
@@ -73,6 +78,7 @@ const chapters: ChapterRef[] = [
     translatedLanguage: "en",
     scanlationGroup: "Manga Plus",
     readableAt: "1997-10-21T00:00:00+00:00",
+    externalUrl: "https://comikey.com/read/example/1",
   },
 ];
 
@@ -138,6 +144,7 @@ const ch0 = chapters[0] ?? {
   translatedLanguage: "en",
   scanlationGroup: null,
   readableAt: "",
+  externalUrl: null,
 };
 
 describe("formatChapterDetail", () => {
@@ -262,5 +269,66 @@ describe("runList", () => {
     await expect(
       runList({ manga: "One Piece", chapter: "999", nonTty: true }, ctx, makeClient()),
     ).rejects.toThrow("Chapter 999 not found");
+  });
+});
+
+// --- formatExternalTag tests ---
+
+describe("formatExternalTag", () => {
+  it("returns 'mangaplus' for mangaplus.shueisha.co.jp", () => {
+    expect(formatExternalTag("https://mangaplus.shueisha.co.jp/viewer/1010633")).toBe("mangaplus");
+  });
+
+  it("returns 'comikey' for comikey.com", () => {
+    expect(formatExternalTag("https://comikey.com/read/example/1")).toBe("comikey");
+  });
+
+  it("returns first subdomain segment for arbitrary URLs", () => {
+    expect(formatExternalTag("https://cubari.moe/read/imgur/xyz")).toBe("cubari");
+  });
+});
+
+// --- external chapter annotation tests ---
+
+describe("formatMangaList — external annotation", () => {
+  it("appends [external: mangaplus] for external chapters", () => {
+    const out = formatMangaList(candidate, volumes, chapters);
+    expect(out).toContain("[external: mangaplus]");
+  });
+
+  it("does NOT append external tag for CDN chapters", () => {
+    const out = formatMangaList(candidate, volumes, chapters);
+    // ch-001 (Romance Dawn) is CDN — must not have external tag
+    expect(out).toContain("Chapter 1 — Romance Dawn\n");
+  });
+});
+
+describe("formatVolumeList — external annotation", () => {
+  it("appends [external: mangaplus] for external chapters", () => {
+    const vol1Chapters = chapters.filter((c) => c.volume === "1");
+    const out = formatVolumeList(candidate, "1", vol1Chapters);
+    expect(out).toContain("[external: mangaplus]");
+  });
+
+  it("does NOT append tag for CDN chapters", () => {
+    const vol1Chapters = chapters.filter((c) => c.volume === "1");
+    const out = formatVolumeList(candidate, "1", vol1Chapters);
+    expect(out).toContain("Chapter 1 — Romance Dawn\n");
+  });
+});
+
+describe("formatChapterDetail — external annotation", () => {
+  it("includes External: line when externalUrl is set", () => {
+    const externalChapter = chapters[2]; // ch-003 with mangaplus URL
+    if (!externalChapter) throw new Error("fixture missing");
+    const out = formatChapterDetail(candidate, externalChapter);
+    expect(out).toContain("External:  https://mangaplus.shueisha.co.jp/viewer/1000001");
+  });
+
+  it("does NOT include External: line when externalUrl is null", () => {
+    const cdnChapter = chapters[0]; // ch-001 with null externalUrl
+    if (!cdnChapter) throw new Error("fixture missing");
+    const out = formatChapterDetail(candidate, cdnChapter);
+    expect(out).not.toContain("External:");
   });
 });

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -286,6 +286,18 @@ describe("formatExternalTag", () => {
   it("returns first subdomain segment for arbitrary URLs", () => {
     expect(formatExternalTag("https://cubari.moe/read/imgur/xyz")).toBe("cubari");
   });
+
+  it("returns empty string for URL without scheme (e.g. 'mangaplus')", () => {
+    expect(formatExternalTag("mangaplus")).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(formatExternalTag("")).toBe("");
+  });
+
+  it("returns empty string for non-URL string", () => {
+    expect(formatExternalTag("not a url at all")).toBe("");
+  });
 });
 
 // --- external chapter annotation tests ---
@@ -314,6 +326,28 @@ describe("formatVolumeList — external annotation", () => {
     const vol1Chapters = chapters.filter((c) => c.volume === "1");
     const out = formatVolumeList(candidate, "1", vol1Chapters);
     expect(out).toContain("Chapter 1 — Romance Dawn\n");
+  });
+});
+
+describe("formatMangaList — malformed externalUrl", () => {
+  it("renders [external] (no host) and does not crash when externalUrl has no scheme", () => {
+    const malformedChapter: ChapterRef = {
+      id: "ch-bad",
+      volume: "1",
+      chapter: "5",
+      title: null,
+      translatedLanguage: "en",
+      scanlationGroup: null,
+      readableAt: "2020-01-01T00:00:00+00:00",
+      externalUrl: "mangaplus",
+    };
+    const out = formatMangaList(
+      candidate,
+      [{ volume: "1", numeric: 1, chapterIds: ["ch-bad"] }],
+      [malformedChapter],
+    );
+    expect(out).toContain("[external]");
+    expect(out).not.toContain("[external: ]");
   });
 });
 

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "bun:test";
 import {
   formatCandidateList,
   formatChapterDetail,
-  formatExternalTag,
   formatMangaList,
   formatVolumeList,
   parseExternalHost,
@@ -270,34 +269,6 @@ describe("runList", () => {
     await expect(
       runList({ manga: "One Piece", chapter: "999", nonTty: true }, ctx, makeClient()),
     ).rejects.toThrow("Chapter 999 not found");
-  });
-});
-
-// --- formatExternalTag tests ---
-
-describe("formatExternalTag", () => {
-  it("returns 'mangaplus' for mangaplus.shueisha.co.jp", () => {
-    expect(formatExternalTag("https://mangaplus.shueisha.co.jp/viewer/1010633")).toBe("mangaplus");
-  });
-
-  it("returns 'comikey' for comikey.com", () => {
-    expect(formatExternalTag("https://comikey.com/read/example/1")).toBe("comikey");
-  });
-
-  it("returns first subdomain segment for arbitrary URLs", () => {
-    expect(formatExternalTag("https://cubari.moe/read/imgur/xyz")).toBe("cubari");
-  });
-
-  it("returns empty string for URL without scheme (e.g. 'mangaplus')", () => {
-    expect(formatExternalTag("mangaplus")).toBe("");
-  });
-
-  it("returns empty string for empty string", () => {
-    expect(formatExternalTag("")).toBe("");
-  });
-
-  it("returns empty string for non-URL string", () => {
-    expect(formatExternalTag("not a url at all")).toBe("");
   });
 });
 

--- a/src/commands/list/list.test.ts
+++ b/src/commands/list/list.test.ts
@@ -15,8 +15,6 @@ import type {
   VolumeRef,
 } from "./types.ts";
 
-// --- Fixtures ---
-
 const candidate: MangaCandidate = {
   id: "a1c7c817-4e59-43b7-9365-09675a149a6f",
   title: "One Piece",
@@ -90,8 +88,6 @@ const ctx: ListContext = {
   },
   languages: ["en"],
 };
-
-// --- formatter tests ---
 
 describe("formatMangaList", () => {
   it("includes manga title and id", () => {
@@ -173,8 +169,6 @@ describe("formatCandidateList", () => {
     expect(out).toContain("[1] One Piece");
   });
 });
-
-// --- runList tests ---
 
 function makeClient(overrides: Partial<MangaDexClientLike> = {}): MangaDexClientLike {
   return {
@@ -272,8 +266,6 @@ describe("runList", () => {
   });
 });
 
-// --- parseExternalHost tests ---
-
 describe("parseExternalHost", () => {
   it("returns 'mangaplus' for mangaplus.shueisha.co.jp", () => {
     expect(parseExternalHost("https://mangaplus.shueisha.co.jp/viewer/1010633")).toBe("mangaplus");
@@ -296,8 +288,6 @@ describe("parseExternalHost", () => {
   });
 });
 
-// --- external chapter annotation tests ---
-
 describe("formatMangaList — external annotation", () => {
   it("appends [external: mangaplus] for external chapters", () => {
     const out = formatMangaList(candidate, volumes, chapters);
@@ -306,7 +296,6 @@ describe("formatMangaList — external annotation", () => {
 
   it("does NOT append external tag for CDN chapters", () => {
     const out = formatMangaList(candidate, volumes, chapters);
-    // ch-001 (Romance Dawn) is CDN — must not have external tag
     expect(out).toContain("Chapter 1 — Romance Dawn\n");
   });
 });

--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -43,8 +43,6 @@ function makeImageResponse(opts: {
   } as unknown as Response;
 }
 
-// ---------- getAtHomeServer ----------
-
 describe("getAtHomeServer", () => {
   it("returns baseUrl, hash, and data pages for quality=data", async () => {
     const client = makeHttpClient();
@@ -135,8 +133,6 @@ describe("getAtHomeServer", () => {
   });
 });
 
-// ---------- mangadexImageFetcher — success path ----------
-
 describe("mangadexImageFetcher — success path", () => {
   it("returns image bytes on first attempt", async () => {
     const imageBytes = new Uint8Array([10, 20, 30]);
@@ -184,8 +180,6 @@ describe("mangadexImageFetcher — success path", () => {
   });
 });
 
-// ---------- stale CDN retry ----------
-
 describe("mangadexImageFetcher — stale CDN retry", () => {
   it("re-fetches /at-home/server on every failure before retrying", async () => {
     let atHomeCallCount = 0;
@@ -223,8 +217,6 @@ describe("mangadexImageFetcher — stale CDN retry", () => {
   });
 });
 
-// ---------- all 5 attempts fail ----------
-
 describe("mangadexImageFetcher — all attempts fail", () => {
   it("throws after 5 attempts", async () => {
     let imageFetchCount = 0;
@@ -247,8 +239,6 @@ describe("mangadexImageFetcher — all attempts fail", () => {
   });
 });
 
-// ---------- at-home refresh fails during retry ----------
-
 describe("mangadexImageFetcher — refresh failure during retry", () => {
   it("throws AtHomeError immediately when refresh call throws AtHomeError(404)", async () => {
     let atHomeCallCount = 0;
@@ -256,20 +246,17 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
       get: async <T>(_path: string) => {
         atHomeCallCount++;
         if (atHomeCallCount === 1) {
-          // first call (initial server fetch) succeeds
           return {
             baseUrl: "https://cdn.example.com",
             chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
           } as T;
         }
-        // refresh after first failure: simulate chapter deleted → 404
         throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
       },
     });
 
     const mockFetch = mock(async (url: string) => {
       if (url === "https://api.mangadex.network/report") return new Response(null, { status: 200 });
-      // image fetch always fails to trigger the refresh path
       return makeImageResponse({ ok: false, status: 503 });
     });
 
@@ -316,7 +303,6 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
     const fetcher = mangadexImageFetcher("ch-net", opts);
     const err = await fetcher({ url: "", page: 1 }).catch((e) => e);
     expect(err).toBeInstanceOf(Error);
-    // Must surface the refresh error, not "Failed to fetch image page X after 5 attempts"
     expect((err as Error).message).toBe("network timeout on refresh");
   });
 
@@ -403,8 +389,6 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
     expect((refreshFailLog?.err as Error).message).toBe(expectedErr.message);
   });
 });
-
-// ---------- report HTTP failure tolerated ----------
 
 describe("mangadexImageFetcher — report failure tolerated", () => {
   it("does not throw when the report POST fails", async () => {

--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
-import { getAtHomeServer, mangadexImageFetcher } from "./index.ts";
+import { AtHomeError, getAtHomeServer, mangadexImageFetcher } from "./index.ts";
 import type { AtHomeOptions } from "./types.ts";
 
 const noopLogger: Logger = {
@@ -58,6 +58,43 @@ describe("getAtHomeServer", () => {
     const client = makeHttpClient();
     const result = await getAtHomeServer(client, "ch-001", "data-saver");
     expect(result.pages).toEqual(["page1-saver.jpg", "page2-saver.jpg"]);
+  });
+
+  it("throws AtHomeError with status 404 and external hint when http layer returns 404", async () => {
+    const client = makeHttpClient({
+      get: async () => {
+        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext");
+      },
+    });
+    const err = await getAtHomeServer(client, "ch-ext", "data").catch((e) => e);
+    expect(err).toBeInstanceOf(AtHomeError);
+    expect((err as AtHomeError).status).toBe(404);
+    expect((err as AtHomeError).chapterId).toBe("ch-ext");
+    expect((err as AtHomeError).message).toContain("externally-hosted");
+  });
+
+  it("throws AtHomeError with correct status for non-404 HTTP errors", async () => {
+    const client = makeHttpClient({
+      get: async () => {
+        throw new Error("MangaDex HTTP 403: https://api.mangadex.org/at-home/server/ch-403");
+      },
+    });
+    const err = await getAtHomeServer(client, "ch-403", "data").catch((e) => e);
+    expect(err).toBeInstanceOf(AtHomeError);
+    expect((err as AtHomeError).status).toBe(403);
+    expect((err as AtHomeError).message).toContain("403");
+  });
+
+  it("re-throws non-HTTP errors as-is", async () => {
+    const client = makeHttpClient({
+      get: async () => {
+        throw new Error("network failure");
+      },
+    });
+    const err = await getAtHomeServer(client, "ch-net", "data").catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(AtHomeError);
+    expect((err as Error).message).toBe("network failure");
   });
 });
 

--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -210,6 +210,80 @@ describe("mangadexImageFetcher — all attempts fail", () => {
   });
 });
 
+// ---------- at-home refresh fails during retry ----------
+
+describe("mangadexImageFetcher — refresh failure during retry", () => {
+  it("throws AtHomeError immediately when refresh call throws AtHomeError(404)", async () => {
+    let atHomeCallCount = 0;
+    const httpClient = makeHttpClient({
+      get: async <T>(_path: string) => {
+        atHomeCallCount++;
+        if (atHomeCallCount === 1) {
+          // first call (initial server fetch) succeeds
+          return {
+            baseUrl: "https://cdn.example.com",
+            chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
+          } as T;
+        }
+        // refresh after first failure: simulate chapter deleted → 404
+        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
+      },
+    });
+
+    const mockFetch = mock(async (url: string) => {
+      if (url === "https://api.mangadex.network/report") return new Response(null, { status: 200 });
+      // image fetch always fails to trigger the refresh path
+      return makeImageResponse({ ok: false, status: 503 });
+    });
+
+    const opts: AtHomeOptions = {
+      httpClient,
+      logger: noopLogger,
+      fetch: mockFetch as unknown as AtHomeOptions["fetch"],
+      sleep: async () => {},
+    };
+
+    const fetcher = mangadexImageFetcher("ch-del", opts);
+    const err = await fetcher({ url: "", page: 1 }).catch((e) => e);
+    expect(err).toBeInstanceOf(AtHomeError);
+    expect((err as AtHomeError).status).toBe(404);
+  });
+
+  it("throws lastErr (not generic retry message) when refresh throws a generic Error", async () => {
+    let atHomeCallCount = 0;
+    const httpClient = makeHttpClient({
+      get: async <T>(_path: string) => {
+        atHomeCallCount++;
+        if (atHomeCallCount === 1) {
+          return {
+            baseUrl: "https://cdn.example.com",
+            chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
+          } as T;
+        }
+        throw new Error("network timeout on refresh");
+      },
+    });
+
+    const mockFetch = mock(async (url: string) => {
+      if (url === "https://api.mangadex.network/report") return new Response(null, { status: 200 });
+      return makeImageResponse({ ok: false, status: 503 });
+    });
+
+    const opts: AtHomeOptions = {
+      httpClient,
+      logger: noopLogger,
+      fetch: mockFetch as unknown as AtHomeOptions["fetch"],
+      sleep: async () => {},
+    };
+
+    const fetcher = mangadexImageFetcher("ch-net", opts);
+    const err = await fetcher({ url: "", page: 1 }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    // Must surface the refresh error, not "Failed to fetch image page X after 5 attempts"
+    expect((err as Error).message).toBe("network timeout on refresh");
+  });
+});
+
 // ---------- report HTTP failure tolerated ----------
 
 describe("mangadexImageFetcher — report failure tolerated", () => {

--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -96,6 +96,43 @@ describe("getAtHomeServer", () => {
     expect(err).not.toBeInstanceOf(AtHomeError);
     expect((err as Error).message).toBe("network failure");
   });
+
+  it("calls logger.warn with mangadex.at_home_error before throwing AtHomeError on HTTP 404", async () => {
+    const warnCalls: Array<Record<string, unknown>> = [];
+    const spyLogger: Logger = {
+      ...noopLogger,
+      warn: (fields) => warnCalls.push(fields as Record<string, unknown>),
+    };
+    const client = makeHttpClient({
+      get: async () => {
+        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext");
+      },
+    });
+    const err = await getAtHomeServer(client, "ch-ext", "data", spyLogger).catch((e) => e);
+    expect(err).toBeInstanceOf(AtHomeError);
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]?.event).toBe("mangadex.at_home_error");
+    expect(warnCalls[0]?.chapterId).toBe("ch-ext");
+    expect(warnCalls[0]?.status).toBe(404);
+  });
+
+  it("calls logger.warn once and re-throws original error for non-HTTP errors", async () => {
+    const warnCalls: Array<Record<string, unknown>> = [];
+    const spyLogger: Logger = {
+      ...noopLogger,
+      warn: (fields) => warnCalls.push(fields as Record<string, unknown>),
+    };
+    const originalErr = new Error("network failure");
+    const client = makeHttpClient({
+      get: async () => {
+        throw originalErr;
+      },
+    });
+    const err = await getAtHomeServer(client, "ch-net", "data", spyLogger).catch((e) => e);
+    expect(err).toBe(originalErr);
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]?.event).toBe("mangadex.at_home_error");
+  });
 });
 
 // ---------- mangadexImageFetcher — success path ----------
@@ -281,6 +318,88 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
     expect(err).toBeInstanceOf(Error);
     // Must surface the refresh error, not "Failed to fetch image page X after 5 attempts"
     expect((err as Error).message).toBe("network timeout on refresh");
+  });
+
+  it("logs mangadex.at_home_refresh_failed when AtHomeError thrown during refresh", async () => {
+    const warnCalls: Array<Record<string, unknown>> = [];
+    const spyLogger: Logger = {
+      ...noopLogger,
+      warn: (fields) => warnCalls.push(fields as Record<string, unknown>),
+    };
+
+    let atHomeCallCount = 0;
+    const httpClient = makeHttpClient({
+      get: async <T>(_path: string) => {
+        atHomeCallCount++;
+        if (atHomeCallCount === 1) {
+          return {
+            baseUrl: "https://cdn.example.com",
+            chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
+          } as T;
+        }
+        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
+      },
+    });
+
+    const mockFetch = mock(async (url: string) => {
+      if (url === "https://api.mangadex.network/report") return new Response(null, { status: 200 });
+      return makeImageResponse({ ok: false, status: 503 });
+    });
+
+    const opts: AtHomeOptions = {
+      httpClient,
+      logger: spyLogger,
+      fetch: mockFetch as unknown as AtHomeOptions["fetch"],
+      sleep: async () => {},
+    };
+
+    const fetcher = mangadexImageFetcher("ch-del", opts);
+    await fetcher({ url: "", page: 1 }).catch(() => {});
+
+    const refreshFailLog = warnCalls.find((f) => f.event === "mangadex.at_home_refresh_failed");
+    expect(refreshFailLog).toBeDefined();
+    expect(refreshFailLog?.chapterId).toBe("ch-del");
+  });
+
+  it("logs mangadex.at_home_refresh_failed when generic Error thrown during refresh", async () => {
+    const warnCalls: Array<Record<string, unknown>> = [];
+    const spyLogger: Logger = {
+      ...noopLogger,
+      warn: (fields) => warnCalls.push(fields as Record<string, unknown>),
+    };
+
+    let atHomeCallCount = 0;
+    const httpClient = makeHttpClient({
+      get: async <T>(_path: string) => {
+        atHomeCallCount++;
+        if (atHomeCallCount === 1) {
+          return {
+            baseUrl: "https://cdn.example.com",
+            chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
+          } as T;
+        }
+        throw new Error("network timeout on refresh");
+      },
+    });
+
+    const mockFetch = mock(async (url: string) => {
+      if (url === "https://api.mangadex.network/report") return new Response(null, { status: 200 });
+      return makeImageResponse({ ok: false, status: 503 });
+    });
+
+    const opts: AtHomeOptions = {
+      httpClient,
+      logger: spyLogger,
+      fetch: mockFetch as unknown as AtHomeOptions["fetch"],
+      sleep: async () => {},
+    };
+
+    const fetcher = mangadexImageFetcher("ch-net", opts);
+    await fetcher({ url: "", page: 1 }).catch(() => {});
+
+    const refreshFailLog = warnCalls.find((f) => f.event === "mangadex.at_home_refresh_failed");
+    expect(refreshFailLog).toBeDefined();
+    expect(refreshFailLog?.chapterId).toBe("ch-net");
   });
 });
 

--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -357,8 +357,8 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
     await fetcher({ url: "", page: 1 }).catch(() => {});
 
     const refreshFailLog = warnCalls.find((f) => f.event === "mangadex.at_home_refresh_failed");
-    expect(refreshFailLog).toBeDefined();
-    expect(refreshFailLog?.chapterId).toBe("ch-del");
+    expect(refreshFailLog).toMatchObject({ chapterId: "ch-del", attempt: 1 });
+    expect(refreshFailLog?.err).toBeInstanceOf(AtHomeError);
   });
 
   it("logs mangadex.at_home_refresh_failed when generic Error thrown during refresh", async () => {
@@ -398,8 +398,9 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
     await fetcher({ url: "", page: 1 }).catch(() => {});
 
     const refreshFailLog = warnCalls.find((f) => f.event === "mangadex.at_home_refresh_failed");
-    expect(refreshFailLog).toBeDefined();
-    expect(refreshFailLog?.chapterId).toBe("ch-net");
+    const expectedErr = new Error("network timeout on refresh");
+    expect(refreshFailLog).toMatchObject({ chapterId: "ch-net", attempt: 1 });
+    expect((refreshFailLog?.err as Error).message).toBe(expectedErr.message);
   });
 });
 

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -66,7 +66,6 @@ export async function getAtHomeServer(
       logAtHomeError(logger, chapterId, err, status);
       throw new AtHomeError(chapterId, status, msg);
     }
-    // Unexpected error shape — log so the root cause survives in logs, then re-throw as-is.
     logAtHomeError(logger, chapterId, err);
     throw err;
   }
@@ -143,8 +142,6 @@ export function mangadexImageFetcher(
           server = await getAtHomeServer(httpClient, chapterId, quality, logger);
         } catch (refreshErr) {
           logRefreshFailed(logger, chapterId, attempt + 1, refreshErr);
-          // AtHomeError already has a clear message (e.g. 404 = externally-hosted chapter).
-          // Propagate it directly so the user sees the real cause, not a generic retry message.
           if (refreshErr instanceof AtHomeError) throw refreshErr;
           lastErr = refreshErr;
           break;

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -113,7 +113,15 @@ export function mangadexImageFetcher(
           logger,
         );
         await sleep(waitMs);
-        server = await getAtHomeServer(httpClient, chapterId, quality);
+        try {
+          server = await getAtHomeServer(httpClient, chapterId, quality);
+        } catch (refreshErr) {
+          // AtHomeError already has a clear message (e.g. 404 = externally-hosted chapter).
+          // Propagate it directly so the user sees the real cause, not a generic retry message.
+          if (refreshErr instanceof AtHomeError) throw refreshErr;
+          lastErr = refreshErr;
+          break;
+        }
         continue;
       }
 
@@ -140,7 +148,13 @@ export function mangadexImageFetcher(
           logger,
         );
         await sleep(waitMs);
-        server = await getAtHomeServer(httpClient, chapterId, quality);
+        try {
+          server = await getAtHomeServer(httpClient, chapterId, quality);
+        } catch (refreshErr) {
+          if (refreshErr instanceof AtHomeError) throw refreshErr;
+          lastErr = refreshErr;
+          break;
+        }
         continue;
       }
 

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -15,6 +15,27 @@ export type { AtHomeOptions, AtHomeServer, ImageQuality, ReportPayload } from ".
 const REPORT_URL = "https://api.mangadex.network/report";
 const MAX_ATTEMPTS = 5;
 
+function logAtHomeError(
+  logger: Logger | undefined,
+  chapterId: string,
+  err: unknown,
+  status?: number | null,
+): void {
+  logger?.warn(
+    { event: "mangadex.at_home_error", context: "at-home", chapterId, status, err },
+    status !== undefined && status !== null
+      ? "at-home server failed; wrapping as AtHomeError"
+      : "at-home server failed with unexpected error",
+  );
+}
+
+function logRefreshFailed(logger: Logger, chapterId: string, attempt: number, err: unknown): void {
+  logger.warn(
+    { event: "mangadex.at_home_refresh_failed", context: "at-home", chapterId, attempt, err },
+    "failed to refresh at-home server during retry",
+  );
+}
+
 // Parse HTTP status from error messages like "MangaDex HTTP 404: <url>"
 function parseHttpStatus(err: unknown): number | null {
   if (!(err instanceof Error)) return null;
@@ -42,17 +63,11 @@ export async function getAtHomeServer(
         status === 404
           ? `at-home server returned 404 for chapter ${chapterId}. Likely an externally-hosted chapter (MangaPlus / Comikey / Cubari). Check chapter.externalUrl in the feed.`
           : `at-home server returned ${status} for chapter ${chapterId}`;
-      logger?.warn(
-        { event: "mangadex.at_home_error", context: "at-home", chapterId, status, err },
-        "at-home server failed; wrapping as AtHomeError",
-      );
+      logAtHomeError(logger, chapterId, err, status);
       throw new AtHomeError(chapterId, status, msg);
     }
     // Unexpected error shape — log so the root cause survives in logs, then re-throw as-is.
-    logger?.warn(
-      { event: "mangadex.at_home_error", context: "at-home", chapterId, err },
-      "at-home server failed with unexpected error",
-    );
+    logAtHomeError(logger, chapterId, err);
     throw err;
   }
 }
@@ -127,16 +142,7 @@ export function mangadexImageFetcher(
         try {
           server = await getAtHomeServer(httpClient, chapterId, quality, logger);
         } catch (refreshErr) {
-          logger.warn(
-            {
-              event: "mangadex.at_home_refresh_failed",
-              context: "at-home",
-              chapterId,
-              attempt: attempt + 1,
-              err: refreshErr,
-            },
-            "failed to refresh at-home server during retry",
-          );
+          logRefreshFailed(logger, chapterId, attempt + 1, refreshErr);
           // AtHomeError already has a clear message (e.g. 404 = externally-hosted chapter).
           // Propagate it directly so the user sees the real cause, not a generic retry message.
           if (refreshErr instanceof AtHomeError) throw refreshErr;
@@ -172,16 +178,7 @@ export function mangadexImageFetcher(
         try {
           server = await getAtHomeServer(httpClient, chapterId, quality, logger);
         } catch (refreshErr) {
-          logger.warn(
-            {
-              event: "mangadex.at_home_refresh_failed",
-              context: "at-home",
-              chapterId,
-              attempt: attempt + 1,
-              err: refreshErr,
-            },
-            "failed to refresh at-home server during retry",
-          );
+          logRefreshFailed(logger, chapterId, attempt + 1, refreshErr);
           if (refreshErr instanceof AtHomeError) throw refreshErr;
           lastErr = refreshErr;
           break;

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -1,4 +1,5 @@
 import type { ImageRef } from "@modules/downloader/types.ts";
+import { AtHomeError } from "./types.ts";
 import type {
   AtHomeOptions,
   AtHomeServer,
@@ -7,22 +8,42 @@ import type {
   ReportPayload,
 } from "./types.ts";
 
+export { AtHomeError } from "./types.ts";
 export type { AtHomeOptions, AtHomeServer, ImageQuality, ReportPayload } from "./types.ts";
 
 const REPORT_URL = "https://api.mangadex.network/report";
 const MAX_ATTEMPTS = 5;
+
+// Parse HTTP status from error messages like "MangaDex HTTP 404: <url>"
+function parseHttpStatus(err: unknown): number | null {
+  if (!(err instanceof Error)) return null;
+  const match = /^MangaDex HTTP (\d+):/.exec(err.message);
+  return match ? Number(match[1]) : null;
+}
 
 export async function getAtHomeServer(
   httpClient: AtHomeOptions["httpClient"],
   chapterId: string,
   quality: ImageQuality = "data",
 ): Promise<AtHomeServer> {
-  const res = await httpClient.get<AtHomeServerResponse>(`/at-home/server/${chapterId}`);
-  return {
-    baseUrl: res.baseUrl,
-    hash: res.chapter.hash,
-    pages: quality === "data" ? res.chapter.data : res.chapter.dataSaver,
-  };
+  try {
+    const res = await httpClient.get<AtHomeServerResponse>(`/at-home/server/${chapterId}`);
+    return {
+      baseUrl: res.baseUrl,
+      hash: res.chapter.hash,
+      pages: quality === "data" ? res.chapter.data : res.chapter.dataSaver,
+    };
+  } catch (err) {
+    const status = parseHttpStatus(err);
+    if (status !== null) {
+      const msg =
+        status === 404
+          ? `at-home server returned 404 for chapter ${chapterId}. Likely an externally-hosted chapter (MangaPlus / Comikey / Cubari). Check chapter.externalUrl in the feed.`
+          : `at-home server returned ${status} for chapter ${chapterId}`;
+      throw new AtHomeError(chapterId, status, msg);
+    }
+    throw err;
+  }
 }
 
 async function sendReport(

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -1,4 +1,5 @@
 import type { ImageRef } from "@modules/downloader/types.ts";
+import type { Logger } from "@plugins/logger/index.ts";
 import { AtHomeError } from "./types.ts";
 import type {
   AtHomeOptions,
@@ -25,6 +26,7 @@ export async function getAtHomeServer(
   httpClient: AtHomeOptions["httpClient"],
   chapterId: string,
   quality: ImageQuality = "data",
+  logger?: Logger,
 ): Promise<AtHomeServer> {
   try {
     const res = await httpClient.get<AtHomeServerResponse>(`/at-home/server/${chapterId}`);
@@ -40,8 +42,17 @@ export async function getAtHomeServer(
         status === 404
           ? `at-home server returned 404 for chapter ${chapterId}. Likely an externally-hosted chapter (MangaPlus / Comikey / Cubari). Check chapter.externalUrl in the feed.`
           : `at-home server returned ${status} for chapter ${chapterId}`;
+      logger?.warn(
+        { event: "mangadex.at_home_error", context: "at-home", chapterId, status, err },
+        "at-home server failed; wrapping as AtHomeError",
+      );
       throw new AtHomeError(chapterId, status, msg);
     }
+    // Unexpected error shape — log so the root cause survives in logs, then re-throw as-is.
+    logger?.warn(
+      { event: "mangadex.at_home_error", context: "at-home", chapterId, err },
+      "at-home server failed with unexpected error",
+    );
     throw err;
   }
 }
@@ -80,7 +91,7 @@ export function mangadexImageFetcher(
   return async function fetchImage(ref: ImageRef): Promise<Uint8Array> {
     let lastErr: unknown;
     // Cache the server result; only re-fetch after a failure to get a fresh CDN URL.
-    let server = await getAtHomeServer(httpClient, chapterId, quality);
+    let server = await getAtHomeServer(httpClient, chapterId, quality, logger);
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       const filename = server.pages[ref.page - 1] ?? ref.url;
@@ -114,8 +125,18 @@ export function mangadexImageFetcher(
         );
         await sleep(waitMs);
         try {
-          server = await getAtHomeServer(httpClient, chapterId, quality);
+          server = await getAtHomeServer(httpClient, chapterId, quality, logger);
         } catch (refreshErr) {
+          logger.warn(
+            {
+              event: "mangadex.at_home_refresh_failed",
+              context: "at-home",
+              chapterId,
+              attempt: attempt + 1,
+              err: refreshErr,
+            },
+            "failed to refresh at-home server during retry",
+          );
           // AtHomeError already has a clear message (e.g. 404 = externally-hosted chapter).
           // Propagate it directly so the user sees the real cause, not a generic retry message.
           if (refreshErr instanceof AtHomeError) throw refreshErr;
@@ -149,8 +170,18 @@ export function mangadexImageFetcher(
         );
         await sleep(waitMs);
         try {
-          server = await getAtHomeServer(httpClient, chapterId, quality);
+          server = await getAtHomeServer(httpClient, chapterId, quality, logger);
         } catch (refreshErr) {
+          logger.warn(
+            {
+              event: "mangadex.at_home_refresh_failed",
+              context: "at-home",
+              chapterId,
+              attempt: attempt + 1,
+              err: refreshErr,
+            },
+            "failed to refresh at-home server during retry",
+          );
           if (refreshErr instanceof AtHomeError) throw refreshErr;
           lastErr = refreshErr;
           break;

--- a/src/integrations/mangadex/at-home/types.ts
+++ b/src/integrations/mangadex/at-home/types.ts
@@ -3,6 +3,17 @@ import type { Logger } from "@plugins/logger/index.ts";
 
 export type ImageQuality = "data" | "data-saver";
 
+export class AtHomeError extends Error {
+  constructor(
+    public chapterId: string,
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AtHomeError";
+  }
+}
+
 export interface AtHomeServer {
   baseUrl: string;
   hash: string;

--- a/src/integrations/mangadex/client/client.test.ts
+++ b/src/integrations/mangadex/client/client.test.ts
@@ -87,6 +87,16 @@ describe("parseChapterFeed", () => {
     expect(chapters[1]?.volume).toBeNull();
     expect(chapters[1]?.chapter).toBeNull();
   });
+
+  it("populates externalUrl as null for CDN-hosted chapters", () => {
+    const chapters = parseChapterFeed(chapterFeedFixture as MdxChapterListResponse);
+    expect(chapters[0]?.externalUrl).toBeNull();
+  });
+
+  it("populates externalUrl with the URL for partner-hosted chapters", () => {
+    const chapters = parseChapterFeed(chapterFeedFixture as MdxChapterListResponse);
+    expect(chapters[2]?.externalUrl).toBe("https://mangaplus.shueisha.co.jp/viewer/1010633");
+  });
 });
 
 describe("createMangaDexClient", () => {

--- a/src/integrations/mangadex/client/mocks/chapter-feed.json
+++ b/src/integrations/mangadex/client/mocks/chapter-feed.json
@@ -10,7 +10,8 @@
         "chapter": "1",
         "title": "Prologue",
         "translatedLanguage": "en",
-        "readableAt": "2021-01-01T00:00:00+00:00"
+        "readableAt": "2021-01-01T00:00:00+00:00",
+        "externalUrl": null
       },
       "relationships": [
         {
@@ -30,12 +31,26 @@
         "chapter": null,
         "title": "Oneshot",
         "translatedLanguage": "pt-br",
-        "readableAt": "2021-02-01T00:00:00+00:00"
+        "readableAt": "2021-02-01T00:00:00+00:00",
+        "externalUrl": null
+      },
+      "relationships": []
+    },
+    {
+      "id": "ch-003",
+      "type": "chapter",
+      "attributes": {
+        "volume": "1",
+        "chapter": "2",
+        "title": "Into the Fray",
+        "translatedLanguage": "en",
+        "readableAt": "2021-01-08T00:00:00+00:00",
+        "externalUrl": "https://mangaplus.shueisha.co.jp/viewer/1010633"
       },
       "relationships": []
     }
   ],
   "limit": 500,
   "offset": 0,
-  "total": 2
+  "total": 3
 }

--- a/src/integrations/mangadex/client/parser.ts
+++ b/src/integrations/mangadex/client/parser.ts
@@ -77,6 +77,7 @@ export function parseChapterFeed(raw: MdxChapterListResponse): ChapterRef[] {
       translatedLanguage: normalizeLang(item.attributes.translatedLanguage),
       scanlationGroup: typeof scanlationGroup === "string" ? scanlationGroup : null,
       readableAt: item.attributes.readableAt,
+      externalUrl: item.attributes.externalUrl ?? null,
     };
   });
 }

--- a/src/integrations/mangadex/client/types.ts
+++ b/src/integrations/mangadex/client/types.ts
@@ -22,6 +22,7 @@ export interface ChapterRef {
   translatedLanguage: string;
   scanlationGroup: string | null;
   readableAt: string;
+  externalUrl: string | null;
 }
 
 // --- MangaDex REST response shapes ---
@@ -80,6 +81,7 @@ export interface MdxChapterAttributes {
   title: string | null;
   translatedLanguage: string;
   readableAt: string;
+  externalUrl: string | null;
 }
 
 export interface MdxChapterData {


### PR DESCRIPTION
## What this PR does

Lays the groundwork to handle MangaDex chapters served by official partners (MangaPlus, Comikey, Cubari, …). Today scanldr explodes with a generic `MangaDex HTTP 404` when it tries to fetch images for these chapters — the at-home CDN doesn't host them. This PR makes the data and the error path graceful so the user (and downstream commands) can react sensibly.

**Scope is intentionally surgical.** Only the parts achievable with the currently-wired commands (`list` and the at-home fetcher) ship here. The integration parts that would touch `download`, `sync`, and `update` are explicitly deferred to those commands' own implementation issues — see "ACs deferred" below.

## Why it exists

Discovered during the real-CLI test of #41 (at-home server with retry + reporting):

- Berserk (scanlation, CDN-hosted) → 23/23 image tests pass.
- Kagurabachi ch.1 (MangaPlus) → `MangaDex HTTP 404: https://api.mangadex.org/at-home/server/<id>` for every page.

Most popular ongoing series are partner-hosted (everything Shueisha publishes weekly is on MangaPlus). Without this fix, `list` couldn't even hint that those chapters live elsewhere, and the at-home fetcher gave a useless error.

Ref: #48

## How it works internally

### 1. `externalUrl` flows from API → client → command

- `MdxChapterAttributes.externalUrl: string | null` (raw API shape) and `ChapterRef.externalUrl: string | null` (public shape) — both non-optional, both nullable.
- `parseChapterFeed` reads `attributes.externalUrl ?? null`. No coercion to empty string.
- `src/integrations/mangadex/client/mocks/chapter-feed.json` — at least one CDN chapter (`null`) and one MangaPlus chapter (real `https://mangaplus.shueisha.co.jp/...` URL).

### 2. `list` annotates external chapters

- `parseExternalHost(url): string | null` — pure helper, returns the first hostname label (`mangaplus.shueisha.co.jp` → `"mangaplus"`, `comikey.com` → `"comikey"`) or `null` for malformed input.
- `formatMangaList` and `formatVolumeList` use a 3-state local variable (`undefined` = no `externalUrl`, `null` = malformed, `string` = host label) to render:
  - CDN chapters → no annotation
  - External chapter with parseable URL → `[external: <tag>]`
  - External chapter with malformed URL → `[external]` (no `[external: ]` artifact)
- `formatChapterDetail` renders an `External:  <url>` line between `Group:` and `Published:` when set; absent otherwise.

### 3. Typed `AtHomeError` with logged root cause

- `class AtHomeError extends Error` in `src/integrations/mangadex/at-home/types.ts` carries `chapterId: string`, `status: number`, and `name: "AtHomeError"`.
- `getAtHomeServer(httpClient, chapterId, quality, logger?)` accepts an optional `logger`. Before wrapping an http error as `AtHomeError` (or re-throwing an unknown-shape error), it emits `warn` via `logAtHomeError(logger, chapterId, err, status)` so the original cause (stack + message from the http layer) survives in logs even when `AtHomeError` is what propagates.
- 404 message: `"at-home server returned 404 for chapter <id>. Likely an externally-hosted chapter (MangaPlus / Comikey / Cubari). Check chapter.externalUrl in the feed."` Non-404 statuses get a message that still includes status and chapter id.

### 4. `mangadexImageFetcher` retry path is observable

- The initial `getAtHomeServer` call now receives the logger.
- The retry-refresh catch logs `warn` via `logRefreshFailed(logger, chapterId, attempt, err)` BEFORE deciding to re-throw `AtHomeError` (chapter is gone, no point retrying with a stale URL) or capture a generic error into `lastErr` and break.
- Both helpers (`logAtHomeError`, `logRefreshFailed`) are private — small wrappers around `logger.warn(...)` that prevent log-shape drift across the (formerly four) duplicated call sites.

### 5. ADR-002 addendum

`docs/adr/002-mangadex-primary-source.md` gets a ~14-line section on partner-hosted vs CDN-hosted chapters and what each command does (or will do, for the deferred ones).

## What did not change

- The unimplemented command handlers (`download`, `update`, `sync`, …) — they're still `NotImplementedError`. The integration parts of #48 were intentionally left for their respective issues.
- `readableAt` is preserved (no #47 regression).
- `ChapterRef` keeps its existing fields; `externalUrl` is purely additive.
- Verify-fetch / cookie-replay paths (untouched).
- `mangadexImageFetcher`'s happy-path behavior, MAX_ATTEMPTS, exponential backoff, and report-payload shape (untouched).

## ACs satisfied (this PR)

- [x] `ChapterRef.externalUrl: string | null` (client + list types)
- [x] `parseChapterFeed` extracts `externalUrl` (preserves `null`)
- [x] `list` formatter annotates external chapters
- [x] `formatChapterDetail` renders `External:` line when set
- [x] `AtHomeError` typed class
- [x] `getAtHomeServer` wraps HTTP errors as `AtHomeError`; 404 hints at external hosting
- [x] `mangadexImageFetcher` retry loop handles refresh failures gracefully
- [x] Original errors are logged at `warn` before any wrap/swallow — `getAtHomeServer` and the retry-refresh catch both emit structured logs carrying the original `err`
- [x] Fixture has CDN + external chapters
- [x] ADR-002 addendum

## ACs deferred (other issues)

- [ ] `download` refuses early with `ExternalChapterError` carrying the URL → **#14 / #15** (download wiring)
- [ ] `sync` / `update` skip external chapters with info log + still call `markSynced` → **#16 / #17** (update / sync wiring)

## Follow-up issues

- **#51** — `chore(http): typed MangaDexHttpError to replace string-parsed status` — the at-home wrapper currently parses `"MangaDex HTTP 404:"` from error messages because the http layer doesn't expose a typed status. Replacing it touches every http caller, so it ships as its own change.

## Test checklist

- [x] Parser test: `externalUrl` populated for both null and URL fixtures
- [x] `parseExternalHost` tests: 3 hosts (`mangaplus`, `comikey`, `cubari`) + 3 malformed (`""`, `"mangaplus"`, `"not a url"`); contract `string | null`
- [x] `formatMangaList` / `formatVolumeList`: external annotation present for external, absent for CDN, `[external]` fallback for malformed URLs
- [x] `formatChapterDetail`: `External:` line present only when set
- [x] `AtHomeError` tests: 404 → external-hosting hint; non-404 → status-bearing message; network error path
- [x] Logging tests: spy logger asserts `mangadex.at_home_error` warn fires before wrap/re-throw in both 404 and unknown-shape paths; `mangadex.at_home_refresh_failed` warn fires in both AtHomeError and generic-error refresh paths; both log assertions use `toMatchObject({ chapterId, attempt })` + check `err` identity / message
- [x] `mangadexImageFetcher` retry: refresh throws `AtHomeError` → re-thrown immediately; refresh throws generic Error → captured into `lastErr` and surfaced
- [x] `bun test` — 211 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- The "out of scope" list is opinionated: `download`/`sync`/`update` ACs were left for their own wiring issues so this PR stays small and reviewable.
- The string-parsed HTTP status in `AtHomeError` wrapping is a known wart; tracked as #51.
- `formatExternalTag` was deleted (no external callers); both formatter sites and tests now use `parseExternalHost` directly.

## Closes

Ref: #48 (partial — see ACs deferred)

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/` (ADR-002 addendum)