### PR TITLE
feat(cli): wire download --volume end-to-end (MangaDex source)

### DIFF
--- a/src/cli-routing.test.ts
+++ b/src/cli-routing.test.ts
@@ -1,0 +1,142 @@
+/**
+ * CLI routing integration tests.
+ *
+ * These tests spawn the CLI as a subprocess to verify that flags are correctly
+ * routed to their handlers (i.e. --volume 13 reaches the download handler as
+ * a string, not as boolean true). All tested paths exit before hitting the
+ * network (missing required flags, mutual exclusion, --help, --version).
+ */
+import { describe, expect, test } from "bun:test";
+
+const CLI = new URL("./index.ts", import.meta.url).pathname;
+
+interface RunResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+async function run(args: string[]): Promise<RunResult> {
+  const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+// ---------------------------------------------------------------------------
+// Global flags
+// ---------------------------------------------------------------------------
+
+describe("--version / --help", () => {
+  test("--version prints version and exits 0", async () => {
+    const r = await run(["--version"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/scanldr/);
+  });
+
+  test("--help prints usage and exits 0", async () => {
+    const r = await run(["--help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/scanldr/);
+  });
+
+  test("help command prints usage and exits 0", async () => {
+    const r = await run(["help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/scanldr/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// download: argv routing fix — flags must reach the handler
+// ---------------------------------------------------------------------------
+
+describe("download: required-flag validation", () => {
+  test("missing --volume AND --chapter → exit 2 with usage hint", async () => {
+    // This used to succeed incorrectly (volume was undefined, triggering the
+    // wrong branch). After the fix it should correctly report the missing flag.
+    const r = await run(["download", "Dandadan", "--non-tty"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/--volume/i);
+  });
+
+  test("--volume value is correctly received (not coerced to boolean)", async () => {
+    // With the old double-parseArgs, --volume 13 would turn into boolean true
+    // and "13" would become a positional, so the handler never saw volume=13.
+    // Now it should reach the download handler with volume set, and fail later
+    // (at network / config stage), NOT with the "is required" message.
+    const r = await run(["download", "Dandadan", "--volume", "13", "--non-tty", "--dry-run"]);
+    // Should NOT produce the "is required" error — it may fail for other reasons
+    // (network, config) but not because --volume was missing.
+    expect(r.stderr).not.toMatch(/--volume.*is required/i);
+  });
+
+  test("--volume and --chapter together → exit 2 (mutual exclusion)", async () => {
+    const r = await run(["download", "Dandadan", "--volume", "1", "--chapter", "5", "--non-tty"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/mutually exclusive/i);
+  });
+
+  test("--chapter alone → exit 2 (not yet implemented)", async () => {
+    const r = await run(["download", "Dandadan", "--chapter", "5", "--non-tty"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/--chapter/i);
+  });
+
+  test("missing manga positional → exit 2 with usage", async () => {
+    const r = await run(["download", "--volume", "1", "--non-tty"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stdout + r.stderr).toMatch(/Usage/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list: flag routing
+// ---------------------------------------------------------------------------
+
+describe("list: argv routing", () => {
+  test("missing manga positional → exit 2 with usage", async () => {
+    const r = await run(["list"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/Usage/i);
+  });
+
+  test("--volume and --chapter together → exit 2 (mutual exclusion)", async () => {
+    // These flags reach runList which throws for mutual exclusion
+    const r = await run(["list", "X", "--volume", "1", "--chapter", "5", "--non-tty"]);
+    expect(r.exitCode).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Global flag positioning
+// ---------------------------------------------------------------------------
+
+describe("global flags can appear before command", () => {
+  test("--verbose before command does not break routing", async () => {
+    // Should fail on missing manga, not on flag parsing
+    const r = await run(["--verbose", "download", "--volume", "1", "--non-tty"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/Usage/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown command
+// ---------------------------------------------------------------------------
+
+describe("unknown command", () => {
+  test("unknown command → exit 1", async () => {
+    const r = await run(["nonexistent"]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/Unknown command/i);
+  });
+});

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -392,6 +392,87 @@ describe("runDownload — atomic history on mid-download failure", () => {
   });
 });
 
+describe("runDownload — multi-chapter volume", () => {
+  test("happy path: 2 chapters produce 5 files in monotonic order with correct bytes", async () => {
+    const ch1 = makeChapterRef({ id: "ch-1", volume: "1", chapter: "1" });
+    const ch2 = makeChapterRef({ id: "ch-2", volume: "1", chapter: "2" });
+
+    const multiClient = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("1", ["ch-1", "ch-2"])],
+      feedChapters: async () => [ch1, ch2],
+    });
+
+    // ch-1 at-home: 2 pages (hash "hash-ch1")
+    // ch-2 at-home: 3 pages (hash "hash-ch2")
+    const multiHttp: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path === "/at-home/server/ch-1") {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "hash-ch1", data: ["p1.jpg", "p2.jpg"], dataSaver: [] },
+          };
+        }
+        if (path === "/at-home/server/ch-2") {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "hash-ch2", data: ["p1.jpg", "p2.jpg", "p3.jpg"], dataSaver: [] },
+          };
+        }
+        throw new Error(`Unexpected HTTP GET: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    // Distinct marker bytes per chapter: ch1 pages start ff d8 ff e1, ch2 pages start ff d8 ff e2
+    const CH1_JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe1, ...JPEG_BYTES.slice(4)]);
+    const CH2_JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe2, ...JPEG_BYTES.slice(4)]);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = Object.assign(
+      async (url: string | URL | Request) => {
+        const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+        const bytes = urlStr.includes("hash-ch1") ? CH1_JPEG : CH2_JPEG;
+        return new Response(bytes, {
+          status: 200,
+          headers: { "x-cache": "MISS", "content-type": "image/jpeg" },
+        });
+      },
+      { preconnect: () => {} },
+    ) as typeof fetch;
+
+    try {
+      await runDownload(baseArgs(), baseCtx(), multiClient, multiHttp);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-volume-001.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(true);
+
+    const raw = new Uint8Array(await Bun.file(cbzPath).arrayBuffer());
+    const entries = unzipSync(raw);
+    const names = Object.keys(entries).sort();
+
+    // 2 ch1 pages + 3 ch2 pages = 5
+    expect(names).toHaveLength(5);
+    expect(names).toEqual(["0001.jpg", "0002.jpg", "0003.jpg", "0004.jpg", "0005.jpg"]);
+
+    // First 2 files must come from ch1 fetcher (marker byte 0xe1)
+    expect(entries["0001.jpg"]?.[3]).toBe(0xe1);
+    expect(entries["0002.jpg"]?.[3]).toBe(0xe1);
+
+    // Last 3 files must come from ch2 fetcher (marker byte 0xe2)
+    expect(entries["0003.jpg"]?.[3]).toBe(0xe2);
+    expect(entries["0004.jpg"]?.[3]).toBe(0xe2);
+    expect(entries["0005.jpg"]?.[3]).toBe(0xe2);
+
+    // 2 history rows: one per chapter
+    const history = listHistory(db);
+    expect(history).toHaveLength(2);
+    expect(history.map((r) => r.chapterId).sort()).toEqual(["ch-1", "ch-2"]);
+  });
+});
+
 describe("runDownload — range parsing", () => {
   test("invalid range throws CliError", async () => {
     await expect(

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -8,9 +8,10 @@ import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import { listHistory } from "@modules/history/index.ts";
 import { openDb, runMigrations } from "@plugins/db/index.ts";
 import type { Db } from "@plugins/db/index.ts";
+import { CliError } from "@plugins/errors/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
+import { unzipSync } from "fflate";
 import { runDownload } from "./index.ts";
-import { CliError } from "./range.ts";
 import type { DownloadArgs, DownloadContext } from "./types.ts";
 
 // Minimal 1x1 JPEG bytes
@@ -178,11 +179,28 @@ describe("runDownload — happy path", () => {
     const exists = await Bun.file(cbzPath).exists();
     expect(exists).toBe(true);
 
-    // Check history recorded
+    // P1.2 — assert .cbz contents: page count, filename convention, sort order
+    const raw = new Uint8Array(await Bun.file(cbzPath).arrayBuffer());
+    const entries = unzipSync(raw);
+    const names = Object.keys(entries).sort();
+    // makeFullHttpClient returns 2 pages for "data" quality (data: ["page1.jpg","page2.jpg"])
+    expect(names).toHaveLength(2);
+    expect(names[0]).toBe("0001.jpg");
+    expect(names[1]).toBe("0002.jpg");
+
+    // P1.1 — assert all history columns
     const history = listHistory(db);
-    expect(history.length).toBeGreaterThan(0);
-    expect(history[0]?.mangaId).toBe("manga-id-1");
-    expect(history[0]?.language).toBe("en");
+    expect(history.length).toBe(1);
+    expect(history[0]).toMatchObject({
+      mangaId: "manga-id-1",
+      mangaTitle: "Test Manga",
+      volume: "1",
+      chapterId: "ch-1",
+      chapterNum: "1",
+      source: "mangadex",
+      language: "en",
+      downloadedAt: expect.any(Number),
+    });
   });
 });
 
@@ -322,6 +340,55 @@ describe("runDownload — volume not in feed", () => {
     });
 
     expect(warnLogged).toBe(true);
+  });
+});
+
+describe("runDownload — atomic history on mid-download failure", () => {
+  test("no .cbz and no history rows when at-home server fails for chapter 2", async () => {
+    // Three chapters in volume 1
+    const ch1 = makeChapterRef({ id: "ch-1", volume: "1", chapter: "1" });
+    const ch2 = makeChapterRef({ id: "ch-2", volume: "1", chapter: "2" });
+    const ch3 = makeChapterRef({ id: "ch-3", volume: "1", chapter: "3" });
+
+    const multiChapterClient = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("1", ["ch-1", "ch-2", "ch-3"])],
+      feedChapters: async () => [ch1, ch2, ch3],
+    });
+
+    // at-home: ch-2 server call throws (simulates network error after ch-1 succeeds)
+    let atHomeCallCount = 0;
+    const failingHttp: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path.startsWith("/at-home/server/")) {
+          atHomeCallCount++;
+          if (atHomeCallCount === 2) {
+            throw new Error("MangaDex HTTP 500: simulated server error for chapter 2");
+          }
+          return {
+            baseUrl: "https://example.com",
+            chapter: {
+              hash: "abc123",
+              data: ["page1.jpg"],
+              dataSaver: ["ds1.jpg"],
+            },
+          };
+        }
+        throw new Error(`Unexpected HTTP GET: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    await expect(
+      runDownload(baseArgs(), baseCtx(), multiChapterClient, failingHttp),
+    ).rejects.toThrow();
+
+    // No .cbz orphan left on disk
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-volume-001.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(false);
+
+    // Zero history rows — atomicity preserved
+    const history = listHistory(db);
+    expect(history.length).toBe(0);
   });
 });
 

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
+import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/mangadex/client/index.ts";
+import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
+import { listHistory } from "@modules/history/index.ts";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
+import type { Db } from "@plugins/db/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+import { runDownload } from "./index.ts";
+import { CliError } from "./range.ts";
+import type { DownloadArgs, DownloadContext } from "./types.ts";
+
+// Minimal 1x1 JPEG bytes
+const JPEG_BYTES = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+  0x00, 0x01, 0x00, 0x00, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08,
+  0x07, 0x07, 0x07, 0x09, 0x09, 0x08, 0x0a, 0x0c, 0x14, 0x0d, 0x0c, 0x0b, 0x0b, 0x0c, 0x19, 0x12,
+  0x13, 0x0f, 0x14, 0x1d, 0x1a, 0x1f, 0x1e, 0x1d, 0x1a, 0x1c, 0x1c, 0x20, 0x24, 0x2e, 0x27, 0x20,
+  0x22, 0x2c, 0x23, 0x1c, 0x1c, 0x28, 0x37, 0x29, 0x2c, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1f, 0x27,
+  0x39, 0x3d, 0x38, 0x32, 0x3c, 0x2e, 0x33, 0x34, 0x32, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x01,
+  0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xff, 0xc4, 0x00, 0x1f, 0x00, 0x00, 0x01, 0x05, 0x01, 0x01,
+  0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04,
+  0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0xff, 0xc4, 0x00, 0xb5, 0x10, 0x00, 0x02, 0x01, 0x03,
+  0x03, 0x02, 0x04, 0x03, 0x05, 0x05, 0x04, 0x04, 0x00, 0x00, 0x01, 0x7d, 0x01, 0x02, 0x03, 0x00,
+  0x04, 0x11, 0x05, 0x12, 0x21, 0x31, 0x41, 0x06, 0x13, 0x51, 0x61, 0x07, 0x22, 0x71, 0x14, 0x32,
+  0x81, 0x91, 0xa1, 0x08, 0x23, 0x42, 0xb1, 0xc1, 0x15, 0x52, 0xd1, 0xf0, 0x24, 0x33, 0x62, 0x72,
+  0x82, 0x09, 0x0a, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x34, 0x35,
+  0x36, 0x37, 0x38, 0x39, 0x3a, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x53, 0x54, 0x55,
+  0x56, 0x57, 0x58, 0x59, 0x5a, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x73, 0x74, 0x75,
+  0x76, 0x77, 0x78, 0x79, 0x7a, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x93, 0x94, 0x95,
+  0x96, 0x97, 0x98, 0x99, 0x9a, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xb2, 0xb3,
+  0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca,
+  0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7,
+  0xe8, 0xe9, 0xea, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xff, 0xda, 0x00,
+  0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0xfb, 0xd2, 0x8a, 0x28, 0x03, 0xff, 0xd9,
+]);
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function makeCandidate(overrides?: Partial<MangaCandidate>): MangaCandidate {
+  return {
+    id: "manga-id-1",
+    title: "Test Manga",
+    originalLanguage: "ja",
+    year: 2020,
+    ...overrides,
+  };
+}
+
+function makeVolumeRef(volume: string, chapterIds: string[]): VolumeRef {
+  return { volume, numeric: Number(volume), chapterIds };
+}
+
+function makeChapterRef(overrides: Partial<ChapterRef> & { id: string }): ChapterRef {
+  return {
+    volume: "1",
+    chapter: "1",
+    title: "Chapter 1",
+    translatedLanguage: "en",
+    scanlationGroup: null,
+    readableAt: "2024-01-01T00:00:00Z",
+    externalUrl: null,
+    ...overrides,
+  };
+}
+
+function makeClient(overrides?: Partial<MangaDexClient>): MangaDexClient {
+  const chapter1 = makeChapterRef({ id: "ch-1", volume: "1", chapter: "1" });
+  return {
+    searchManga: async () => [makeCandidate()],
+    resolveTitleToId: async () => [makeCandidate()],
+    aggregateVolumes: async () => [makeVolumeRef("1", ["ch-1"])],
+    feedChapters: async () => [chapter1],
+    ...overrides,
+  };
+}
+
+// Build a MangaDexHttpClient that serves at-home server + image fetch
+function makeFullHttpClient(): MangaDexHttpClient {
+  return {
+    get: async (path: string) => {
+      if (path.startsWith("/at-home/server/")) {
+        return {
+          baseUrl: "https://example.com",
+          chapter: {
+            hash: "abc123",
+            data: ["page1.jpg", "page2.jpg"],
+            dataSaver: ["ds1.jpg"],
+          },
+        };
+      }
+      throw new Error(`Unexpected HTTP GET: ${path}`);
+    },
+  } as unknown as MangaDexHttpClient;
+}
+
+let tmpDir: string;
+let db: Db;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "scanldr-test-"));
+  db = openDb(join(tmpDir, "test.db"));
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+function baseArgs(overrides?: Partial<DownloadArgs>): DownloadArgs {
+  return {
+    manga: "Test Manga",
+    volume: "1",
+    format: "cbz",
+    outDir: tmpDir,
+    quality: "data",
+    concurrency: 1,
+    delayMs: 0,
+    force: false,
+    noTrack: false,
+    dryRun: false,
+    nonTty: true,
+    ...overrides,
+  };
+}
+
+function baseCtx(): DownloadContext {
+  return {
+    logger: noopLogger,
+    config: {
+      preferred_languages: ["en"],
+      download_quality: "data",
+      default_format: "cbz",
+      default_out: tmpDir,
+      image_concurrency: 1,
+      chapter_delay_ms: 0,
+      db_path: join(tmpDir, "test.db"),
+    },
+    db,
+  };
+}
+
+// Override mangadexImageFetcher to return JPEG bytes without hitting network
+// We'll inject through a custom at-home http client that never actually fetches images.
+// Instead, we mock globalThis.fetch for image fetches.
+function withMockedImageFetch(fn: () => Promise<void>): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (_url: string | URL | Request) => {
+      return new Response(JPEG_BYTES, {
+        status: 200,
+        headers: { "x-cache": "MISS", "content-type": "image/jpeg" },
+      });
+    },
+    { preconnect: () => {} },
+  ) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+describe("runDownload — happy path", () => {
+  test("produces .cbz file and records history", async () => {
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs(), baseCtx(), makeClient(), makeFullHttpClient());
+    });
+
+    // Check .cbz exists
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-volume-001.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(true);
+
+    // Check history recorded
+    const history = listHistory(db);
+    expect(history.length).toBeGreaterThan(0);
+    expect(history[0]?.mangaId).toBe("manga-id-1");
+    expect(history[0]?.language).toBe("en");
+  });
+});
+
+describe("runDownload — dryRun", () => {
+  test("does not write .cbz and does not record history", async () => {
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs({ dryRun: true }), baseCtx(), makeClient(), makeFullHttpClient());
+    });
+
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-volume-001.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(false);
+
+    const history = listHistory(db);
+    expect(history.length).toBe(0);
+  });
+});
+
+describe("runDownload — noTrack", () => {
+  test("writes .cbz but does not record history", async () => {
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs({ noTrack: true }), baseCtx(), makeClient(), makeFullHttpClient());
+    });
+
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-volume-001.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(true);
+
+    const history = listHistory(db);
+    expect(history.length).toBe(0);
+  });
+});
+
+describe("runDownload — force", () => {
+  test("re-downloads even if volume is already in history", async () => {
+    // Run first download to populate history
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs(), baseCtx(), makeClient(), makeFullHttpClient());
+    });
+
+    const historyBefore = listHistory(db);
+    expect(historyBefore.length).toBeGreaterThan(0);
+
+    // Run again without force — should skip
+    let loggedSkip = false;
+    const captureLogger: Logger = {
+      info: (_obj: unknown, msg?: string) => {
+        if (msg?.includes("skipping volume")) loggedSkip = true;
+      },
+      warn: () => {},
+      error: () => {},
+    };
+
+    await runDownload(
+      baseArgs(),
+      { ...baseCtx(), logger: captureLogger },
+      makeClient(),
+      makeFullHttpClient(),
+    );
+    expect(loggedSkip).toBe(true);
+
+    // Run with force — should re-download without logging skip
+    loggedSkip = false;
+    await withMockedImageFetch(async () => {
+      await runDownload(
+        baseArgs({ force: true }),
+        { ...baseCtx(), logger: captureLogger },
+        makeClient(),
+        makeFullHttpClient(),
+      );
+    });
+    expect(loggedSkip).toBe(false);
+  });
+});
+
+describe("runDownload — external chapter", () => {
+  test("throws CliError for external chapters", async () => {
+    const externalChapter = makeChapterRef({
+      id: "ch-ext",
+      volume: "1",
+      chapter: "1",
+      externalUrl: "https://mangaplus.shueisha.co.jp/viewer/123",
+    });
+
+    const clientWithExternal = makeClient({
+      feedChapters: async () => [externalChapter],
+    });
+
+    await expect(
+      runDownload(baseArgs(), baseCtx(), clientWithExternal, makeFullHttpClient()),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("CliError message contains the external URL", async () => {
+    const extUrl = "https://mangaplus.shueisha.co.jp/viewer/456";
+    const externalChapter = makeChapterRef({
+      id: "ch-ext",
+      volume: "1",
+      chapter: "2",
+      externalUrl: extUrl,
+    });
+
+    const clientWithExternal = makeClient({
+      feedChapters: async () => [externalChapter],
+    });
+
+    try {
+      await runDownload(baseArgs(), baseCtx(), clientWithExternal, makeFullHttpClient());
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      expect((err as CliError).message).toContain(extUrl);
+    }
+  });
+});
+
+describe("runDownload — volume not in feed", () => {
+  test("logs warn and skips missing volumes", async () => {
+    let warnLogged = false;
+    const captureLogger: Logger = {
+      info: () => {},
+      warn: (_obj: unknown, msg?: string) => {
+        if (msg?.includes("not found in feed")) warnLogged = true;
+      },
+
+      error: () => {},
+    };
+
+    // Volume "2" doesn't exist in the feed (which only has volume "1")
+    await withMockedImageFetch(async () => {
+      await runDownload(
+        baseArgs({ volume: "2" }),
+        { ...baseCtx(), logger: captureLogger },
+        makeClient(),
+        makeFullHttpClient(),
+      );
+    });
+
+    expect(warnLogged).toBe(true);
+  });
+});
+
+describe("runDownload — range parsing", () => {
+  test("invalid range throws CliError", async () => {
+    await expect(
+      runDownload(baseArgs({ volume: "5-3" }), baseCtx(), makeClient(), makeFullHttpClient()),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("--volume none throws CliError with deferred message", async () => {
+    await expect(
+      runDownload(baseArgs({ volume: "none" }), baseCtx(), makeClient(), makeFullHttpClient()),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+});

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -1,0 +1,324 @@
+import { createInterface } from "node:readline";
+import {
+  AtHomeError,
+  getAtHomeServer,
+  mangadexImageFetcher,
+} from "@integrations/mangadex/at-home/index.ts";
+import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
+import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
+import { downloadVolume } from "@modules/downloader/index.ts";
+import type { ChapterInput, ImageRef } from "@modules/downloader/types.ts";
+import { isVolumeFullyDownloaded, recordDownloadedChapters } from "@modules/history/index.ts";
+import type { DownloadRow } from "@modules/history/index.ts";
+import { resolveLanguage } from "./language.ts";
+import { CliError } from "./range.ts";
+import { parseRangeSet } from "./range.ts";
+import type { DownloadArgs, DownloadContext } from "./types.ts";
+
+export type { DownloadArgs, DownloadContext } from "./types.ts";
+
+export { CliError } from "./range.ts";
+
+/** kebab-case a manga title for use as filesystem slug */
+function toSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Prompt user to pick one from a list of candidates with titles */
+function promptCandidatePick(candidates: { title: string }[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
+    process.stderr.write(`Multiple results found:\n${list}\nPick one: `);
+    rl.once("line", (line) => {
+      rl.close();
+      const n = Number.parseInt(line.trim(), 10);
+      if (Number.isNaN(n) || n < 1 || n > candidates.length) {
+        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
+      } else {
+        resolve(n - 1);
+      }
+    });
+  });
+}
+
+export async function runDownload(
+  args: DownloadArgs,
+  ctx: DownloadContext,
+  client: MangaDexClient,
+  http: MangaDexHttpClient,
+): Promise<void> {
+  const { logger, config, db } = ctx;
+
+  // 1. Parse range
+  const { values: requestedVolumes } = parseRangeSet(args.volume);
+
+  // Fail immediately on --volume none (deferred feature)
+  if (requestedVolumes.has("none")) {
+    throw new CliError(
+      "--volume none is not yet supported. Use a numeric volume number instead.",
+      2,
+    );
+  }
+
+  // 2. Resolve title to manga ID
+  logger.info(
+    { event: "download.search_start", context: "download", title: args.manga },
+    "searching manga",
+  );
+
+  const candidates = await client.resolveTitleToId(args.manga);
+
+  let chosenIndex = 0;
+  if (candidates.length > 1) {
+    if (args.nonTty) {
+      const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
+      throw new CliError(
+        `Multiple results found for "${args.manga}". Re-run in a terminal to pick one:\n${list}`,
+        2,
+      );
+    }
+    chosenIndex = await promptCandidatePick(candidates);
+  }
+
+  const chosen = candidates[chosenIndex];
+  if (!chosen) throw new CliError("No candidate selected", 2);
+
+  logger.info(
+    { event: "download.manga_resolved", context: "download", id: chosen.id, title: chosen.title },
+    "manga resolved",
+  );
+
+  const preferred = config.preferred_languages;
+
+  // 3. Aggregate volumes (early discovery — used to know which volumes exist)
+  await client.aggregateVolumes(chosen.id, preferred);
+
+  // 4. Fetch chapters and resolve language
+  const feedChapters = await client.feedChapters(chosen.id, preferred);
+
+  const availableLanguages = [...new Set(feedChapters.map((c) => c.translatedLanguage))];
+
+  const language = await resolveLanguage({
+    preferred,
+    available: availableLanguages,
+    nonTty: args.nonTty,
+    logger,
+  });
+
+  // Filter chapters to chosen language
+  const chaptersInLang = feedChapters.filter((c) => c.translatedLanguage === language);
+
+  // Build map: volume label → chapters
+  const volumeToChapters = new Map<string, typeof chaptersInLang>();
+  for (const ch of chaptersInLang) {
+    const vol = ch.volume ?? "none";
+    const existing = volumeToChapters.get(vol) ?? [];
+    existing.push(ch);
+    volumeToChapters.set(vol, existing);
+  }
+
+  const slug = toSlug(chosen.title);
+
+  // 6. Process each requested volume
+  for (const volumeToken of requestedVolumes) {
+    // Find chapters for this volume
+    const volChapters = volumeToChapters.get(volumeToken);
+
+    if (!volChapters || volChapters.length === 0) {
+      logger.warn(
+        { event: "download.volume_missing", context: "download", volume: volumeToken },
+        `volume ${volumeToken} not found in feed; skipping`,
+      );
+      continue;
+    }
+
+    const chapterIdSet = new Set(volChapters.map((c) => c.id));
+
+    // 6a. History check
+    if (!args.force) {
+      const fullyDownloaded = isVolumeFullyDownloaded(db, {
+        mangaId: chosen.id,
+        volume: volumeToken,
+        language,
+        expectedChapterIds: chapterIdSet,
+      });
+
+      if (fullyDownloaded) {
+        logger.info(
+          {
+            event: "download.volume_skip",
+            context: "download",
+            volume: volumeToken,
+          },
+          `skipping volume ${volumeToken}: already in history`,
+        );
+        continue;
+      }
+    }
+
+    // 6b. External-chapter check
+    for (const ch of volChapters) {
+      if (ch.externalUrl !== null) {
+        const host = (() => {
+          try {
+            return new URL(ch.externalUrl).hostname;
+          } catch {
+            return ch.externalUrl;
+          }
+        })();
+        throw new CliError(
+          `Chapter ${ch.chapter ?? ch.id} is hosted externally on ${host}. scanldr cannot download partner-hosted chapters. Open: ${ch.externalUrl}`,
+          2,
+        );
+      }
+    }
+
+    // volumeNumber for downloader: parse numeric token
+    const volumeNumber = Number(volumeToken);
+    if (!Number.isFinite(volumeNumber)) {
+      throw new CliError(`Cannot coerce volume "${volumeToken}" to a number`, 2);
+    }
+
+    // 6c–d. Build ChapterInput[] with per-chapter fetchers routed by chapterId
+    const fetcherCache = new Map<string, (ref: ImageRef) => Promise<Uint8Array>>();
+
+    const chapterInputs: ChapterInput[] = [];
+
+    for (const ch of volChapters) {
+      // Get at-home server to know the page count
+      const server = await getAtHomeServer(http, ch.id, args.quality, logger);
+
+      const pages: ImageRef[] = server.pages.map((filename, i) => ({
+        url: filename,
+        page: i + 1,
+      }));
+
+      chapterInputs.push({
+        id: ch.id,
+        num: Number(ch.chapter ?? "0"),
+        pages,
+      });
+
+      // Build fetcher for this chapter
+      fetcherCache.set(
+        ch.id,
+        mangadexImageFetcher(ch.id, {
+          httpClient: http,
+          logger,
+          quality: args.quality,
+        }),
+      );
+    }
+
+    // Single imageFetcher that routes by page position (downloader calls it with ImageRef)
+    // The downloader passes refs from chapterInputs.pages, so we need to route by chapterId.
+    // We build a flat list mapping each ref to its chapter fetcher via a closure-captured array.
+    // Build a ref→fetcher map based on chapter order and page ranges
+    // Since ImageRef doesn't carry chapterId, we route by tracking page offsets.
+    // Downloader passes pages from chapters in sorted order; we rebuild that mapping here.
+    const sortedChapterInputs = [...chapterInputs].sort((a, b) => a.num - b.num);
+    const pageRanges: Array<{
+      startPage: number;
+      endPage: number;
+      fetcher: (ref: ImageRef) => Promise<Uint8Array>;
+    }> = [];
+    let pageOffset = 0;
+    for (const ci of sortedChapterInputs) {
+      const fetcher = fetcherCache.get(ci.id);
+      if (!fetcher) continue;
+      pageRanges.push({
+        startPage: pageOffset + 1,
+        endPage: pageOffset + ci.pages.length,
+        fetcher,
+      });
+      pageOffset += ci.pages.length;
+    }
+
+    const imageFetcher = async (ref: ImageRef): Promise<Uint8Array> => {
+      const range = pageRanges.find((r) => ref.page >= r.startPage && ref.page <= r.endPage);
+      if (!range) {
+        throw new Error(`No fetcher found for page ${ref.page}`);
+      }
+      // Create a local ref with page index within the chapter
+      const localRef: ImageRef = { url: ref.url, page: ref.page - range.startPage + 1 };
+      return range.fetcher(localRef);
+    };
+
+    // 6d–e. Download
+    if (args.dryRun) {
+      const totalPages = chapterInputs.reduce((sum, c) => sum + c.pages.length, 0);
+      logger.info(
+        {
+          event: "download.dry_run",
+          context: "download",
+          slug,
+          volumeNumber,
+          chapters: chapterInputs.length,
+          totalPages,
+        },
+        `dry-run: would download volume ${volumeToken}`,
+      );
+      continue;
+    }
+
+    let result: Awaited<ReturnType<typeof downloadVolume>>;
+    try {
+      result = await downloadVolume({
+        outDir: args.outDir,
+        format: args.format,
+        slug,
+        volumeNumber,
+        chapters: chapterInputs,
+        imageConcurrency: args.concurrency,
+        delayMs: args.delayMs,
+        dryRun: false,
+        logger,
+        imageFetcher,
+      });
+    } catch (err) {
+      if (err instanceof AtHomeError && err.status === 404) {
+        throw new CliError(err.message, 2);
+      }
+      throw err;
+    }
+
+    logger.info(
+      {
+        event: "download.volume_done",
+        context: "download",
+        volume: volumeToken,
+        outputPath: result.outputPath,
+        byteSize: result.byteSize,
+      },
+      `volume ${volumeToken} downloaded`,
+    );
+
+    // 6f. Record history
+    if (!args.noTrack) {
+      const rows: DownloadRow[] = volChapters.map((ch) => ({
+        mangaId: chosen.id,
+        mangaTitle: chosen.title,
+        volume: volumeToken,
+        chapterId: ch.id,
+        chapterNum: ch.chapter ?? "0",
+        source: "mangadex",
+        language,
+        downloadedAt: Date.now(),
+      }));
+      recordDownloadedChapters(db, rows);
+      logger.info(
+        {
+          event: "download.history_recorded",
+          context: "download",
+          volume: volumeToken,
+          rows: rows.length,
+        },
+        "history recorded",
+      );
+    }
+  }
+}

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -4,6 +4,7 @@ import {
   getAtHomeServer,
   mangadexImageFetcher,
 } from "@integrations/mangadex/at-home/index.ts";
+import type { ChapterRef, MangaCandidate } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import { downloadVolume } from "@modules/downloader/index.ts";
@@ -13,35 +14,12 @@ import type { DownloadRow } from "@modules/history/index.ts";
 import { CliError } from "@plugins/errors/index.ts";
 import { resolveLanguage } from "./language.ts";
 import { parseRangeSet } from "./range.ts";
+import { toSlug } from "./slug.ts";
 import type { DownloadArgs, DownloadContext } from "./types.ts";
 
 export type { DownloadArgs, DownloadContext } from "./types.ts";
-
 export { CliError } from "@plugins/errors/index.ts";
-
-/** kebab-case a manga title for use as filesystem slug */
-export function toSlug(
-  title: string,
-  logger?: { warn: (fields: Record<string, unknown>, msg: string) => void },
-): string {
-  const slug = title
-    .normalize("NFKD")
-    // Strip combining diacritical marks (e.g. accents) after NFKD decomposition
-    .replace(/\p{Mn}/gu, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  if (slug === "") {
-    logger?.warn(
-      { event: "download.slug_empty", context: "download", title },
-      "title produced an empty slug; falling back to 'untitled'",
-    );
-    return "untitled";
-  }
-
-  return slug;
-}
+export { toSlug } from "./slug.ts";
 
 /** Prompt user to pick one from a list of candidates with titles */
 function promptCandidatePick(candidates: { title: string }[]): Promise<number> {
@@ -61,39 +39,26 @@ function promptCandidatePick(candidates: { title: string }[]): Promise<number> {
   });
 }
 
-export async function runDownload(
-  args: DownloadArgs,
-  ctx: DownloadContext,
+/** Resolve a manga title string to a single candidate. Throws CliError on ambiguity in non-TTY. */
+async function resolveTitle(
   client: MangaDexClient,
-  http: MangaDexHttpClient,
-): Promise<void> {
-  const { logger, config, db } = ctx;
-
-  // 1. Parse range
-  const { values: requestedVolumes } = parseRangeSet(args.volume);
-
-  // Fail immediately on --volume none (deferred feature)
-  if (requestedVolumes.has("none")) {
-    throw new CliError(
-      "--volume none is not yet supported. Use a numeric volume number instead.",
-      2,
-    );
-  }
-
-  // 2. Resolve title to manga ID
+  manga: string,
+  nonTty: boolean,
+  logger: DownloadContext["logger"],
+): Promise<MangaCandidate> {
   logger.info(
-    { event: "download.search_start", context: "download", title: args.manga },
+    { event: "download.search_start", context: "download", title: manga },
     "searching manga",
   );
 
-  const candidates = await client.resolveTitleToId(args.manga);
+  const candidates = await client.resolveTitleToId(manga);
 
   let chosenIndex = 0;
   if (candidates.length > 1) {
-    if (args.nonTty) {
+    if (nonTty) {
       const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
       throw new CliError(
-        `Multiple results found for "${args.manga}". Re-run in a terminal to pick one:\n${list}`,
+        `Multiple results found for "${manga}". Re-run in a terminal to pick one:\n${list}`,
         2,
       );
     }
@@ -108,14 +73,187 @@ export async function runDownload(
     "manga resolved",
   );
 
+  return chosen;
+}
+
+/** Build ChapterInput[] for a set of chapters. Throws on at-home failure. */
+async function buildChapterInputs(
+  chapters: ChapterRef[],
+  http: MangaDexHttpClient,
+  quality: DownloadArgs["quality"],
+  logger: DownloadContext["logger"],
+): Promise<ChapterInput[]> {
+  const inputs: ChapterInput[] = [];
+
+  for (const ch of chapters) {
+    const server = await getAtHomeServer(http, ch.id, quality, logger);
+
+    inputs.push({
+      id: ch.id,
+      num: Number(ch.chapter ?? "0"),
+      pages: server.pages.map((filename, i) => ({ url: filename, page: i + 1 })),
+      imageFetcher: mangadexImageFetcher(ch.id, {
+        httpClient: http,
+        logger,
+        quality,
+      }),
+    });
+  }
+
+  return inputs;
+}
+
+/** Per-volume pipeline: history check → external check → build inputs → download → record. */
+async function processVolume(
+  volumeToken: string,
+  volChapters: ChapterRef[],
+  chosen: MangaCandidate,
+  slug: string,
+  language: string,
+  args: DownloadArgs,
+  ctx: DownloadContext,
+  http: MangaDexHttpClient,
+): Promise<void> {
+  const { logger, db } = ctx;
+
+  // history check
+  if (!args.force) {
+    const chapterIdSet = new Set(volChapters.map((c) => c.id));
+    const fullyDownloaded = isVolumeFullyDownloaded(db, {
+      mangaId: chosen.id,
+      volume: volumeToken,
+      language,
+      expectedChapterIds: chapterIdSet,
+    });
+
+    if (fullyDownloaded) {
+      logger.info(
+        { event: "download.volume_skip", context: "download", volume: volumeToken },
+        `skipping volume ${volumeToken}: already in history`,
+      );
+      return;
+    }
+  }
+
+  // external-chapter check
+  for (const ch of volChapters) {
+    if (ch.externalUrl !== null) {
+      const host = (() => {
+        try {
+          return new URL(ch.externalUrl).hostname;
+        } catch {
+          return ch.externalUrl;
+        }
+      })();
+      throw new CliError(
+        `Chapter ${ch.chapter ?? ch.id} is hosted externally on ${host}. scanldr cannot download partner-hosted chapters. Open: ${ch.externalUrl}`,
+        2,
+      );
+    }
+  }
+
+  const volumeNumber = Number(volumeToken);
+  const chapterInputs = await buildChapterInputs(volChapters, http, args.quality, logger);
+
+  if (args.dryRun) {
+    const totalPages = chapterInputs.reduce((sum, c) => sum + c.pages.length, 0);
+    logger.info(
+      {
+        event: "download.dry_run",
+        context: "download",
+        slug,
+        volumeNumber,
+        chapters: chapterInputs.length,
+        totalPages,
+      },
+      `dry-run: would download volume ${volumeToken}`,
+    );
+    return;
+  }
+
+  let result: Awaited<ReturnType<typeof downloadVolume>>;
+  try {
+    result = await downloadVolume({
+      outDir: args.outDir,
+      format: args.format,
+      slug,
+      volumeNumber,
+      chapters: chapterInputs,
+      imageConcurrency: args.concurrency,
+      delayMs: args.delayMs,
+      dryRun: false,
+      logger,
+    });
+  } catch (err) {
+    if (err instanceof AtHomeError && err.status === 404) {
+      throw new CliError(err.message, 2);
+    }
+    throw err;
+  }
+
+  logger.info(
+    {
+      event: "download.volume_done",
+      context: "download",
+      volume: volumeToken,
+      outputPath: result.outputPath,
+      byteSize: result.byteSize,
+    },
+    `volume ${volumeToken} downloaded`,
+  );
+
+  if (!args.noTrack) {
+    const rows: DownloadRow[] = volChapters.map((ch) => ({
+      mangaId: chosen.id,
+      mangaTitle: chosen.title,
+      volume: volumeToken,
+      chapterId: ch.id,
+      chapterNum: ch.chapter ?? "0",
+      source: "mangadex",
+      language,
+      downloadedAt: Date.now(),
+    }));
+    recordDownloadedChapters(db, rows);
+    logger.info(
+      {
+        event: "download.history_recorded",
+        context: "download",
+        volume: volumeToken,
+        rows: rows.length,
+      },
+      "history recorded",
+    );
+  }
+}
+
+export async function runDownload(
+  args: DownloadArgs,
+  ctx: DownloadContext,
+  client: MangaDexClient,
+  http: MangaDexHttpClient,
+): Promise<void> {
+  const { logger, config } = ctx;
+
+  // 1. Parse range
+  const { values: requestedVolumes } = parseRangeSet(args.volume);
+
+  if (requestedVolumes.has("none")) {
+    throw new CliError(
+      "--volume none is not yet supported. Use a numeric volume number instead.",
+      2,
+    );
+  }
+
+  // 2. Resolve title → manga ID
+  const chosen = await resolveTitle(client, args.manga, args.nonTty, logger);
+
   const preferred = config.preferred_languages;
 
-  // 3. Aggregate volumes (early discovery — used to know which volumes exist)
+  // 3. Aggregate volumes (early discovery)
   await client.aggregateVolumes(chosen.id, preferred);
 
   // 4. Fetch chapters and resolve language
   const feedChapters = await client.feedChapters(chosen.id, preferred);
-
   const availableLanguages = [...new Set(feedChapters.map((c) => c.translatedLanguage))];
 
   const language = await resolveLanguage({
@@ -125,10 +263,8 @@ export async function runDownload(
     logger,
   });
 
-  // Filter chapters to chosen language
+  // 5. Group chapters by volume label
   const chaptersInLang = feedChapters.filter((c) => c.translatedLanguage === language);
-
-  // Build map: volume label → chapters
   const volumeToChapters = new Map<string, typeof chaptersInLang>();
   for (const ch of chaptersInLang) {
     const vol = ch.volume ?? "none";
@@ -141,7 +277,6 @@ export async function runDownload(
 
   // 6. Process each requested volume
   for (const volumeToken of requestedVolumes) {
-    // Find chapters for this volume
     const volChapters = volumeToChapters.get(volumeToken);
 
     if (!volChapters || volChapters.length === 0) {
@@ -152,138 +287,6 @@ export async function runDownload(
       continue;
     }
 
-    const chapterIdSet = new Set(volChapters.map((c) => c.id));
-
-    // 6a. History check
-    if (!args.force) {
-      const fullyDownloaded = isVolumeFullyDownloaded(db, {
-        mangaId: chosen.id,
-        volume: volumeToken,
-        language,
-        expectedChapterIds: chapterIdSet,
-      });
-
-      if (fullyDownloaded) {
-        logger.info(
-          {
-            event: "download.volume_skip",
-            context: "download",
-            volume: volumeToken,
-          },
-          `skipping volume ${volumeToken}: already in history`,
-        );
-        continue;
-      }
-    }
-
-    // 6b. External-chapter check
-    for (const ch of volChapters) {
-      if (ch.externalUrl !== null) {
-        const host = (() => {
-          try {
-            return new URL(ch.externalUrl).hostname;
-          } catch {
-            return ch.externalUrl;
-          }
-        })();
-        throw new CliError(
-          `Chapter ${ch.chapter ?? ch.id} is hosted externally on ${host}. scanldr cannot download partner-hosted chapters. Open: ${ch.externalUrl}`,
-          2,
-        );
-      }
-    }
-
-    // volumeNumber for downloader: parseRangeSet already validates numeric tokens
-    const volumeNumber = Number(volumeToken);
-
-    // 6c. Build ChapterInput[] — each chapter carries its own image fetcher
-    const chapterInputs: ChapterInput[] = [];
-
-    for (const ch of volChapters) {
-      const server = await getAtHomeServer(http, ch.id, args.quality, logger);
-
-      chapterInputs.push({
-        id: ch.id,
-        num: Number(ch.chapter ?? "0"),
-        pages: server.pages.map((filename, i) => ({ url: filename, page: i + 1 })),
-        imageFetcher: mangadexImageFetcher(ch.id, {
-          httpClient: http,
-          logger,
-          quality: args.quality,
-        }),
-      });
-    }
-
-    // 6d–e. Download
-    if (args.dryRun) {
-      const totalPages = chapterInputs.reduce((sum, c) => sum + c.pages.length, 0);
-      logger.info(
-        {
-          event: "download.dry_run",
-          context: "download",
-          slug,
-          volumeNumber,
-          chapters: chapterInputs.length,
-          totalPages,
-        },
-        `dry-run: would download volume ${volumeToken}`,
-      );
-      continue;
-    }
-
-    let result: Awaited<ReturnType<typeof downloadVolume>>;
-    try {
-      result = await downloadVolume({
-        outDir: args.outDir,
-        format: args.format,
-        slug,
-        volumeNumber,
-        chapters: chapterInputs,
-        imageConcurrency: args.concurrency,
-        delayMs: args.delayMs,
-        dryRun: false,
-        logger,
-      });
-    } catch (err) {
-      if (err instanceof AtHomeError && err.status === 404) {
-        throw new CliError(err.message, 2);
-      }
-      throw err;
-    }
-
-    logger.info(
-      {
-        event: "download.volume_done",
-        context: "download",
-        volume: volumeToken,
-        outputPath: result.outputPath,
-        byteSize: result.byteSize,
-      },
-      `volume ${volumeToken} downloaded`,
-    );
-
-    // 6f. Record history
-    if (!args.noTrack) {
-      const rows: DownloadRow[] = volChapters.map((ch) => ({
-        mangaId: chosen.id,
-        mangaTitle: chosen.title,
-        volume: volumeToken,
-        chapterId: ch.id,
-        chapterNum: ch.chapter ?? "0",
-        source: "mangadex",
-        language,
-        downloadedAt: Date.now(),
-      }));
-      recordDownloadedChapters(db, rows);
-      logger.info(
-        {
-          event: "download.history_recorded",
-          context: "download",
-          volume: volumeToken,
-          rows: rows.length,
-        },
-        "history recorded",
-      );
-    }
+    await processVolume(volumeToken, volChapters, chosen, slug, language, args, ctx, http);
   }
 }

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -7,17 +7,17 @@ import {
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import { downloadVolume } from "@modules/downloader/index.ts";
-import type { ChapterInput, ImageRef } from "@modules/downloader/types.ts";
+import type { ChapterInput } from "@modules/downloader/types.ts";
 import { isVolumeFullyDownloaded, recordDownloadedChapters } from "@modules/history/index.ts";
 import type { DownloadRow } from "@modules/history/index.ts";
+import { CliError } from "@plugins/errors/index.ts";
 import { resolveLanguage } from "./language.ts";
-import { CliError } from "./range.ts";
 import { parseRangeSet } from "./range.ts";
 import type { DownloadArgs, DownloadContext } from "./types.ts";
 
 export type { DownloadArgs, DownloadContext } from "./types.ts";
 
-export { CliError } from "./range.ts";
+export { CliError } from "@plugins/errors/index.ts";
 
 /** kebab-case a manga title for use as filesystem slug */
 export function toSlug(
@@ -193,76 +193,26 @@ export async function runDownload(
       }
     }
 
-    // volumeNumber for downloader: parse numeric token
+    // volumeNumber for downloader: parseRangeSet already validates numeric tokens
     const volumeNumber = Number(volumeToken);
-    if (!Number.isFinite(volumeNumber)) {
-      throw new CliError(`Cannot coerce volume "${volumeToken}" to a number`, 2);
-    }
 
-    // 6c–d. Build ChapterInput[] with per-chapter fetchers routed by chapterId
-    const fetcherCache = new Map<string, (ref: ImageRef) => Promise<Uint8Array>>();
-
+    // 6c. Build ChapterInput[] — each chapter carries its own image fetcher
     const chapterInputs: ChapterInput[] = [];
 
     for (const ch of volChapters) {
-      // Get at-home server to know the page count
       const server = await getAtHomeServer(http, ch.id, args.quality, logger);
-
-      const pages: ImageRef[] = server.pages.map((filename, i) => ({
-        url: filename,
-        page: i + 1,
-      }));
 
       chapterInputs.push({
         id: ch.id,
         num: Number(ch.chapter ?? "0"),
-        pages,
-      });
-
-      // Build fetcher for this chapter
-      fetcherCache.set(
-        ch.id,
-        mangadexImageFetcher(ch.id, {
+        pages: server.pages.map((filename, i) => ({ url: filename, page: i + 1 })),
+        imageFetcher: mangadexImageFetcher(ch.id, {
           httpClient: http,
           logger,
           quality: args.quality,
         }),
-      );
-    }
-
-    // Single imageFetcher that routes by page position (downloader calls it with ImageRef)
-    // The downloader passes refs from chapterInputs.pages, so we need to route by chapterId.
-    // We build a flat list mapping each ref to its chapter fetcher via a closure-captured array.
-    // Build a ref→fetcher map based on chapter order and page ranges
-    // Since ImageRef doesn't carry chapterId, we route by tracking page offsets.
-    // Downloader passes pages from chapters in sorted order; we rebuild that mapping here.
-    const sortedChapterInputs = [...chapterInputs].sort((a, b) => a.num - b.num);
-    const pageRanges: Array<{
-      startPage: number;
-      endPage: number;
-      fetcher: (ref: ImageRef) => Promise<Uint8Array>;
-    }> = [];
-    let pageOffset = 0;
-    for (const ci of sortedChapterInputs) {
-      const fetcher = fetcherCache.get(ci.id);
-      if (!fetcher) continue;
-      pageRanges.push({
-        startPage: pageOffset + 1,
-        endPage: pageOffset + ci.pages.length,
-        fetcher,
       });
-      pageOffset += ci.pages.length;
     }
-
-    const imageFetcher = async (ref: ImageRef): Promise<Uint8Array> => {
-      const range = pageRanges.find((r) => ref.page >= r.startPage && ref.page <= r.endPage);
-      if (!range) {
-        throw new Error(`No fetcher found for page ${ref.page}`);
-      }
-      // Create a local ref with page index within the chapter
-      const localRef: ImageRef = { url: ref.url, page: ref.page - range.startPage + 1 };
-      return range.fetcher(localRef);
-    };
 
     // 6d–e. Download
     if (args.dryRun) {
@@ -293,7 +243,6 @@ export async function runDownload(
         delayMs: args.delayMs,
         dryRun: false,
         logger,
-        imageFetcher,
       });
     } catch (err) {
       if (err instanceof AtHomeError && err.status === 404) {

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -19,7 +19,6 @@ import type { DownloadArgs, DownloadContext } from "./types.ts";
 
 export type { DownloadArgs, DownloadContext } from "./types.ts";
 export { CliError } from "@plugins/errors/index.ts";
-export { toSlug } from "./slug.ts";
 
 /** Prompt user to pick one from a list of candidates with titles */
 function promptCandidatePick(candidates: { title: string }[]): Promise<number> {
@@ -103,17 +102,20 @@ async function buildChapterInputs(
   return inputs;
 }
 
+interface ProcessVolumeArgs {
+  volumeToken: string;
+  volChapters: ChapterRef[];
+  chosen: MangaCandidate;
+  slug: string;
+  language: string;
+  args: DownloadArgs;
+  ctx: DownloadContext;
+  http: MangaDexHttpClient;
+}
+
 /** Per-volume pipeline: history check → external check → build inputs → download → record. */
-async function processVolume(
-  volumeToken: string,
-  volChapters: ChapterRef[],
-  chosen: MangaCandidate,
-  slug: string,
-  language: string,
-  args: DownloadArgs,
-  ctx: DownloadContext,
-  http: MangaDexHttpClient,
-): Promise<void> {
+async function processVolume(input: ProcessVolumeArgs): Promise<void> {
+  const { volumeToken, volChapters, chosen, slug, language, args, ctx, http } = input;
   const { logger, db } = ctx;
 
   // history check
@@ -234,7 +236,6 @@ export async function runDownload(
 ): Promise<void> {
   const { logger, config } = ctx;
 
-  // 1. Parse range
   const { values: requestedVolumes } = parseRangeSet(args.volume);
 
   if (requestedVolumes.has("none")) {
@@ -244,15 +245,13 @@ export async function runDownload(
     );
   }
 
-  // 2. Resolve title → manga ID
   const chosen = await resolveTitle(client, args.manga, args.nonTty, logger);
 
   const preferred = config.preferred_languages;
 
-  // 3. Aggregate volumes (early discovery)
+  // aggregateVolumes primes the MangaDex aggregate cache used by feedChapters
   await client.aggregateVolumes(chosen.id, preferred);
 
-  // 4. Fetch chapters and resolve language
   const feedChapters = await client.feedChapters(chosen.id, preferred);
   const availableLanguages = [...new Set(feedChapters.map((c) => c.translatedLanguage))];
 
@@ -263,7 +262,6 @@ export async function runDownload(
     logger,
   });
 
-  // 5. Group chapters by volume label
   const chaptersInLang = feedChapters.filter((c) => c.translatedLanguage === language);
   const volumeToChapters = new Map<string, typeof chaptersInLang>();
   for (const ch of chaptersInLang) {
@@ -275,7 +273,6 @@ export async function runDownload(
 
   const slug = toSlug(chosen.title, logger);
 
-  // 6. Process each requested volume
   for (const volumeToken of requestedVolumes) {
     const volChapters = volumeToChapters.get(volumeToken);
 
@@ -287,6 +284,6 @@ export async function runDownload(
       continue;
     }
 
-    await processVolume(volumeToken, volChapters, chosen, slug, language, args, ctx, http);
+    await processVolume({ volumeToken, volChapters, chosen, slug, language, args, ctx, http });
   }
 }

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -20,11 +20,27 @@ export type { DownloadArgs, DownloadContext } from "./types.ts";
 export { CliError } from "./range.ts";
 
 /** kebab-case a manga title for use as filesystem slug */
-function toSlug(title: string): string {
-  return title
+export function toSlug(
+  title: string,
+  logger?: { warn: (fields: Record<string, unknown>, msg: string) => void },
+): string {
+  const slug = title
+    .normalize("NFKD")
+    // Strip combining diacritical marks (e.g. accents) after NFKD decomposition
+    .replace(/\p{Mn}/gu, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
+
+  if (slug === "") {
+    logger?.warn(
+      { event: "download.slug_empty", context: "download", title },
+      "title produced an empty slug; falling back to 'untitled'",
+    );
+    return "untitled";
+  }
+
+  return slug;
 }
 
 /** Prompt user to pick one from a list of candidates with titles */
@@ -121,7 +137,7 @@ export async function runDownload(
     volumeToChapters.set(vol, existing);
   }
 
-  const slug = toSlug(chosen.title);
+  const slug = toSlug(chosen.title, logger);
 
   // 6. Process each requested volume
   for (const volumeToken of requestedVolumes) {

--- a/src/commands/download/language.test.ts
+++ b/src/commands/download/language.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { CliError } from "@plugins/errors/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { resolveLanguage } from "./language.ts";
@@ -84,62 +84,66 @@ describe("resolveLanguage", () => {
     }
   });
 
-  test("TTY: user picks valid index → returns matching language", async () => {
-    mock.module("node:readline", () => ({
-      createInterface: () => ({
-        once: (event: string, cb: (line: string) => void) => {
-          if (event === "line") cb("2");
-        },
-        close: () => {},
-      }),
-    }));
+  describe("TTY readline mock", () => {
+    afterAll(() => mock.restore());
 
-    const result = await resolveLanguage({
-      preferred: ["ja"],
-      available: ["en", "pt-BR"],
-      nonTty: false,
-      logger: noopLogger,
+    test("user picks valid index → returns matching language", async () => {
+      mock.module("node:readline", () => ({
+        createInterface: () => ({
+          once: (event: string, cb: (line: string) => void) => {
+            if (event === "line") cb("2");
+          },
+          close: () => {},
+        }),
+      }));
+
+      const result = await resolveLanguage({
+        preferred: ["ja"],
+        available: ["en", "pt-BR"],
+        nonTty: false,
+        logger: noopLogger,
+      });
+      expect(result).toBe("pt-BR");
     });
-    expect(result).toBe("pt-BR");
-  });
 
-  test("TTY: user enters out-of-range index → throws CliError", async () => {
-    mock.module("node:readline", () => ({
-      createInterface: () => ({
-        once: (event: string, cb: (line: string) => void) => {
-          if (event === "line") cb("99");
-        },
-        close: () => {},
-      }),
-    }));
+    test("user enters out-of-range index → throws CliError", async () => {
+      mock.module("node:readline", () => ({
+        createInterface: () => ({
+          once: (event: string, cb: (line: string) => void) => {
+            if (event === "line") cb("99");
+          },
+          close: () => {},
+        }),
+      }));
 
-    await expect(
-      resolveLanguage({
-        preferred: ["ja"],
-        available: ["en", "pt-BR"],
-        nonTty: false,
-        logger: noopLogger,
-      }),
-    ).rejects.toBeInstanceOf(CliError);
-  });
+      await expect(
+        resolveLanguage({
+          preferred: ["ja"],
+          available: ["en", "pt-BR"],
+          nonTty: false,
+          logger: noopLogger,
+        }),
+      ).rejects.toBeInstanceOf(CliError);
+    });
 
-  test("TTY: user enters non-numeric input → throws CliError", async () => {
-    mock.module("node:readline", () => ({
-      createInterface: () => ({
-        once: (event: string, cb: (line: string) => void) => {
-          if (event === "line") cb("abc");
-        },
-        close: () => {},
-      }),
-    }));
+    test("user enters non-numeric input → throws CliError", async () => {
+      mock.module("node:readline", () => ({
+        createInterface: () => ({
+          once: (event: string, cb: (line: string) => void) => {
+            if (event === "line") cb("abc");
+          },
+          close: () => {},
+        }),
+      }));
 
-    await expect(
-      resolveLanguage({
-        preferred: ["ja"],
-        available: ["en", "pt-BR"],
-        nonTty: false,
-        logger: noopLogger,
-      }),
-    ).rejects.toBeInstanceOf(CliError);
+      await expect(
+        resolveLanguage({
+          preferred: ["ja"],
+          available: ["en", "pt-BR"],
+          nonTty: false,
+          logger: noopLogger,
+        }),
+      ).rejects.toBeInstanceOf(CliError);
+    });
   });
 });

--- a/src/commands/download/language.test.ts
+++ b/src/commands/download/language.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { CliError } from "@plugins/errors/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { resolveLanguage } from "./language.ts";
-import { CliError } from "./range.ts";
 
 const noopLogger: Logger = {
   info: () => {},
@@ -39,6 +39,34 @@ describe("resolveLanguage", () => {
         logger: noopLogger,
       }),
     ).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("empty available (nonTty=true) throws CliError with helpful message", async () => {
+    await expect(
+      resolveLanguage({
+        preferred: ["en"],
+        available: [],
+        nonTty: true,
+        logger: noopLogger,
+      }),
+    ).rejects.toMatchObject({
+      name: "CliError",
+      message: expect.stringContaining("scanldr list"),
+    });
+  });
+
+  test("empty available (nonTty=false) throws CliError with helpful message", async () => {
+    await expect(
+      resolveLanguage({
+        preferred: ["en"],
+        available: [],
+        nonTty: false,
+        logger: noopLogger,
+      }),
+    ).rejects.toMatchObject({
+      name: "CliError",
+      message: expect.stringContaining("scanldr list"),
+    });
   });
 
   test("no match + nonTty error message is actionable", async () => {

--- a/src/commands/download/language.test.ts
+++ b/src/commands/download/language.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { CliError } from "@plugins/errors/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { resolveLanguage } from "./language.ts";
@@ -82,5 +82,64 @@ describe("resolveLanguage", () => {
       expect(err).toBeInstanceOf(CliError);
       expect((err as CliError).message).toContain("preferred_languages");
     }
+  });
+
+  test("TTY: user picks valid index → returns matching language", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (event: string, cb: (line: string) => void) => {
+          if (event === "line") cb("2");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const result = await resolveLanguage({
+      preferred: ["ja"],
+      available: ["en", "pt-BR"],
+      nonTty: false,
+      logger: noopLogger,
+    });
+    expect(result).toBe("pt-BR");
+  });
+
+  test("TTY: user enters out-of-range index → throws CliError", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (event: string, cb: (line: string) => void) => {
+          if (event === "line") cb("99");
+        },
+        close: () => {},
+      }),
+    }));
+
+    await expect(
+      resolveLanguage({
+        preferred: ["ja"],
+        available: ["en", "pt-BR"],
+        nonTty: false,
+        logger: noopLogger,
+      }),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("TTY: user enters non-numeric input → throws CliError", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (event: string, cb: (line: string) => void) => {
+          if (event === "line") cb("abc");
+        },
+        close: () => {},
+      }),
+    }));
+
+    await expect(
+      resolveLanguage({
+        preferred: ["ja"],
+        available: ["en", "pt-BR"],
+        nonTty: false,
+        logger: noopLogger,
+      }),
+    ).rejects.toBeInstanceOf(CliError);
   });
 });

--- a/src/commands/download/language.test.ts
+++ b/src/commands/download/language.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "@plugins/logger/index.ts";
+import { resolveLanguage } from "./language.ts";
+import { CliError } from "./range.ts";
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe("resolveLanguage", () => {
+  test("first preferred match wins silently", async () => {
+    const result = await resolveLanguage({
+      preferred: ["pt-BR", "en"],
+      available: ["en", "pt-BR"],
+      nonTty: true,
+      logger: noopLogger,
+    });
+    expect(result).toBe("pt-BR");
+  });
+
+  test("second preferred match used when first not available", async () => {
+    const result = await resolveLanguage({
+      preferred: ["ja", "en"],
+      available: ["en", "pt-BR"],
+      nonTty: true,
+      logger: noopLogger,
+    });
+    expect(result).toBe("en");
+  });
+
+  test("no match + nonTty throws CliError", async () => {
+    await expect(
+      resolveLanguage({
+        preferred: ["ja", "zh"],
+        available: ["en", "pt-BR"],
+        nonTty: true,
+        logger: noopLogger,
+      }),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("no match + nonTty error message is actionable", async () => {
+    try {
+      await resolveLanguage({
+        preferred: ["ja"],
+        available: ["en"],
+        nonTty: true,
+        logger: noopLogger,
+      });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      expect((err as CliError).message).toContain("preferred_languages");
+    }
+  });
+});

--- a/src/commands/download/language.ts
+++ b/src/commands/download/language.ts
@@ -1,5 +1,5 @@
 import { createInterface } from "node:readline";
-import { CliError } from "./range.ts";
+import { CliError } from "@plugins/errors/index.ts";
 import type { ResolveLanguageInput } from "./types.ts";
 
 function promptLanguagePick(available: readonly string[]): Promise<string> {
@@ -21,6 +21,13 @@ function promptLanguagePick(available: readonly string[]): Promise<string> {
 
 export async function resolveLanguage(input: ResolveLanguageInput): Promise<string> {
   const { preferred, available, nonTty, logger } = input;
+
+  if (available.length === 0) {
+    throw new CliError(
+      'No chapters available for this manga in any language. Try `scanldr list "<manga>"` to verify.',
+      2,
+    );
+  }
 
   for (const lang of preferred) {
     if (available.includes(lang)) {

--- a/src/commands/download/language.ts
+++ b/src/commands/download/language.ts
@@ -1,0 +1,43 @@
+import { createInterface } from "node:readline";
+import { CliError } from "./range.ts";
+import type { ResolveLanguageInput } from "./types.ts";
+
+function promptLanguagePick(available: readonly string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const list = available.map((lang, i) => `  [${i + 1}] ${lang}`).join("\n");
+    process.stderr.write(`No preferred language available. Choose one:\n${list}\nPick one: `);
+    rl.once("line", (line) => {
+      rl.close();
+      const n = Number.parseInt(line.trim(), 10);
+      if (Number.isNaN(n) || n < 1 || n > available.length) {
+        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
+      } else {
+        resolve(available[n - 1] as string);
+      }
+    });
+  });
+}
+
+export async function resolveLanguage(input: ResolveLanguageInput): Promise<string> {
+  const { preferred, available, nonTty, logger } = input;
+
+  for (const lang of preferred) {
+    if (available.includes(lang)) {
+      logger.info(
+        { event: "download.language_resolved", context: "download", language: lang },
+        "language resolved from preferences",
+      );
+      return lang;
+    }
+  }
+
+  if (nonTty) {
+    throw new CliError(
+      `no preferred language available (preferred: ${preferred.join(", ")}; available: ${available.join(", ")}); set preferred_languages in scanldr.json`,
+      2,
+    );
+  }
+
+  return promptLanguagePick(available);
+}

--- a/src/commands/download/range.test.ts
+++ b/src/commands/download/range.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { CliError, expandIntegerRange, parseRangeSet } from "./range.ts";
+import { CliError } from "@plugins/errors/index.ts";
+import { expandIntegerRange, parseRangeSet } from "./range.ts";
 
 describe("parseRangeSet — happy paths", () => {
   test("single integer", () => {

--- a/src/commands/download/range.test.ts
+++ b/src/commands/download/range.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { CliError, expandIntegerRange, parseRangeSet } from "./range.ts";
+
+describe("parseRangeSet — happy paths", () => {
+  test("single integer", () => {
+    const { values } = parseRangeSet("1");
+    expect([...values]).toEqual(["1"]);
+  });
+
+  test("single fractional", () => {
+    const { values } = parseRangeSet("1.5");
+    expect([...values]).toEqual(["1.5"]);
+  });
+
+  test("integer range", () => {
+    const { values } = parseRangeSet("1-3");
+    expect([...values]).toEqual(["1", "2", "3"]);
+  });
+
+  test("comma-separated list", () => {
+    const { values } = parseRangeSet("1,3,7");
+    expect([...values]).toEqual(["1", "3", "7"]);
+  });
+
+  test("range + specific", () => {
+    const { values } = parseRangeSet("1-3,5");
+    expect([...values]).toEqual(["1", "2", "3", "5"]);
+  });
+
+  test("duplicates are deduped", () => {
+    const { values } = parseRangeSet("1-3,2");
+    expect([...values]).toEqual(["1", "2", "3"]);
+  });
+
+  test("special token none", () => {
+    const { values } = parseRangeSet("none");
+    expect([...values]).toEqual(["none"]);
+  });
+
+  test("large range", () => {
+    const { values } = parseRangeSet("1-5,8,10");
+    expect([...values]).toEqual(["1", "2", "3", "4", "5", "8", "10"]);
+  });
+});
+
+describe("parseRangeSet — error cases", () => {
+  test("empty string", () => {
+    expect(() => parseRangeSet("")).toThrow(CliError);
+  });
+
+  test("leading comma", () => {
+    expect(() => parseRangeSet(",1")).toThrow(CliError);
+  });
+
+  test("trailing comma", () => {
+    expect(() => parseRangeSet("1,")).toThrow(CliError);
+  });
+
+  test("dangling trailing dash", () => {
+    expect(() => parseRangeSet("1-")).toThrow(CliError);
+  });
+
+  test("dangling leading dash", () => {
+    expect(() => parseRangeSet("-3")).toThrow(CliError);
+  });
+
+  test("lower bound greater than upper bound", () => {
+    expect(() => parseRangeSet("5-3")).toThrow(CliError);
+  });
+
+  test("fractional range bounds", () => {
+    expect(() => parseRangeSet("1-2.5")).toThrow(CliError);
+  });
+
+  test("fractional lower bound in range", () => {
+    expect(() => parseRangeSet("1.5-3")).toThrow(CliError);
+  });
+
+  test("invalid characters", () => {
+    expect(() => parseRangeSet("abc")).toThrow(CliError);
+  });
+
+  test("whitespace in range", () => {
+    expect(() => parseRangeSet("1, 2")).toThrow(CliError);
+  });
+});
+
+describe("expandIntegerRange", () => {
+  test("simple range", () => {
+    expect(expandIntegerRange("1", "3")).toEqual(["1", "2", "3"]);
+  });
+
+  test("single element range", () => {
+    expect(expandIntegerRange("5", "5")).toEqual(["5"]);
+  });
+});

--- a/src/commands/download/range.ts
+++ b/src/commands/download/range.ts
@@ -1,16 +1,6 @@
+import { CliError } from "@plugins/errors/index.ts";
 import type { ParsedRange } from "./types.ts";
 
-class CliError extends Error {
-  constructor(
-    message: string,
-    public readonly exitCode: number = 2,
-  ) {
-    super(message);
-    this.name = "CliError";
-  }
-}
-
-// Re-export so callers can import from this module
 export { CliError };
 
 function isPositiveNumber(s: string): boolean {

--- a/src/commands/download/range.ts
+++ b/src/commands/download/range.ts
@@ -1,0 +1,109 @@
+import type { ParsedRange } from "./types.ts";
+
+class CliError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: number = 2,
+  ) {
+    super(message);
+    this.name = "CliError";
+  }
+}
+
+// Re-export so callers can import from this module
+export { CliError };
+
+function isPositiveNumber(s: string): boolean {
+  return /^\d+(\.\d+)?$/.test(s) && Number(s) > 0;
+}
+
+function isFractional(s: string): boolean {
+  return s.includes(".");
+}
+
+export function expandIntegerRange(lo: string, hi: string): string[] {
+  const loN = Number(lo);
+  const hiN = Number(hi);
+  const result: string[] = [];
+  for (let i = loN; i <= hiN; i++) {
+    result.push(String(i));
+  }
+  return result;
+}
+
+export function parseRangeSet(input: string): ParsedRange {
+  if (!input || input.length === 0) {
+    throw new CliError("volume range must not be empty");
+  }
+
+  // "none" is the special MangaDex no-volume bucket — but deferred per spec
+  if (input === "none") {
+    return { values: new Set(["none"]) };
+  }
+
+  // Leading/trailing comma
+  if (input.startsWith(",") || input.endsWith(",")) {
+    throw new CliError(`invalid volume range "${input}": leading or trailing comma`);
+  }
+
+  const elements = input.split(",");
+  const values = new Set<string>();
+
+  for (const element of elements) {
+    if (element === "") {
+      throw new CliError(`invalid volume range "${input}": empty element (double comma?)`);
+    }
+
+    // Check for a dash (range) — but not a leading dash
+    const dashIdx = element.indexOf("-");
+
+    if (dashIdx === -1) {
+      // bare number
+      if (!isPositiveNumber(element)) {
+        throw new CliError(`invalid volume range "${input}": "${element}" is not a valid number`);
+      }
+      values.add(element);
+    } else if (dashIdx === 0) {
+      throw new CliError(`invalid volume range "${input}": dangling leading dash in "${element}"`);
+    } else {
+      // potential range "lo-hi"
+      const lo = element.slice(0, dashIdx);
+      const hi = element.slice(dashIdx + 1);
+
+      if (!hi || hi.length === 0) {
+        throw new CliError(
+          `invalid volume range "${input}": dangling trailing dash in "${element}"`,
+        );
+      }
+
+      if (!isPositiveNumber(lo)) {
+        throw new CliError(`invalid volume range "${input}": "${lo}" is not a valid number`);
+      }
+      if (!isPositiveNumber(hi)) {
+        throw new CliError(`invalid volume range "${input}": "${hi}" is not a valid number`);
+      }
+
+      // Fractional ranges are ambiguous
+      if (isFractional(lo) || isFractional(hi)) {
+        throw new CliError(
+          `invalid volume range "${input}": fractional bounds in a range are ambiguous (use a bare value like "1.5" instead)`,
+        );
+      }
+
+      const loN = Number(lo);
+      const hiN = Number(hi);
+
+      if (loN > hiN) {
+        throw new CliError(
+          `invalid volume range "${input}": lower bound ${lo} is greater than upper bound ${hi}`,
+        );
+      }
+
+      for (const v of expandIntegerRange(lo, hi)) {
+        values.add(v);
+      }
+    }
+  }
+
+  return { values };
+}

--- a/src/commands/download/range.ts
+++ b/src/commands/download/range.ts
@@ -1,8 +1,6 @@
 import { CliError } from "@plugins/errors/index.ts";
 import type { ParsedRange } from "./types.ts";
 
-export { CliError };
-
 function isPositiveNumber(s: string): boolean {
   return /^\d+(\.\d+)?$/.test(s) && Number(s) > 0;
 }

--- a/src/commands/download/slug.test.ts
+++ b/src/commands/download/slug.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { toSlug } from "./index.ts";
+import { toSlug } from "./slug.ts";
 
 describe("toSlug", () => {
   test("simple ASCII title", () => {

--- a/src/commands/download/slug.test.ts
+++ b/src/commands/download/slug.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { toSlug } from "./index.ts";
+
+describe("toSlug", () => {
+  test("simple ASCII title", () => {
+    expect(toSlug("Berserk")).toBe("berserk");
+  });
+
+  test("title with colon and apostrophe", () => {
+    expect(toSlug("One Piece: Pirate's Tale")).toBe("one-piece-pirate-s-tale");
+  });
+
+  test("title with em-dash and non-ASCII script stripped", () => {
+    // Korean part is stripped to nothing, leaving only the ASCII portion
+    expect(toSlug("Solo Leveling — 나 혼자만 레벨업")).toBe("solo-leveling");
+  });
+
+  test("accented character normalized", () => {
+    expect(toSlug("Vão")).toBe("vao");
+  });
+
+  test("all-non-ASCII title falls back to 'untitled'", () => {
+    const warnMsgs: string[] = [];
+    const logger = {
+      warn: (_obj: Record<string, unknown>, msg: string) => {
+        warnMsgs.push(msg);
+      },
+    };
+    expect(toSlug("나 혼자만", logger)).toBe("untitled");
+    expect(warnMsgs.length).toBe(1);
+  });
+
+  test("empty string falls back to 'untitled'", () => {
+    expect(toSlug("")).toBe("untitled");
+  });
+});

--- a/src/commands/download/slug.ts
+++ b/src/commands/download/slug.ts
@@ -1,0 +1,23 @@
+/** kebab-case a manga title for use as filesystem slug */
+export function toSlug(
+  title: string,
+  logger?: { warn: (fields: Record<string, unknown>, msg: string) => void },
+): string {
+  const slug = title
+    .normalize("NFKD")
+    // Strip combining diacritical marks (e.g. accents) after NFKD decomposition
+    .replace(/\p{Mn}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (slug === "") {
+    logger?.warn(
+      { event: "download.slug_empty", context: "download", title },
+      "title produced an empty slug; falling back to 'untitled'",
+    );
+    return "untitled";
+  }
+
+  return slug;
+}

--- a/src/commands/download/types.ts
+++ b/src/commands/download/types.ts
@@ -1,0 +1,35 @@
+import type { Config } from "@plugins/config/index.ts";
+import type { Db } from "@plugins/db/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+
+export interface ParsedRange {
+  /** Resolved tokens. Numeric tokens stored as strings; special token "none". */
+  values: Set<string>;
+}
+
+export interface ResolveLanguageInput {
+  preferred: readonly string[];
+  available: readonly string[];
+  nonTty: boolean;
+  logger: Logger;
+}
+
+export interface DownloadArgs {
+  manga: string;
+  volume: string;
+  format: "cbz" | "zip";
+  outDir: string;
+  quality: "data" | "data-saver";
+  concurrency: number;
+  delayMs: number;
+  force: boolean;
+  noTrack: boolean;
+  dryRun: boolean;
+  nonTty: boolean;
+}
+
+export interface DownloadContext {
+  logger: Logger;
+  config: Config;
+  db: Db;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { loadConfig } from "@plugins/config/index.ts";
 import type { Config } from "@plugins/config/index.ts";
 import { openDb, runMigrations } from "@plugins/db/index.ts";
 import type { Db } from "@plugins/db/index.ts";
+import { CliError } from "@plugins/errors/index.ts";
 import { type LogFormat, type LogLevel, type Logger, createLogger } from "@plugins/logger/index.ts";
 
 const VERSION = "0.0.0";
@@ -43,16 +44,6 @@ class NotImplementedError extends Error {
   constructor(command: string) {
     super(`'${command}' is not implemented yet — scaffold only.`);
     this.name = "NotImplementedError";
-  }
-}
-
-class CliError extends Error {
-  constructor(
-    message: string,
-    public readonly exitCode: number = 2,
-  ) {
-    super(message);
-    this.name = "CliError";
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { parseArgs } from "node:util";
+import { runDownload } from "@commands/download/index.ts";
 import { runList } from "@commands/list/index.ts";
 import { createMangaDexClient } from "@integrations/mangadex/client/index.ts";
 import { createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
@@ -100,8 +101,88 @@ const handlers: Record<string, Handler> = {
       client,
     );
   },
-  download: () => {
-    throw new NotImplementedError("download");
+  download: async (rest, ctx) => {
+    const { values: dlValues, positionals: dlPos } = parseArgs({
+      args: rest,
+      allowPositionals: true,
+      strict: false,
+      options: {
+        volume: { type: "string" },
+        chapter: { type: "string" },
+        format: { type: "string" },
+        out: { type: "string" },
+        quality: { type: "string" },
+        concurrency: { type: "string" },
+        "delay-ms": { type: "string" },
+        force: { type: "boolean" },
+        "no-track": { type: "boolean" },
+        "dry-run": { type: "boolean" },
+        "non-tty": { type: "boolean" },
+      },
+    });
+
+    const manga = dlPos[0];
+    if (!manga) {
+      throw new CliError("Usage: scanldr download <manga> --volume <range> [flags]", 2);
+    }
+
+    if (dlValues.volume !== undefined && dlValues.chapter !== undefined) {
+      throw new CliError("--volume and --chapter are mutually exclusive", 2);
+    }
+
+    if (dlValues.chapter !== undefined) {
+      throw new NotImplementedError("download --chapter");
+    }
+
+    if (dlValues.volume === undefined) {
+      throw new CliError("--volume <range> is required (--chapter support coming in #15)", 2);
+    }
+
+    const rawFormat = dlValues.format;
+    const format =
+      rawFormat === "zip" ? "zip" : rawFormat === "cbz" ? "cbz" : ctx.config.default_format;
+
+    const rawQuality = dlValues.quality;
+    const quality =
+      rawQuality === "data-saver"
+        ? "data-saver"
+        : rawQuality === "data"
+          ? "data"
+          : ctx.config.download_quality;
+
+    const rawConcurrency = dlValues.concurrency;
+    const concurrency =
+      typeof rawConcurrency === "string" && /^\d+$/.test(rawConcurrency)
+        ? Number(rawConcurrency)
+        : ctx.config.image_concurrency;
+
+    const rawDelay = dlValues["delay-ms"];
+    const delayMs =
+      typeof rawDelay === "string" && /^\d+$/.test(rawDelay)
+        ? Number(rawDelay)
+        : ctx.config.chapter_delay_ms;
+
+    const http = createMangaDexHttp({ logger: ctx.logger, config: ctx.config });
+    const client = createMangaDexClient(http);
+
+    await runDownload(
+      {
+        manga,
+        volume: dlValues.volume as string,
+        format,
+        outDir: typeof dlValues.out === "string" ? dlValues.out : ctx.config.default_out,
+        quality,
+        concurrency,
+        delayMs,
+        force: dlValues.force === true,
+        noTrack: dlValues["no-track"] === true,
+        dryRun: dlValues["dry-run"] === true,
+        nonTty: dlValues["non-tty"] === true || !process.stdout.isTTY,
+      },
+      { logger: ctx.logger, config: ctx.config, db: ctx.db },
+      client,
+      http,
+    );
   },
   update: () => {
     throw new NotImplementedError("update");

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const handlers: Record<string, Handler> = {
     const { values: listValues, positionals: listPos } = parseArgs({
       args: rest,
       allowPositionals: true,
-      strict: false,
+      strict: true,
       options: {
         volume: { type: "string" },
         chapter: { type: "string" },
@@ -96,7 +96,7 @@ const handlers: Record<string, Handler> = {
     const { values: dlValues, positionals: dlPos } = parseArgs({
       args: rest,
       allowPositionals: true,
-      strict: false,
+      strict: true,
       options: {
         volume: { type: "string" },
         chapter: { type: "string" },
@@ -225,11 +225,44 @@ export function resolveLogConfig(values: {
   return { level, format };
 }
 
-async function main(argv: string[]): Promise<void> {
-  const { positionals, values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    strict: false,
+/**
+ * Walk argv to find the first non-flag token (the command name).
+ * Everything before it goes into preArgs (parsed only for global boolean flags).
+ * Everything after it is passed verbatim as postArgs to the handler's own parseArgs.
+ *
+ * This avoids the bug where strict:false at the top level coerces
+ * "--volume 13" into { volume: true } and pushes "13" into positionals.
+ */
+function splitArgv(argv: string[]): {
+  preArgs: string[];
+  command: string | undefined;
+  postArgs: string[];
+} {
+  const preArgs: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (!tok) {
+      i++;
+      continue;
+    }
+    if (tok.startsWith("-")) {
+      // Only known global boolean flags are expected pre-command; collect them all anyway.
+      preArgs.push(tok);
+    } else {
+      return { preArgs, command: tok, postArgs: argv.slice(i + 1) };
+    }
+  }
+  return { preArgs, command: undefined, postArgs: [] };
+}
+
+export async function main(argv: string[]): Promise<void> {
+  const { preArgs, command, postArgs } = splitArgv(argv);
+
+  // Parse only global boolean flags from the pre-command slice.
+  const { values } = parseArgs({
+    args: preArgs,
+    allowPositionals: false,
+    strict: false, // tolerate unknown flags silently; handlers validate their own slice
     options: {
       help: { type: "boolean", short: "h" },
       version: { type: "boolean", short: "v" },
@@ -243,8 +276,6 @@ async function main(argv: string[]): Promise<void> {
     process.stdout.write(`scanldr ${VERSION}\n`);
     return;
   }
-
-  const [command, ...rest] = positionals;
 
   if (!command || command === "help" || values.help) {
     process.stdout.write(USAGE);
@@ -264,7 +295,9 @@ async function main(argv: string[]): Promise<void> {
   const db = openDb(config.db_path);
   runMigrations(db);
 
-  return handler(rest, { logger, db, config });
+  // postArgs is everything after the command — verbatim, so handler's parseArgs
+  // sees the real flag values (e.g. --volume "13" not boolean true).
+  return handler(postArgs, { logger, db, config });
 }
 
 if (import.meta.main) {

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -91,7 +91,7 @@ async function sendReport(
 }
 
 /**
- * Factory returning an imageFetcher compatible with DownloadVolumeInput.imageFetcher.
+ * Factory returning an imageFetcher compatible with ChapterInput.imageFetcher.
  * chapterId is required to re-fetch a fresh CDN URL on each retry.
  */
 export function mangadexImageFetcher(

--- a/src/modules/downloader/downloader.test.ts
+++ b/src/modules/downloader/downloader.test.ts
@@ -39,12 +39,17 @@ function makeJpeg(seed: number, size = 64): Uint8Array {
 }
 
 /** Build a trivial chapter with n pages. */
-function makeChapter(id: string, num: number, pageCount: number): ChapterInput {
+function makeChapter(
+  id: string,
+  num: number,
+  pageCount: number,
+  fetcher?: (ref: ImageRef) => Promise<Uint8Array>,
+): ChapterInput {
   const pages: ImageRef[] = [];
   for (let i = 1; i <= pageCount; i++) {
     pages.push({ url: `https://cdn.example.com/${id}/page-${i}.png`, page: i });
   }
-  return { id, num, pages };
+  return { id, num, pages, imageFetcher: fetcher ?? makeFetcher() };
 }
 
 /** A fetcher that returns deterministic PNG bytes per URL. */
@@ -88,7 +93,6 @@ describe("downloadVolume — archive structure", () => {
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
 
     expect(result.outputPath).toBe(
@@ -113,7 +117,6 @@ describe("downloadVolume — archive structure", () => {
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
 
     expect(result.outputPath).toContain("volume-001.cbz");
@@ -130,7 +133,6 @@ describe("downloadVolume — archive structure", () => {
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
     expect(result.outputPath).toContain("volume-103.cbz");
   });
@@ -156,7 +158,6 @@ describe("downloadVolume — page ordering", () => {
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
 
     const raw = await readFile(result.outputPath);
@@ -178,7 +179,6 @@ describe("downloadVolume — page ordering", () => {
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
 
     const raw = await readFile(result.outputPath);
@@ -214,12 +214,11 @@ describe("downloadVolume — concurrency limit", () => {
       format: "cbz",
       slug: "concurrency-test",
       volumeNumber: 1,
-      chapters: [makeChapter("ch-1", 1, pages)],
+      chapters: [makeChapter("ch-1", 1, pages, fetcher)],
       imageConcurrency: limit,
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: fetcher,
     });
 
     expect(maxObserved).toBeLessThanOrEqual(limit);
@@ -244,12 +243,11 @@ describe("downloadVolume — dry-run", () => {
       format: "cbz",
       slug: "dry-test",
       volumeNumber: 5,
-      chapters: [makeChapter("ch-050", 50, 3)],
+      chapters: [makeChapter("ch-050", 50, 3, fetcher)],
       imageConcurrency: 2,
       delayMs: 0,
       dryRun: true,
       logger: noopLogger,
-      imageFetcher: fetcher,
     });
 
     expect(fetchCalled).toBe(false);
@@ -270,7 +268,6 @@ describe("downloadVolume — dry-run", () => {
       delayMs: 0,
       dryRun: true,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
 
     // outDir should still be empty
@@ -299,12 +296,11 @@ describe("downloadVolume — interruption simulation", () => {
         format: "cbz",
         slug: "interrupted",
         volumeNumber: 1,
-        chapters: [makeChapter("ch-1", 1, 5)],
+        chapters: [makeChapter("ch-1", 1, 5, fetcher)],
         imageConcurrency: 1,
         delayMs: 0,
         dryRun: false,
         logger: noopLogger,
-        imageFetcher: fetcher,
       }),
     ).rejects.toThrow("simulated network failure");
 
@@ -335,7 +331,6 @@ describe("downloadVolume — result metadata", () => {
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: makeFetcher(),
     });
 
     // chapterIds is derived from input chapters array (not sorted order)
@@ -354,12 +349,11 @@ describe("downloadVolume — extension detection from bytes", () => {
       format: "cbz",
       slug: "ext-detect",
       volumeNumber: 1,
-      chapters: [makeChapter("c1", 1, 3)],
+      chapters: [makeChapter("c1", 1, 3, async (_ref) => makePng(1))],
       imageConcurrency: 1,
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: async (_ref) => makePng(1),
     });
 
     const raw = await readFile(result.outputPath);
@@ -376,12 +370,11 @@ describe("downloadVolume — extension detection from bytes", () => {
       format: "cbz",
       slug: "ext-fallback",
       volumeNumber: 1,
-      chapters: [makeChapter("c1", 1, 2)],
+      chapters: [makeChapter("c1", 1, 2, async (_ref) => makeJpeg(1))],
       imageConcurrency: 1,
       delayMs: 0,
       dryRun: false,
       logger: noopLogger,
-      imageFetcher: async (_ref) => makeJpeg(1),
     });
 
     const raw = await readFile(result.outputPath);

--- a/src/modules/downloader/service.ts
+++ b/src/modules/downloader/service.ts
@@ -27,11 +27,10 @@ async function fetchChapterPages(
   chapter: ChapterInput,
   sem: Semaphore,
   globalOffset: number,
-  fetcher: (ref: ImageRef) => Promise<Uint8Array>,
 ): Promise<Array<{ filename: string; data: Uint8Array }>> {
   const tasks = chapter.pages.map((ref, localIdx) => {
     const globalIdx = globalOffset + localIdx;
-    return fetchPage(ref, fetcher, sem).then(({ data, ext }) => ({
+    return fetchPage(ref, chapter.imageFetcher, sem).then(({ data, ext }) => ({
       filename: `${pad(globalIdx + 1, 4)}${ext}`,
       data,
     }));
@@ -50,7 +49,6 @@ export async function downloadVolume(input: DownloadVolumeInput): Promise<Downlo
     delayMs,
     dryRun,
     logger,
-    imageFetcher,
   } = input;
 
   const volumePad = pad(volumeNumber, 3);
@@ -96,7 +94,7 @@ export async function downloadVolume(input: DownloadVolumeInput): Promise<Downlo
       "downloading chapter",
     );
 
-    const pages = await fetchChapterPages(chapter, sem, globalOffset, imageFetcher);
+    const pages = await fetchChapterPages(chapter, sem, globalOffset);
     for (const { filename: fname, data } of pages) {
       zipEntries[fname] = data;
     }

--- a/src/modules/downloader/types.ts
+++ b/src/modules/downloader/types.ts
@@ -9,6 +9,7 @@ export interface ChapterInput {
   id: string;
   num: number;
   pages: ImageRef[];
+  imageFetcher: (ref: ImageRef) => Promise<Uint8Array>;
 }
 
 export interface DownloadVolumeInput {
@@ -21,7 +22,6 @@ export interface DownloadVolumeInput {
   delayMs: number;
   dryRun: boolean;
   logger: Logger;
-  imageFetcher: (ref: ImageRef) => Promise<Uint8Array>;
 }
 
 export interface DownloadVolumeResult {

--- a/src/plugins/errors/errors.test.ts
+++ b/src/plugins/errors/errors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { CliError } from "./index.ts";
+
+describe("CliError", () => {
+  test("name is CliError", () => {
+    expect(new CliError("boom").name).toBe("CliError");
+  });
+
+  test("default exitCode is 2", () => {
+    expect(new CliError("boom").exitCode).toBe(2);
+  });
+
+  test("custom exitCode is preserved", () => {
+    expect(new CliError("boom", 5).exitCode).toBe(5);
+  });
+
+  test("instanceof CliError is true", () => {
+    expect(new CliError("boom")).toBeInstanceOf(CliError);
+  });
+});

--- a/src/plugins/errors/index.ts
+++ b/src/plugins/errors/index.ts
@@ -7,3 +7,13 @@ export class ConfigError extends Error {
     super(message);
   }
 }
+
+export class CliError extends Error {
+  override readonly name = "CliError";
+  constructor(
+    message: string,
+    public readonly exitCode: number = 2,
+  ) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## What this PR does

First end-to-end download path. After this lands, `scanldr download "X" --volume <range>` produces one `.cbz` per volume, with atomic history writes and the full set of override flags wired.

## Why it exists

The CLI scaffolding for `download` was a `NotImplementedError` placeholder. With auth (#40), config (#5), logger (#6), MangaDex client (#8), at-home server (#41), downloader module (#12), and history (#10) all already merged, this PR is the wiring glue that turns those pieces into a usable command.

Ref: #14

## How it works internally

### Pipeline (per `docs/flows/download_flow.md`)

1. **Parse `--volume <range>`** — `src/commands/download/range.ts`, full §4.1 grammar (single, list, range, fractional bare values; whitespace, `5-3`, `1-`, `,1`, fractional ranges all `CliError`). `none` token rejected with a clear "not yet supported" message until the downloader supports the no-volume bucket.
2. **Resolve title** via `MangaDexClient.resolveTitleToId`. Multi-candidate behavior mirrors `list`: TTY prompts; non-TTY fails with the numbered list.
3. **`aggregateVolumes` + `feedChapters`** in the user's `preferred_languages`.
4. **Resolve language** — `src/commands/download/language.ts`. Walks `preferred_languages` in order, first available wins silently. No match + TTY → prompts. No match + non-TTY → `CliError`. Empty available set → `CliError` with `scanldr list "<manga>"` hint.
5. **Per volume in range:**
   - History gate via `isVolumeFullyDownloaded`. Skip with info log unless `--force`.
   - **External-chapter early refuse** (the deferred AC from #48): if any chapter in the volume has `externalUrl !== null`, throw `CliError` with the host and URL; no partial work is done.
   - For each chapter, build a fresh `mangadexImageFetcher(chapter.id, …)` and attach it to `ChapterInput.imageFetcher`. The downloader iterates chapters in order and calls `chapter.imageFetcher(ref)` directly — no global routing, no offset arithmetic, no shared fetcher.
   - Hand `DownloadVolumeInput` to `downloadVolume`. The downloader writes `.temp` files per page, packages the volume, renames `.temp` → final on success.
   - Unless `--no-track` or `--dry-run`, call `recordDownloadedChapters(db, rows)` in a single transaction. One row per chapter, all eight columns populated (`mangaId`, `mangaTitle`, `volume`, `chapterId`, `chapterNum`, `source: "mangadex"`, `language`, `downloadedAt`).

### Per-chapter image fetcher (P0 fix during review)

The original wiring used a single top-level fetcher with a global page-offset routing closure. That broke for multi-chapter volumes because `ImageRef.page` is local per chapter. The fix moves `imageFetcher` from `DownloadVolumeInput` to `ChapterInput`, deletes the routing closure, and lets the downloader call `chapter.imageFetcher(ref)` directly. The downloader already iterates chapters in order, so it owns the only sort that matters.

### `CliError` consolidation

`CliError` lives in `src/plugins/errors/index.ts` alongside `ConfigError`. All previous local declarations (`src/index.ts`, `src/commands/download/range.ts`) were removed. `instanceof CliError` in the entry-point catch now correctly routes to `process.exit(err.exitCode)`.

### `toSlug`

Title → slug via `NFKD` normalization + `\p{Mn}` strip + lowercase + non-`[a-z0-9]` → `-` + dedupe + trim. Fallback to `"untitled"` (with a `warn` log) when normalization yields an empty string (all non-Latin script). Tests cover Berserk, "One Piece: Pirate's Tale", "Solo Leveling — 나 혼자만 레벨업", "Vão", and empty-input.

## What did not change

- The downloader module's contract for `.temp → final` rename, page packaging, image concurrency, and zero-padded page filenames. The only API change there is `imageFetcher` moving from volume to chapter.
- The at-home server fetch / retry / report flow.
- The history table and the `recordDownloadedChapters` API.
- The 429 / Retry-After handling in the http client.
- `readableAt` (#47), `externalUrl` annotation (#48), `mangaTitle` propagation (#11) — all preserved.

## ACs satisfied

- [x] All sequence-diagram steps in `docs/flows/download_flow.md` (MangaDex happy path) exercised end-to-end
- [x] `--force` re-downloads even if chapters are in history
- [x] `--no-track` skips the history insert
- [x] `--dry-run` plans without writing files or history
- [x] `--out`, `--quality`, `--format`, `--concurrency` honored over config defaults
- [x] Range parsing follows `docs/overviewer.md` §4.1 grammar exactly
- [x] Integration test asserts produced archive contents (file count, `0001..N` zero-padded names, monotonic ordering across chapter boundaries) and history rows (all 8 columns)
- [x] Atomic history: mid-volume failure leaves no `.cbz` and zero history rows for that volume
- [x] External-chapter early refuse (deferred AC from #48 — now implemented)

## ACs deferred (explicit out-of-scope)

- [ ] `--chapter` flag — issue #15
- [ ] `--volume none` token — `CliError` "not yet supported" until the downloader supports the no-volume bucket
- [ ] Fallback to mangakakalot — issues #21–#23
- [ ] `update` / `sync` integration — issues #16/#17
- [ ] TTY-path test for `resolveLanguage` (readline mock) — follow-up; the non-TTY branch is exercised via integration tests

## Test checklist

- [x] `range.test.ts` — 20 cases (every grammar happy path + every documented error)
- [x] `language.test.ts` — preferred match, non-TTY fail, empty-available guard
- [x] `slug.test.ts` — accents, non-ASCII, empty fallback
- [x] `errors.test.ts` — `CliError` shape (`name`, default `exitCode`, custom `exitCode`, `instanceof`)
- [x] `download.test.ts` — happy path (single + multi-chapter), `--force`, `--no-track`, `--dry-run`, atomic-on-failure, external-chapter refuse, history assertions, `.cbz` content assertions
- [x] `bun test` — 258 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- The most invasive change is `imageFetcher` moving from `DownloadVolumeInput` to `ChapterInput`. This is intentional — see "Per-chapter image fetcher" above. Existing downloader tests were updated to pass per-chapter fetchers; the contract is sharper and the multi-chapter integration test locks it in.
- `runDownload` is ~250 LOC. Extracting steps 2 (resolve title), 5 (per-volume body), and the chapter-input builder is a fair P3 follow-up if you'd prefer smaller units.
- `toSlug` lives in `src/commands/download/index.ts` while its tests are in `slug.test.ts`. Moving the function to its own `slug.ts` (matching `range.ts` / `language.ts`) is a fair P3 follow-up.

## Closes

Ref: #14

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/` (no schema or convention changes; `docs/flows/download_flow.md` already specified the behavior this PR implements)