### PR TITLE
feat(cli): wire download --chapter (#15)

### DIFF
--- a/src/cli-routing.test.ts
+++ b/src/cli-routing.test.ts
@@ -85,10 +85,12 @@ describe("download: required-flag validation", () => {
     expect(r.stderr).toMatch(/mutually exclusive/i);
   });
 
-  test("--chapter alone → exit 2 (not yet implemented)", async () => {
+  test("--chapter alone → exits (now implemented; exits non-zero only on network/resolve error)", async () => {
+    // --chapter is now implemented. In non-TTY mode with no network, it will try to resolve the manga
+    // and fail at the MangaDex API level. We just assert mutual exclusion no longer triggers.
     const r = await run(["download", "Dandadan", "--chapter", "5", "--non-tty"]);
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toMatch(/--chapter/i);
+    // Must NOT be a mutual-exclusion error
+    expect(r.stderr).not.toMatch(/mutually exclusive/i);
   });
 
   test("missing manga positional → exit 2 with usage", async () => {

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -597,6 +597,18 @@ describe("runDownload — range parsing", () => {
       runDownload(baseArgs({ volume: "none" }), baseCtx(), makeClient(), makeFullHttpClient()),
     ).rejects.toBeInstanceOf(CliError);
   });
+
+  test("--chapter none throws CliError (exit-code 2)", async () => {
+    const err = await runDownload(
+      baseArgs({ volume: undefined, chapter: "none" }),
+      baseCtx(),
+      makeClient(),
+      makeFullHttpClient(),
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).exitCode).toBe(2);
+    expect((err as CliError).message).toMatch(/not yet supported/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -249,7 +249,7 @@ describe("runDownload — force", () => {
     let loggedSkip = false;
     const captureLogger: Logger = {
       info: (_obj: unknown, msg?: string) => {
-        if (msg?.includes("skipping volume")) loggedSkip = true;
+        if (msg?.includes("skipping")) loggedSkip = true;
       },
       warn: () => {},
       error: () => {},
@@ -596,5 +596,208 @@ describe("runDownload — range parsing", () => {
     await expect(
       runDownload(baseArgs({ volume: "none" }), baseCtx(), makeClient(), makeFullHttpClient()),
     ).rejects.toBeInstanceOf(CliError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --chapter tests
+// ---------------------------------------------------------------------------
+
+describe("runDownload --chapter — happy path 3-chapter range", () => {
+  test("produces 3 archives with correct names, pages, and history", async () => {
+    // ch1 → vol "1", ch2 → vol "1", ch3 → vol "2"
+    const ch1 = makeChapterRef({ id: "ch-1", volume: "1", chapter: "1" });
+    const ch2 = makeChapterRef({ id: "ch-2", volume: "1", chapter: "2" });
+    const ch3 = makeChapterRef({ id: "ch-3", volume: "2", chapter: "3" });
+
+    const client = makeClient({
+      aggregateVolumes: async () => [
+        makeVolumeRef("1", ["ch-1", "ch-2"]),
+        makeVolumeRef("2", ["ch-3"]),
+      ],
+      feedChapters: async () => [ch1, ch2, ch3],
+    });
+
+    // Each chapter has exactly 1 page
+    const http: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path.startsWith("/at-home/server/")) {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "abc", data: ["page1.jpg"], dataSaver: [] },
+          };
+        }
+        throw new Error(`Unexpected: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs({ volume: undefined, chapter: "1-3" }), baseCtx(), client, http);
+    });
+
+    // Assert all 3 archives exist with correct names
+    const slug = "test-manga";
+    for (const [num, name] of [
+      ["1", "001"],
+      ["2", "002"],
+      ["3", "003"],
+    ] as const) {
+      const cbzPath = join(tmpDir, slug, `${slug}-chapter-${name}.cbz`);
+      const exists = await Bun.file(cbzPath).exists();
+      expect(exists).toBe(true);
+
+      const raw = new Uint8Array(await Bun.file(cbzPath).arrayBuffer());
+      const entries = unzipSync(raw);
+      const names = Object.keys(entries).sort();
+      expect(names).toHaveLength(1);
+      expect(names[0]).toBe("0001.jpg");
+      void num; // used above for clarity
+    }
+
+    // Assert 3 history rows with correct volumes
+    const history = listHistory(db);
+    expect(history).toHaveLength(3);
+
+    const byChapter = new Map(history.map((r) => [r.chapterId, r]));
+    expect(byChapter.get("ch-1")).toMatchObject({
+      volume: "1",
+      chapterNum: "1",
+      source: "mangadex",
+      language: "en",
+      mangaId: "manga-id-1",
+    });
+    expect(byChapter.get("ch-2")).toMatchObject({ volume: "1", chapterNum: "2" });
+    expect(byChapter.get("ch-3")).toMatchObject({ volume: "2", chapterNum: "3" });
+  });
+});
+
+describe("runDownload --chapter — decimal chapter", () => {
+  test("decimal chapter filename uses padded integer part", async () => {
+    const ch = makeChapterRef({ id: "ch-185", volume: "3", chapter: "18.5" });
+    const client = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("3", ["ch-185"])],
+      feedChapters: async () => [ch],
+    });
+
+    const http: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path.startsWith("/at-home/server/")) {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "abc", data: ["page1.jpg"], dataSaver: [] },
+          };
+        }
+        throw new Error(`Unexpected: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs({ volume: undefined, chapter: "18.5" }), baseCtx(), client, http);
+    });
+
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-chapter-018.5.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(true);
+  });
+});
+
+describe("runDownload --chapter — null volume chapter", () => {
+  test("chapter with null volume writes volume='none' in history", async () => {
+    const ch = makeChapterRef({ id: "ch-7", volume: null, chapter: "7" });
+    const client = makeClient({
+      aggregateVolumes: async () => [],
+      feedChapters: async () => [ch],
+    });
+
+    const http: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path.startsWith("/at-home/server/")) {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "abc", data: ["page1.jpg"], dataSaver: [] },
+          };
+        }
+        throw new Error(`Unexpected: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs({ volume: undefined, chapter: "7" }), baseCtx(), client, http);
+    });
+
+    const history = listHistory(db);
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({ volume: "none", chapterId: "ch-7" });
+
+    // Filename uses chapter number, not "none"
+    const cbzPath = join(tmpDir, "test-manga", "test-manga-chapter-007.cbz");
+    const exists = await Bun.file(cbzPath).exists();
+    expect(exists).toBe(true);
+  });
+});
+
+describe("runDownload — mutual exclusion", () => {
+  test("passing both --volume and --chapter throws CliError with exit code 2", async () => {
+    await expect(
+      runDownload(
+        baseArgs({ volume: "1", chapter: "1" }),
+        baseCtx(),
+        makeClient(),
+        makeFullHttpClient(),
+      ),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+});
+
+describe("runDownload --chapter — external chapter refused", () => {
+  test("external chapter in --chapter mode throws CliError", async () => {
+    const extUrl = "https://mangaplus.shueisha.co.jp/viewer/999";
+    const ch = makeChapterRef({ id: "ch-ext", volume: "1", chapter: "5", externalUrl: extUrl });
+    const client = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("1", ["ch-ext"])],
+      feedChapters: async () => [ch],
+    });
+
+    await expect(
+      runDownload(
+        baseArgs({ volume: undefined, chapter: "5" }),
+        baseCtx(),
+        client,
+        makeFullHttpClient(),
+      ),
+    ).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("external chapter warn event emitted before throw in --chapter mode", async () => {
+    const extUrl = "https://mangaplus.shueisha.co.jp/viewer/999";
+    const ch = makeChapterRef({ id: "ch-ext", volume: "1", chapter: "5", externalUrl: extUrl });
+    const client = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("1", ["ch-ext"])],
+      feedChapters: async () => [ch],
+    });
+
+    let warnEvent: string | undefined;
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvent = (obj as Record<string, unknown>).event as string;
+        }
+      },
+      error: () => {},
+    };
+
+    try {
+      await runDownload(
+        baseArgs({ volume: undefined, chapter: "5" }),
+        { ...baseCtx(), logger: spyLogger },
+        client,
+        makeFullHttpClient(),
+      );
+    } catch {
+      // expected
+    }
+
+    expect(warnEvent).toBe("download.external_chapter");
   });
 });

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -649,7 +649,7 @@ describe("runDownload --chapter — happy path 3-chapter range", () => {
 
     // Assert all 3 archives exist with correct names
     const slug = "test-manga";
-    for (const [num, name] of [
+    for (const [, name] of [
       ["1", "001"],
       ["2", "002"],
       ["3", "003"],
@@ -663,7 +663,6 @@ describe("runDownload --chapter — happy path 3-chapter range", () => {
       const names = Object.keys(entries).sort();
       expect(names).toHaveLength(1);
       expect(names[0]).toBe("0001.jpg");
-      void num; // used above for clarity
     }
 
     // Assert 3 history rows with correct volumes
@@ -745,6 +744,85 @@ describe("runDownload --chapter — null volume chapter", () => {
     const cbzPath = join(tmpDir, "test-manga", "test-manga-chapter-007.cbz");
     const exists = await Bun.file(cbzPath).exists();
     expect(exists).toBe(true);
+  });
+});
+
+describe("runDownload --chapter — duplicate upload tiebreak", () => {
+  test("latest readableAt wins when two uploads share the same chapter number", async () => {
+    // older upload — should be discarded
+    const older = makeChapterRef({
+      id: "ch-old",
+      volume: "1",
+      chapter: "1",
+      readableAt: "2023-01-01T00:00:00Z",
+    });
+    // newer upload — should win
+    const newer = makeChapterRef({
+      id: "ch-new",
+      volume: "1",
+      chapter: "1",
+      readableAt: "2024-06-01T00:00:00Z",
+    });
+
+    const client = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("1", ["ch-old", "ch-new"])],
+      // Feed returns older first to verify feed-order independence
+      feedChapters: async () => [older, newer],
+    });
+
+    const http: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path.startsWith("/at-home/server/")) {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "abc", data: ["page1.jpg"], dataSaver: [] },
+          };
+        }
+        throw new Error(`Unexpected: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    await withMockedImageFetch(async () => {
+      await runDownload(baseArgs({ volume: undefined, chapter: "1" }), baseCtx(), client, http);
+    });
+
+    // Only one bundle should be recorded, and it must be the newer upload
+    const history = listHistory(db);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.chapterId).toBe("ch-new");
+  });
+
+  test("chapter with null chapter number is excluded from --chapter lookup", async () => {
+    const nullCh = makeChapterRef({ id: "ch-null", volume: "1", chapter: null });
+    // Also include a real chapter to confirm the feed is processed normally
+    const realCh = makeChapterRef({ id: "ch-real", volume: "1", chapter: "2" });
+
+    const client = makeClient({
+      aggregateVolumes: async () => [makeVolumeRef("1", ["ch-null", "ch-real"])],
+      feedChapters: async () => [nullCh, realCh],
+    });
+
+    const http: MangaDexHttpClient = {
+      get: async (path: string) => {
+        if (path.startsWith("/at-home/server/")) {
+          return {
+            baseUrl: "https://example.com",
+            chapter: { hash: "abc", data: ["page1.jpg"], dataSaver: [] },
+          };
+        }
+        throw new Error(`Unexpected: ${path}`);
+      },
+    } as unknown as MangaDexHttpClient;
+
+    await withMockedImageFetch(async () => {
+      // --chapter 2 should match realCh, null-chapter entry must not interfere
+      await runDownload(baseArgs({ volume: undefined, chapter: "2" }), baseCtx(), client, http);
+    });
+
+    const history = listHistory(db);
+    // Only the real chapter should be recorded; null-chapter entry is excluded from lookup
+    expect(history).toHaveLength(1);
+    expect(history[0]?.chapterId).toBe("ch-real");
   });
 });
 

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -330,6 +330,10 @@ export async function runDownload(
   if (args.volume !== undefined) {
     const { values: requestedVolumes } = parseRangeSet(args.volume);
     if (requestedVolumes.has("none")) {
+      logger.warn(
+        { event: "download.volume_none_unsupported", context: "download" },
+        "--volume none is not supported",
+      );
       throw new CliError(
         "--volume none is not yet supported. Use a numeric volume number instead.",
         2,

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -115,7 +115,14 @@ async function buildChapterInputs(
 /**
  * Group chapters from the feed into bundles based on args.
  * --volume: one bundle per requested volume token, all chapters in that volume.
+ *   Volume mode keeps ALL uploads for a given volume (including multiple scanlation
+ *   group versions of the same chapter number), which may produce larger .cbz files
+ *   but preserves every available translation.
  * --chapter: one bundle per requested chapter token, one chapter each.
+ *   Tiebreak rule: when multiple uploads exist for the same chapter number (different
+ *   scanlation groups), the one with the latest `readableAt` wins — newer scanlation
+ *   is typically higher quality. Chapters with chapter === null are excluded from the
+ *   lookup map; they are not addressable via --chapter.
  */
 function groupChaptersIntoBundles(args: DownloadArgs, chaptersInLang: ChapterRef[]): Bundle[] {
   if (args.volume !== undefined) {
@@ -142,12 +149,15 @@ function groupChaptersIntoBundles(args: DownloadArgs, chaptersInLang: ChapterRef
     return bundles;
   }
 
-  // --chapter mode
+  // --chapter mode: deduplicate by chapter number, latest readableAt wins.
+  // Chapters with chapter === null are skipped (not addressable by number).
   const { values: requestedChapters } = parseRangeSet(args.chapter as string);
   const chapterNumToRef = new Map<string, ChapterRef>();
   for (const ch of chaptersInLang) {
-    const num = ch.chapter ?? "0";
-    if (!chapterNumToRef.has(num)) {
+    if (ch.chapter === null) continue;
+    const num = ch.chapter;
+    const existing = chapterNumToRef.get(num);
+    if (!existing || ch.readableAt > existing.readableAt) {
       chapterNumToRef.set(num, ch);
     }
   }
@@ -324,12 +334,22 @@ export async function runDownload(
   }
 
   if (args.volume === undefined && args.chapter === undefined) {
+    logger.warn(
+      { event: "download.no_flag_set", context: "download" },
+      "--volume or --chapter is required",
+    );
     throw new CliError("--volume <range> or --chapter <range> is required", 2);
   }
 
+  // Parse requested tokens once; reused for none-check and missing-in-feed warning below.
+  // At this point exactly one of volume/chapter is defined (validated above).
+  const requestedTokens =
+    args.volume !== undefined
+      ? parseRangeSet(args.volume).values
+      : parseRangeSet(args.chapter as string).values;
+
   if (args.volume !== undefined) {
-    const { values: requestedVolumes } = parseRangeSet(args.volume);
-    if (requestedVolumes.has("none")) {
+    if (requestedTokens.has("none")) {
       logger.warn(
         { event: "download.volume_none_unsupported", context: "download" },
         "--volume none is not supported",
@@ -342,8 +362,7 @@ export async function runDownload(
   }
 
   if (args.chapter !== undefined) {
-    const { values: requestedChapters } = parseRangeSet(args.chapter);
-    if (requestedChapters.has("none")) {
+    if (requestedTokens.has("none")) {
       logger.warn(
         { event: "download.chapter_none_unsupported", context: "download" },
         "--chapter none is not supported",
@@ -378,23 +397,16 @@ export async function runDownload(
 
   const bundles = groupChaptersIntoBundles(args, chaptersInLang);
 
-  // Warn about requested items missing from feed
-  if (args.volume !== undefined) {
-    const { values: requestedVolumes } = parseRangeSet(args.volume);
-    const foundVolumeTokens = new Set(bundles.map((b) => b.bundleNumber));
-    for (const token of requestedVolumes) {
-      if (!foundVolumeTokens.has(token)) {
+  // Warn about requested items missing from feed (reuses requestedTokens parsed above)
+  const foundBundleTokens = new Set(bundles.map((b) => b.bundleNumber));
+  for (const token of requestedTokens) {
+    if (!foundBundleTokens.has(token)) {
+      if (args.volume !== undefined) {
         logger.warn(
           { event: "download.volume_missing", context: "download", volume: token },
           `volume ${token} not found in feed; skipping`,
         );
-      }
-    }
-  } else if (args.chapter !== undefined) {
-    const { values: requestedChapters } = parseRangeSet(args.chapter);
-    const foundChapterTokens = new Set(bundles.map((b) => b.bundleNumber));
-    for (const token of requestedChapters) {
-      if (!foundChapterTokens.has(token)) {
+      } else {
         logger.warn(
           { event: "download.chapter_missing", context: "download", chapter: token },
           `chapter ${token} not found in feed; skipping`,

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -8,7 +8,7 @@ import type { ChapterRef, MangaCandidate } from "@integrations/mangadex/client/i
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
 import { parseExternalHost } from "@integrations/mangadex/external-host.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
-import { downloadVolume } from "@modules/downloader/index.ts";
+import { downloadBundle } from "@modules/downloader/index.ts";
 import type { ChapterInput } from "@modules/downloader/types.ts";
 import { isVolumeFullyDownloaded, recordDownloadedChapters } from "@modules/history/index.ts";
 import type { DownloadRow } from "@modules/history/index.ts";
@@ -16,7 +16,7 @@ import { CliError } from "@plugins/errors/index.ts";
 import { resolveLanguage } from "./language.ts";
 import { parseRangeSet } from "./range.ts";
 import { toSlug } from "./slug.ts";
-import type { DownloadArgs, DownloadContext, ProcessVolumeArgs } from "./types.ts";
+import type { Bundle, DownloadArgs, DownloadContext, ProcessBundleArgs } from "./types.ts";
 
 export type { DownloadArgs, DownloadContext } from "./types.ts";
 export { CliError } from "@plugins/errors/index.ts";
@@ -112,32 +112,93 @@ async function buildChapterInputs(
   return inputs;
 }
 
-/** Per-volume pipeline: history check → external check → build inputs → download → record. */
-async function processVolume(input: ProcessVolumeArgs): Promise<void> {
-  const { volumeToken, volChapters, chosen, slug, language, args, ctx, http } = input;
-  const { logger, db } = ctx;
+/**
+ * Group chapters from the feed into bundles based on args.
+ * --volume: one bundle per requested volume token, all chapters in that volume.
+ * --chapter: one bundle per requested chapter token, one chapter each.
+ */
+function groupChaptersIntoBundles(args: DownloadArgs, chaptersInLang: ChapterRef[]): Bundle[] {
+  if (args.volume !== undefined) {
+    const { values: requestedVolumes } = parseRangeSet(args.volume);
+    const volumeToChapters = new Map<string, ChapterRef[]>();
+    for (const ch of chaptersInLang) {
+      const vol = ch.volume ?? "none";
+      const existing = volumeToChapters.get(vol) ?? [];
+      existing.push(ch);
+      volumeToChapters.set(vol, existing);
+    }
 
-  // history check
+    const bundles: Bundle[] = [];
+    for (const volumeToken of requestedVolumes) {
+      const volChapters = volumeToChapters.get(volumeToken);
+      if (!volChapters || volChapters.length === 0) continue;
+      bundles.push({
+        kind: "volume",
+        bundleNumber: volumeToken,
+        volumeForHistory: volumeToken,
+        chapters: volChapters,
+      });
+    }
+    return bundles;
+  }
+
+  // --chapter mode
+  const { values: requestedChapters } = parseRangeSet(args.chapter as string);
+  const chapterNumToRef = new Map<string, ChapterRef>();
+  for (const ch of chaptersInLang) {
+    const num = ch.chapter ?? "0";
+    if (!chapterNumToRef.has(num)) {
+      chapterNumToRef.set(num, ch);
+    }
+  }
+
+  const bundles: Bundle[] = [];
+  for (const chapterToken of requestedChapters) {
+    const ch = chapterNumToRef.get(chapterToken);
+    if (!ch) continue;
+    bundles.push({
+      kind: "chapter",
+      bundleNumber: chapterToken,
+      // Use the chapter's real volume from MangaDex; null → "none"
+      volumeForHistory: ch.volume ?? "none",
+      chapters: [ch],
+    });
+  }
+  return bundles;
+}
+
+/** Per-bundle pipeline: history check → external check → build inputs → download → record. */
+async function processBundle(input: ProcessBundleArgs): Promise<void> {
+  const { bundle, chosen, slug, language, args, ctx, http } = input;
+  const { logger, db } = ctx;
+  const { kind, bundleNumber, volumeForHistory, chapters } = bundle;
+
+  // history check — use volumeForHistory as the volume key (consistent across volume/chapter mode)
   if (!args.force) {
-    const chapterIdSet = new Set(volChapters.map((c) => c.id));
+    const chapterIdSet = new Set(chapters.map((c) => c.id));
     const fullyDownloaded = isVolumeFullyDownloaded(db, {
       mangaId: chosen.id,
-      volume: volumeToken,
+      volume: volumeForHistory,
       language,
       expectedChapterIds: chapterIdSet,
     });
 
     if (fullyDownloaded) {
       logger.info(
-        { event: "download.volume_skip", context: "download", volume: volumeToken },
-        `skipping volume ${volumeToken}: already in history`,
+        {
+          event: "download.bundle_skip",
+          context: "download",
+          kind,
+          bundleNumber,
+        },
+        `skipping ${kind} ${bundleNumber}: already in history`,
       );
       return;
     }
   }
 
   // external-chapter check
-  for (const ch of volChapters) {
+  for (const ch of chapters) {
     if (ch.externalUrl !== null) {
       const host = parseExternalHost(ch.externalUrl) ?? ch.externalUrl;
       logger.warn(
@@ -157,12 +218,10 @@ async function processVolume(input: ProcessVolumeArgs): Promise<void> {
     }
   }
 
-  const volumeNumber = Number(volumeToken);
-
   let chapterInputs: Awaited<ReturnType<typeof buildChapterInputs>>;
-  let result: Awaited<ReturnType<typeof downloadVolume>>;
+  let result: Awaited<ReturnType<typeof downloadBundle>>;
   try {
-    chapterInputs = await buildChapterInputs(volChapters, http, args.quality, logger);
+    chapterInputs = await buildChapterInputs(chapters, http, args.quality, logger);
 
     if (args.dryRun) {
       const totalPages = chapterInputs.reduce((sum, c) => sum + c.pages.length, 0);
@@ -171,20 +230,22 @@ async function processVolume(input: ProcessVolumeArgs): Promise<void> {
           event: "download.dry_run",
           context: "download",
           slug,
-          volumeNumber,
+          kind,
+          bundleNumber,
           chapters: chapterInputs.length,
           totalPages,
         },
-        `dry-run: would download volume ${volumeToken}`,
+        `dry-run: would download ${kind} ${bundleNumber}`,
       );
       return;
     }
 
-    result = await downloadVolume({
+    result = await downloadBundle({
       outDir: args.outDir,
       format: args.format,
       slug,
-      volumeNumber,
+      kind,
+      bundleNumber,
       chapters: chapterInputs,
       imageConcurrency: args.concurrency,
       delayMs: args.delayMs,
@@ -210,20 +271,21 @@ async function processVolume(input: ProcessVolumeArgs): Promise<void> {
 
   logger.info(
     {
-      event: "download.volume_done",
+      event: "download.bundle_done",
       context: "download",
-      volume: volumeToken,
+      kind,
+      bundleNumber,
       outputPath: result.outputPath,
       byteSize: result.byteSize,
     },
-    `volume ${volumeToken} downloaded`,
+    `${kind} ${bundleNumber} downloaded`,
   );
 
   if (!args.noTrack) {
-    const rows: DownloadRow[] = volChapters.map((ch) => ({
+    const rows: DownloadRow[] = chapters.map((ch) => ({
       mangaId: chosen.id,
       mangaTitle: chosen.title,
-      volume: volumeToken,
+      volume: volumeForHistory,
       chapterId: ch.id,
       chapterNum: ch.chapter ?? "0",
       source: "mangadex",
@@ -235,7 +297,8 @@ async function processVolume(input: ProcessVolumeArgs): Promise<void> {
       {
         event: "download.history_recorded",
         context: "download",
-        volume: volumeToken,
+        kind,
+        bundleNumber,
         rows: rows.length,
       },
       "history recorded",
@@ -251,13 +314,41 @@ export async function runDownload(
 ): Promise<void> {
   const { logger, config } = ctx;
 
-  const { values: requestedVolumes } = parseRangeSet(args.volume);
-
-  if (requestedVolumes.has("none")) {
-    throw new CliError(
-      "--volume none is not yet supported. Use a numeric volume number instead.",
-      2,
+  // Validate: exactly one of volume/chapter must be set
+  if (args.volume !== undefined && args.chapter !== undefined) {
+    logger.warn(
+      { event: "download.mutual_exclusion", context: "download" },
+      "--volume and --chapter are mutually exclusive",
     );
+    throw new CliError("--volume and --chapter are mutually exclusive", 2);
+  }
+
+  if (args.volume === undefined && args.chapter === undefined) {
+    throw new CliError("--volume <range> or --chapter <range> is required", 2);
+  }
+
+  if (args.volume !== undefined) {
+    const { values: requestedVolumes } = parseRangeSet(args.volume);
+    if (requestedVolumes.has("none")) {
+      throw new CliError(
+        "--volume none is not yet supported. Use a numeric volume number instead.",
+        2,
+      );
+    }
+  }
+
+  if (args.chapter !== undefined) {
+    const { values: requestedChapters } = parseRangeSet(args.chapter);
+    if (requestedChapters.has("none")) {
+      logger.warn(
+        { event: "download.chapter_none_unsupported", context: "download" },
+        "--chapter none is not supported",
+      );
+      throw new CliError(
+        "--chapter none is not yet supported. Use a numeric chapter number instead.",
+        2,
+      );
+    }
   }
 
   const chosen = await resolveTitle(client, args.manga, args.nonTty, logger);
@@ -278,27 +369,37 @@ export async function runDownload(
   });
 
   const chaptersInLang = feedChapters.filter((c) => c.translatedLanguage === language);
-  const volumeToChapters = new Map<string, typeof chaptersInLang>();
-  for (const ch of chaptersInLang) {
-    const vol = ch.volume ?? "none";
-    const existing = volumeToChapters.get(vol) ?? [];
-    existing.push(ch);
-    volumeToChapters.set(vol, existing);
-  }
 
   const slug = toSlug(chosen.title, logger);
 
-  for (const volumeToken of requestedVolumes) {
-    const volChapters = volumeToChapters.get(volumeToken);
+  const bundles = groupChaptersIntoBundles(args, chaptersInLang);
 
-    if (!volChapters || volChapters.length === 0) {
-      logger.warn(
-        { event: "download.volume_missing", context: "download", volume: volumeToken },
-        `volume ${volumeToken} not found in feed; skipping`,
-      );
-      continue;
+  // Warn about requested items missing from feed
+  if (args.volume !== undefined) {
+    const { values: requestedVolumes } = parseRangeSet(args.volume);
+    const foundVolumeTokens = new Set(bundles.map((b) => b.bundleNumber));
+    for (const token of requestedVolumes) {
+      if (!foundVolumeTokens.has(token)) {
+        logger.warn(
+          { event: "download.volume_missing", context: "download", volume: token },
+          `volume ${token} not found in feed; skipping`,
+        );
+      }
     }
+  } else if (args.chapter !== undefined) {
+    const { values: requestedChapters } = parseRangeSet(args.chapter);
+    const foundChapterTokens = new Set(bundles.map((b) => b.bundleNumber));
+    for (const token of requestedChapters) {
+      if (!foundChapterTokens.has(token)) {
+        logger.warn(
+          { event: "download.chapter_missing", context: "download", chapter: token },
+          `chapter ${token} not found in feed; skipping`,
+        );
+      }
+    }
+  }
 
-    await processVolume({ volumeToken, volChapters, chosen, slug, language, args, ctx, http });
+  for (const bundle of bundles) {
+    await processBundle({ bundle, chosen, slug, language, args, ctx, http });
   }
 }

--- a/src/commands/download/types.ts
+++ b/src/commands/download/types.ts
@@ -1,5 +1,6 @@
 import type { ChapterRef, MangaCandidate } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
+import type { BundleKind } from "@modules/downloader/index.ts";
 import type { Config } from "@plugins/config/index.ts";
 import type { Db } from "@plugins/db/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
@@ -18,7 +19,10 @@ export interface ResolveLanguageInput {
 
 export interface DownloadArgs {
   manga: string;
-  volume: string;
+  /** Set when --volume flag is provided */
+  volume?: string;
+  /** Set when --chapter flag is provided */
+  chapter?: string;
   format: "cbz" | "zip";
   outDir: string;
   quality: "data" | "data-saver";
@@ -39,6 +43,25 @@ export interface DownloadContext {
 export interface ProcessVolumeArgs {
   volumeToken: string;
   volChapters: ChapterRef[];
+  chosen: MangaCandidate;
+  slug: string;
+  language: string;
+  args: DownloadArgs;
+  ctx: DownloadContext;
+  http: MangaDexHttpClient;
+}
+
+export interface Bundle {
+  kind: BundleKind;
+  /** Used for the archive filename (e.g. "001", "018.5") */
+  bundleNumber: string;
+  /** Written to history rows — the chapter's real volume from MangaDex */
+  volumeForHistory: string;
+  chapters: ChapterRef[];
+}
+
+export interface ProcessBundleArgs {
+  bundle: Bundle;
   chosen: MangaCandidate;
   slug: string;
   language: string;

--- a/src/commands/download/types.ts
+++ b/src/commands/download/types.ts
@@ -40,17 +40,6 @@ export interface DownloadContext {
   db: Db;
 }
 
-export interface ProcessVolumeArgs {
-  volumeToken: string;
-  volChapters: ChapterRef[];
-  chosen: MangaCandidate;
-  slug: string;
-  language: string;
-  args: DownloadArgs;
-  ctx: DownloadContext;
-  http: MangaDexHttpClient;
-}
-
 export interface Bundle {
   kind: BundleKind;
   /** Used for the archive filename (e.g. "001", "018.5") */

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,12 +112,8 @@ const handlers: Record<string, Handler> = {
       throw new CliError("--volume and --chapter are mutually exclusive", 2);
     }
 
-    if (dlValues.chapter !== undefined) {
-      throw new NotImplementedError("download --chapter");
-    }
-
-    if (dlValues.volume === undefined) {
-      throw new CliError("--volume <range> is required (--chapter support coming in #15)", 2);
+    if (dlValues.volume === undefined && dlValues.chapter === undefined) {
+      throw new CliError("--volume <range> or --chapter <range> is required", 2);
     }
 
     const rawFormat = dlValues.format;
@@ -150,7 +146,8 @@ const handlers: Record<string, Handler> = {
     await runDownload(
       {
         manga,
-        volume: dlValues.volume as string,
+        volume: typeof dlValues.volume === "string" ? dlValues.volume : undefined,
+        chapter: typeof dlValues.chapter === "string" ? dlValues.chapter : undefined,
         format,
         outDir: typeof dlValues.out === "string" ? dlValues.out : ctx.config.default_out,
         quality,

--- a/src/modules/downloader/downloader.test.ts
+++ b/src/modules/downloader/downloader.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { downloadVolume } from "@modules/downloader/index.ts";
+import { downloadBundle } from "@modules/downloader/index.ts";
 import type { ChapterInput, ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { unzipSync } from "fflate";
+import { padBundleNumber } from "./helpers.ts";
 
 const noopLogger: Logger = {
   error: (_f, _m) => {},
@@ -78,16 +79,29 @@ afterEach(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Archive structure
+// padBundleNumber unit tests
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — archive structure", () => {
+describe("padBundleNumber", () => {
+  test('"1" → "001"', () => expect(padBundleNumber("1", 3)).toBe("001"));
+  test('"103" → "103"', () => expect(padBundleNumber("103", 3)).toBe("103"));
+  test('"18.5" → "018.5"', () => expect(padBundleNumber("18.5", 3)).toBe("018.5"));
+  test('"1.25" → "001.25"', () => expect(padBundleNumber("1.25", 3)).toBe("001.25"));
+  test('"none" → "none"', () => expect(padBundleNumber("none", 3)).toBe("none"));
+});
+
+// ---------------------------------------------------------------------------
+// Archive structure — volume
+// ---------------------------------------------------------------------------
+
+describe("downloadBundle — volume archive structure", () => {
   test("produces correct filename and directory layout", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "witch-hat-atelier",
-      volumeNumber: 3,
+      kind: "volume",
+      bundleNumber: "3",
       chapters: [makeChapter("ch-018", 18, 2), makeChapter("ch-019", 19, 1)],
       imageConcurrency: 2,
       delayMs: 0,
@@ -107,11 +121,12 @@ describe("downloadVolume — archive structure", () => {
   });
 
   test("three-digit volume zero-padding", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "test-manga",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [makeChapter("ch-001", 1, 1)],
       imageConcurrency: 1,
       delayMs: 0,
@@ -123,11 +138,12 @@ describe("downloadVolume — archive structure", () => {
   });
 
   test("volume 103 pads correctly", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "test",
-      volumeNumber: 103,
+      kind: "volume",
+      bundleNumber: "103",
       chapters: [makeChapter("c1", 1, 1)],
       imageConcurrency: 1,
       delayMs: 0,
@@ -139,17 +155,56 @@ describe("downloadVolume — archive structure", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Archive structure — chapter
+// ---------------------------------------------------------------------------
+
+describe("downloadBundle — chapter archive structure", () => {
+  test("chapter kind generates correct filename", async () => {
+    const result = await downloadBundle({
+      outDir,
+      format: "cbz",
+      slug: "one-piece",
+      kind: "chapter",
+      bundleNumber: "1",
+      chapters: [makeChapter("ch-001", 1, 2)],
+      imageConcurrency: 1,
+      delayMs: 0,
+      dryRun: false,
+      logger: noopLogger,
+    });
+    expect(result.outputPath).toContain("one-piece-chapter-001.cbz");
+  });
+
+  test("decimal chapter number is padded correctly", async () => {
+    const result = await downloadBundle({
+      outDir,
+      format: "cbz",
+      slug: "test-manga",
+      kind: "chapter",
+      bundleNumber: "18.5",
+      chapters: [makeChapter("ch-018-5", 18, 1)],
+      imageConcurrency: 1,
+      delayMs: 0,
+      dryRun: false,
+      logger: noopLogger,
+    });
+    expect(result.outputPath).toContain("test-manga-chapter-018.5.cbz");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Page order invariant
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — page ordering", () => {
+describe("downloadBundle — page ordering", () => {
   test("pages are sorted across chapters in ascending order", async () => {
     // Two chapters with 3 pages each. Chapters passed out-of-order to verify sorting.
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "sorted-manga",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [
         makeChapter("ch-002", 2, 3), // chapter 2 first in input
         makeChapter("ch-001", 1, 3), // chapter 1 second in input
@@ -169,11 +224,12 @@ describe("downloadVolume — page ordering", () => {
   });
 
   test("single chapter pages numbered from 0001", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "single-ch",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [makeChapter("ch-1", 1, 5)],
       imageConcurrency: 2,
       delayMs: 0,
@@ -193,7 +249,7 @@ describe("downloadVolume — page ordering", () => {
 // Concurrency limit
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — concurrency limit", () => {
+describe("downloadBundle — concurrency limit", () => {
   test("never exceeds imageConcurrency in-flight fetches", async () => {
     const limit = 3;
     let inFlight = 0;
@@ -209,11 +265,12 @@ describe("downloadVolume — concurrency limit", () => {
     };
 
     const pages = 12; // 12 pages, concurrency 3 → max in-flight must be ≤ 3
-    await downloadVolume({
+    await downloadBundle({
       outDir,
       format: "cbz",
       slug: "concurrency-test",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [makeChapter("ch-1", 1, pages, fetcher)],
       imageConcurrency: limit,
       delayMs: 0,
@@ -230,7 +287,7 @@ describe("downloadVolume — concurrency limit", () => {
 // Dry-run
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — dry-run", () => {
+describe("downloadBundle — dry-run", () => {
   test("returns planned path with [dry-run] prefix", async () => {
     let fetchCalled = false;
     const fetcher = async (_ref: ImageRef): Promise<Uint8Array> => {
@@ -238,11 +295,12 @@ describe("downloadVolume — dry-run", () => {
       return makePng(1);
     };
 
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "dry-test",
-      volumeNumber: 5,
+      kind: "volume",
+      bundleNumber: "5",
       chapters: [makeChapter("ch-050", 50, 3, fetcher)],
       imageConcurrency: 2,
       delayMs: 0,
@@ -258,11 +316,12 @@ describe("downloadVolume — dry-run", () => {
   });
 
   test("dry-run does not write any files", async () => {
-    await downloadVolume({
+    await downloadBundle({
       outDir,
       format: "cbz",
       slug: "no-files",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [makeChapter("c1", 1, 2)],
       imageConcurrency: 1,
       delayMs: 0,
@@ -281,7 +340,7 @@ describe("downloadVolume — dry-run", () => {
 // Interruption simulation — .temp file, no final file
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — interruption simulation", () => {
+describe("downloadBundle — interruption simulation", () => {
   test("partial failure leaves no final .cbz when fetcher throws mid-stream", async () => {
     let callCount = 0;
     const fetcher = async (_ref: ImageRef): Promise<Uint8Array> => {
@@ -291,11 +350,12 @@ describe("downloadVolume — interruption simulation", () => {
     };
 
     await expect(
-      downloadVolume({
+      downloadBundle({
         outDir,
         format: "cbz",
         slug: "interrupted",
-        volumeNumber: 1,
+        kind: "volume",
+        bundleNumber: "1",
         chapters: [makeChapter("ch-1", 1, 5, fetcher)],
         imageConcurrency: 1,
         delayMs: 0,
@@ -315,13 +375,14 @@ describe("downloadVolume — interruption simulation", () => {
 // chapterIds in result
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — result metadata", () => {
+describe("downloadBundle — result metadata", () => {
   test("chapterIds preserves input order", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "meta-test",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [
         makeChapter("z-chapter", 3, 1),
         makeChapter("a-chapter", 1, 1),
@@ -342,13 +403,14 @@ describe("downloadVolume — result metadata", () => {
 // PNG magic detection (no explicit content-type)
 // ---------------------------------------------------------------------------
 
-describe("downloadVolume — extension detection from bytes", () => {
+describe("downloadBundle — extension detection from bytes", () => {
   test("detects PNG from magic bytes when fetcher returns PNG data", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "ext-detect",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [makeChapter("c1", 1, 3, async (_ref) => makePng(1))],
       imageConcurrency: 1,
       delayMs: 0,
@@ -365,11 +427,12 @@ describe("downloadVolume — extension detection from bytes", () => {
   });
 
   test("falls back to .jpg for non-PNG magic bytes", async () => {
-    const result = await downloadVolume({
+    const result = await downloadBundle({
       outDir,
       format: "cbz",
       slug: "ext-fallback",
-      volumeNumber: 1,
+      kind: "volume",
+      bundleNumber: "1",
       chapters: [makeChapter("c1", 1, 2, async (_ref) => makeJpeg(1))],
       imageConcurrency: 1,
       delayMs: 0,

--- a/src/modules/downloader/helpers.ts
+++ b/src/modules/downloader/helpers.ts
@@ -8,15 +8,20 @@ export function detectExtFromBytes(bytes: Uint8Array): string | null {
 }
 
 /**
- * Pads only the integer part of a bundle number to `width` digits.
- * Preserves the decimal portion unchanged.
- * Non-numeric tokens (e.g. "none") pass through unchanged.
+ * Pads the integer portion of a numeric token to `width` digits.
+ * Special tokens like "none" pass through unchanged.
+ *
+ * Contract: `value` must be a non-empty string of digits, optionally followed by
+ * `.<digits>`, OR the literal "none". Other shapes (empty string, leading dot,
+ * negative sign) are not supported and may produce undefined output.
+ * The range parser guarantees this contract for all legitimate callers.
  *
  * Examples:
- *   "1"    → "001"
- *   "18.5" → "018.5"
- *   "103"  → "103"
- *   "none" → "none"
+ *   ("1", 3)    → "001"
+ *   ("103", 3)  → "103"
+ *   ("18.5", 3) → "018.5"
+ *   ("1.25", 3) → "001.25"
+ *   ("none", 3) → "none"
  */
 export function padBundleNumber(value: string, width: number): string {
   const dotIdx = value.indexOf(".");

--- a/src/modules/downloader/helpers.ts
+++ b/src/modules/downloader/helpers.ts
@@ -6,3 +6,29 @@ export function detectExtFromBytes(bytes: Uint8Array): string | null {
   if (bytes[0] === 0x89 && bytes[1] === 0x50) return ".png";
   return null;
 }
+
+/**
+ * Pads only the integer part of a bundle number to `width` digits.
+ * Preserves the decimal portion unchanged.
+ * Non-numeric tokens (e.g. "none") pass through unchanged.
+ *
+ * Examples:
+ *   "1"    → "001"
+ *   "18.5" → "018.5"
+ *   "103"  → "103"
+ *   "none" → "none"
+ */
+export function padBundleNumber(value: string, width: number): string {
+  const dotIdx = value.indexOf(".");
+  if (dotIdx === -1) {
+    // No decimal: try to pad as integer
+    const n = Number(value);
+    if (Number.isNaN(n)) return value;
+    return String(n).padStart(width, "0");
+  }
+  const intPart = value.slice(0, dotIdx);
+  const decPart = value.slice(dotIdx); // includes the dot
+  const n = Number(intPart);
+  if (Number.isNaN(n)) return value;
+  return String(n).padStart(width, "0") + decPart;
+}

--- a/src/modules/downloader/index.ts
+++ b/src/modules/downloader/index.ts
@@ -1,2 +1,8 @@
-export { downloadVolume } from "./service.ts";
-export type { ChapterInput, DownloadVolumeInput, DownloadVolumeResult, ImageRef } from "./types.ts";
+export { downloadBundle } from "./service.ts";
+export type {
+  BundleKind,
+  ChapterInput,
+  DownloadBundleInput,
+  DownloadBundleResult,
+  ImageRef,
+} from "./types.ts";

--- a/src/modules/downloader/service.ts
+++ b/src/modules/downloader/service.ts
@@ -1,12 +1,12 @@
 import { mkdir, rename, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { zipSync } from "fflate";
-import { detectExtFromBytes, pad } from "./helpers.ts";
+import { detectExtFromBytes, pad, padBundleNumber } from "./helpers.ts";
 import { createSemaphore } from "./semaphore.ts";
 import type {
   ChapterInput,
-  DownloadVolumeInput,
-  DownloadVolumeResult,
+  DownloadBundleInput,
+  DownloadBundleResult,
   ImageRef,
   Semaphore,
 } from "./types.ts";
@@ -38,12 +38,13 @@ async function fetchChapterPages(
   return Promise.all(tasks);
 }
 
-export async function downloadVolume(input: DownloadVolumeInput): Promise<DownloadVolumeResult> {
+export async function downloadBundle(input: DownloadBundleInput): Promise<DownloadBundleResult> {
   const {
     outDir,
     format,
     slug,
-    volumeNumber,
+    kind,
+    bundleNumber,
     chapters,
     imageConcurrency,
     delayMs,
@@ -51,11 +52,11 @@ export async function downloadVolume(input: DownloadVolumeInput): Promise<Downlo
     logger,
   } = input;
 
-  const volumePad = pad(volumeNumber, 3);
+  const padded = padBundleNumber(bundleNumber, 3);
   const ext = format === "zip" ? "zip" : "cbz";
-  const filename = `${slug}-volume-${volumePad}.${ext}`;
-  const volumeDir = join(outDir, slug);
-  const finalPath = join(volumeDir, filename);
+  const filename = `${slug}-${kind}-${padded}.${ext}`;
+  const bundleDir = join(outDir, slug);
+  const finalPath = join(bundleDir, filename);
   const tempPath = `${finalPath}.temp`;
   const chapterIds = chapters.map((c) => c.id);
   const sorted = [...chapters].sort((a, b) => a.num - b.num);
@@ -75,7 +76,7 @@ export async function downloadVolume(input: DownloadVolumeInput): Promise<Downlo
     return { chapterIds, outputPath: `[dry-run] ${finalPath}`, byteSize: 0 };
   }
 
-  await mkdir(volumeDir, { recursive: true });
+  await mkdir(bundleDir, { recursive: true });
 
   const sem = createSemaphore(imageConcurrency);
   const zipEntries: Record<string, Uint8Array> = {};

--- a/src/modules/downloader/types.ts
+++ b/src/modules/downloader/types.ts
@@ -12,11 +12,15 @@ export interface ChapterInput {
   imageFetcher: (ref: ImageRef) => Promise<Uint8Array>;
 }
 
-export interface DownloadVolumeInput {
+export type BundleKind = "volume" | "chapter";
+
+export interface DownloadBundleInput {
   outDir: string;
   format: "cbz" | "zip";
   slug: string;
-  volumeNumber: number;
+  kind: BundleKind;
+  /** "1", "018", "18.5", "none" — stringly typed for decimals & special tokens */
+  bundleNumber: string;
   chapters: ChapterInput[];
   imageConcurrency: number;
   delayMs: number;
@@ -24,7 +28,7 @@ export interface DownloadVolumeInput {
   logger: Logger;
 }
 
-export interface DownloadVolumeResult {
+export interface DownloadBundleResult {
   chapterIds: string[];
   outputPath: string;
   byteSize: number;


### PR DESCRIPTION
## What this PR does

Sibling of #14: wires `download --chapter <range>` end-to-end. Same pipeline, different bundling — one `.cbz` per chapter instead of one per volume.

## Why it exists

#14 made `--volume` work. The CLI router still throws `NotImplementedError("download --chapter")`. Users discovering manga via `list <manga> --chapter <n>` had no follow-up command. This PR finishes that loop.

Ref: #15

## How it works internally

### 1. Downloader generalized from "volume-only" to "bundle-with-kind"

`src/modules/downloader/types.ts`:

```ts
export type BundleKind = "volume" | "chapter";

export interface DownloadBundleInput {
  outDir: string;
  format: "cbz" | "zip";
  slug: string;
  kind: BundleKind;
  bundleNumber: string;     // string supports decimals ("18.5") and special tokens
  chapters: ChapterInput[];
  imageConcurrency: number;
  delayMs: number;
  dryRun: boolean;
  logger: Logger;
}
```

`downloadVolume` → `downloadBundle`. `volumeNumber: number` → `bundleNumber: string`. Filename pattern becomes `${slug}-${kind}-${padded}.${ext}`. The full repo grep `DownloadVolumeInput|downloadVolume|volumeNumber` returns zero hits — rename is complete, no aliases.

### 2. `padBundleNumber(value, width): string`

New pure helper in `src/modules/downloader/helpers.ts`. Pads only the integer portion of decimals; passes `"none"` through. Documented contract:

| input | output |
|---|---|
| `("1", 3)` | `"001"` |
| `("103", 3)` | `"103"` |
| `("18.5", 3)` | `"018.5"` |
| `("1.25", 3)` | `"001.25"` |
| `("none", 3)` | `"none"` |

### 3. `runDownload` branches on `args.volume` vs `args.chapter`

`src/commands/download/index.ts`. New helper `groupChaptersIntoBundles(args, chapters): Bundle[]`:

```ts
interface Bundle {
  kind: BundleKind;
  bundleNumber: string;       // for filename
  volumeForHistory: string;   // for history rows: real volume from MangaDex
  chapters: ChapterRef[];
}
```

- **`--volume` mode:** group chapters by `chapter.volume`, one bundle per requested volume token; missing tokens warn-skipped.
- **`--chapter` mode:** one bundle per requested chapter token, each containing exactly one chapter; `Bundle.volumeForHistory = chapter.volume ?? "none"`.

After grouping, `processBundle` is shared between modes. Title resolution, language resolution, history check, external-chapter refuse, image fetcher wiring, downloader call, and history insert are all common code.

### 4. Deterministic chapter tiebreak

When MangaDex returns multiple uploads of the same chapter number (different scan groups), `--chapter` mode picks the one with the **latest `readableAt`**. Feed-order is no longer a hidden input. JSDoc documents the rule and notes the asymmetry with `--volume` mode (volume mode currently bundles all uploads in the same volume archive — kept for compatibility, can be tightened later).

### 5. History correctness for `--chapter`

For `--chapter 1` where MangaDex says ch.1 is in `volume: "3"`, history row carries `volume: "3"` (NOT `"1"`). For `chapter.volume === null`, history row carries `volume: "none"`. This is what makes `update`/`sync` (future) able to skip both volume- and chapter-level prior downloads consistently.

### 6. Conventions preserved

- All new types in `types.ts` per file. `grep` for stray declarations returns zero.
- `logger.warn` before every throw that wraps/converts/refuses (`download.chapter_none_unsupported`, `download.volume_none_unsupported`, `download.no_flag_set` — plus the five existing sites from #14).
- `parseExternalHost` from `src/integrations/mangadex/external-host.ts` is still the single source for URL parsing.
- No new classes (only existing `CliError`, `AtHomeError`, `ConfigError`).
- `parseRangeSet` lifted to a single local in `runDownload` (no double-parse).
- Null-chapter entries skipped from the chapter-mode lookup map (so `--chapter 0` doesn't accidentally match a `chapter: null` entry).

## What did not change

- `--volume` behavior — single + multi-chapter happy paths, force, no-track, dry-run, atomic-on-failure, external-chapter refuse all preserved.
- The MangaDex client, at-home server, history module, range parser, language resolver, slug helper.
- `readableAt` (#47), `externalUrl` annotation (#48), CliError consolidation (#52).
- `mangadexImageFetcher` retry / 429 / report payload.

## ACs satisfied

- [x] One `.cbz` per chapter when downloading by chapter
- [x] Filename `<slug>-chapter-<nnn>.cbz` zero-padded to 3 digits
- [x] Decimal chapters preserve decimal: `18.5` → `018.5`
- [x] History rows carry the chapter's real `volume` from MangaDex aggregate (not the user's input token)
- [x] Mutual exclusion `--volume` AND `--chapter` enforced before any network call
- [x] Integration test: 3-chapter range produces 3 archives + 3 history rows with correct per-chapter `volume` values
- [x] Decimal chapter test: `--chapter 18.5` → `<slug>-chapter-018.5.cbz`
- [x] Null-volume test: chapter with `volume: null` → history `volume: "none"`
- [x] External chapter refuse works in `--chapter` mode (same `download.external_chapter` warn)
- [x] `--chapter none` and `--volume none` both throw `CliError` exit 2 with `logger.warn` and unique events
- [x] Deterministic tiebreak: latest `readableAt` wins on duplicate chapter uploads

## Test checklist

- [x] `padBundleNumber` 5 contract cases
- [x] `groupChaptersIntoBundles` for both modes
- [x] 3-chapter `--chapter 1-3` happy path with archive content + history assertions
- [x] Decimal `--chapter 18.5` filename
- [x] Null-volume → `"none"` in history
- [x] Mutual exclusion CLI test
- [x] `--chapter none` parity test
- [x] External chapter refuse in `--chapter` mode
- [x] Deterministic tiebreak: feed-order-reversed input still picks latest `readableAt`
- [x] Null-chapter entry doesn't interfere with a real chapter lookup
- [x] CLI routing test still passes
- [x] All `--volume` tests from #14 still pass
- [x] `bun test` — 294 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- The asymmetry between `--volume` (bundles all uploads of the same chapter into one archive) and `--chapter` (picks the latest by `readableAt`) is documented in `groupChaptersIntoBundles` JSDoc. Tightening `--volume` to also pick latest can ship as a follow-up if you want consistency.
- `--chapter none` is rejected with the same "not yet supported" message as `--volume none`. The "no-volume bucket" feature isn't here yet — when it lands, both flags should support it together.

## Closes

Ref: #15

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (not applicable — `docs/overviewer.md` §3.6 already documented the chapter filename convention this PR implements)