### PR TITLE
feat(fallback-http): HttpClient with cookie replay

### DIFF
--- a/src/integrations/fallback-http/fallback-http.test.ts
+++ b/src/integrations/fallback-http/fallback-http.test.ts
@@ -1,0 +1,443 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Logger } from "@plugins/logger/index.ts";
+import { CloudflareError, MissingAuthError, createFallbackHttp } from "./index.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger(): {
+  logger: Logger;
+  calls: Array<{ level: string; fields: Record<string, unknown>; msg: string }>;
+} {
+  const calls: Array<{ level: string; fields: Record<string, unknown>; msg: string }> = [];
+  const logger: Logger = {
+    info: (fields, msg) => calls.push({ level: "info", fields, msg }),
+    warn: (fields, msg) => calls.push({ level: "warn", fields, msg }),
+    error: (fields, msg) => calls.push({ level: "error", fields, msg }),
+  };
+  return { logger, calls };
+}
+
+function makeFakeResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+const VALID_SESSION = {
+  cookies: { cf_clearance: "abc123", __cf_bm: "xyz" },
+  userAgent: "Mozilla/5.0 TestUA",
+  savedAt: 1700000000000,
+};
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "fallback-http-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function mkdtemp(path: string): Promise<string> {
+  await mkdir(path, { recursive: true });
+  return path;
+}
+
+async function writeAuth(dir: string, content: unknown): Promise<string> {
+  const path = join(dir, "auth.json");
+  await writeFile(path, typeof content === "string" ? content : JSON.stringify(content), "utf8");
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Missing file → MissingAuthError
+// ---------------------------------------------------------------------------
+
+test("missing auth file throws MissingAuthError", async () => {
+  const { logger, calls } = makeLogger();
+  const path = join(tmpDir, "nonexistent.json");
+
+  await expect(createFallbackHttp({ authPath: path, logger })).rejects.toBeInstanceOf(
+    MissingAuthError,
+  );
+
+  const warnCall = calls.find((c) => c.level === "warn");
+  expect(warnCall).toBeDefined();
+  expect(warnCall?.fields.reason).toBe("missing");
+  expect(warnCall?.fields.path).toBe(path);
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Corrupt file (not JSON) → MissingAuthError
+// ---------------------------------------------------------------------------
+
+test("corrupt auth file (not JSON) throws MissingAuthError", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, "not json");
+
+  await expect(createFallbackHttp({ authPath: path, logger })).rejects.toBeInstanceOf(
+    MissingAuthError,
+  );
+
+  const warnCall = calls.find((c) => c.level === "warn");
+  expect(warnCall).toBeDefined();
+  expect(warnCall?.fields.reason).toBe("corrupt");
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Wrong shape → MissingAuthError (corrupt path)
+// ---------------------------------------------------------------------------
+
+describe("wrong shape → MissingAuthError", () => {
+  test("empty object", async () => {
+    const { logger } = makeLogger();
+    const path = await writeAuth(tmpDir, {});
+
+    await expect(createFallbackHttp({ authPath: path, logger })).rejects.toBeInstanceOf(
+      MissingAuthError,
+    );
+  });
+
+  test("cookies is a string instead of object", async () => {
+    const { logger } = makeLogger();
+    const path = await writeAuth(tmpDir, {
+      cookies: "string-instead-of-object",
+      userAgent: "UA",
+      savedAt: 123,
+    });
+
+    await expect(createFallbackHttp({ authPath: path, logger })).rejects.toBeInstanceOf(
+      MissingAuthError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Happy construction + get → 200 with correct headers
+// ---------------------------------------------------------------------------
+
+test("happy construction + get sends Cookie and User-Agent headers", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  const capturedHeaders: Record<string, string> = {};
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> = async (
+    _url,
+    init,
+  ) => {
+    const headers = init?.headers as Record<string, string>;
+    Object.assign(capturedHeaders, headers);
+    return makeFakeResponse(200);
+  };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => Date.now(),
+  });
+
+  const res = await client.get("https://example.com/page");
+  expect(res.status).toBe(200);
+
+  // Cookie header must contain all cookies (order independent).
+  const cookieParts = new Set((capturedHeaders.cookie ?? "").split("; "));
+  expect(cookieParts).toContain("cf_clearance=abc123");
+  expect(cookieParts).toContain("__cf_bm=xyz");
+
+  expect(capturedHeaders["user-agent"]).toBe(VALID_SESSION.userAgent);
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: Cookie values and UA are never logged
+// ---------------------------------------------------------------------------
+
+test("cookie values and UA string are never logged", async () => {
+  const SENTINEL_UA = "SENTINEL_USERAGENT_UNIQUE_12345";
+  const SENTINEL_COOKIE_VAL = "SENTINEL_COOKIE_VALUE_67890";
+
+  const session = {
+    cookies: { cf_clearance: SENTINEL_COOKIE_VAL },
+    userAgent: SENTINEL_UA,
+    savedAt: 1700000000000,
+  };
+
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, session);
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => makeFakeResponse(200);
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  await client.get("https://example.com/test");
+
+  const allPayloads = JSON.stringify(calls);
+  expect(allPayloads).not.toContain(SENTINEL_UA);
+  expect(allPayloads).not.toContain(SENTINEL_COOKIE_VAL);
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: 403 → CloudflareError, no retry
+// ---------------------------------------------------------------------------
+
+test("403 throws CloudflareError without retrying", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      return makeFakeResponse(403);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  await expect(client.get("https://example.com/")).rejects.toBeInstanceOf(CloudflareError);
+
+  // Exactly one fetch attempt — no retry on 403.
+  expect(fetchCount).toBe(1);
+
+  const warnCall = calls.find(
+    (c) => c.level === "warn" && c.fields.event === "fallback_http.cloudflare_rejected",
+  );
+  expect(warnCall).toBeDefined();
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: 5xx then 200 → resolves, one retry warn
+// ---------------------------------------------------------------------------
+
+test("5xx then 200 resolves with the 200 response after one retry", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let call = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      call++;
+      return call === 1 ? makeFakeResponse(503) : makeFakeResponse(200);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/");
+  expect(res.status).toBe(200);
+
+  const retryWarns = calls.filter(
+    (c) => c.level === "warn" && c.fields.event === "fallback_http.retry",
+  );
+  expect(retryWarns).toHaveLength(1);
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: Network error then success → resolves, one retry warn
+// ---------------------------------------------------------------------------
+
+test("network error then success resolves after one retry", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let call = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      call++;
+      if (call === 1) throw new Error("ECONNRESET");
+      return makeFakeResponse(200);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/");
+  expect(res.status).toBe(200);
+
+  const retryWarns = calls.filter(
+    (c) => c.level === "warn" && c.fields.event === "fallback_http.retry",
+  );
+  expect(retryWarns).toHaveLength(1);
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: Permanent 5xx exhaustion → throws, 3 retry warns
+// ---------------------------------------------------------------------------
+
+test("permanent 5xx exhausts all attempts and throws with 3 retry warns", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      return makeFakeResponse(500);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  await expect(client.get("https://example.com/")).rejects.toThrow(/500/);
+
+  // 4 total attempts (1 initial + 3 retries).
+  expect(fetchCount).toBe(4);
+
+  const retryWarns = calls.filter(
+    (c) => c.level === "warn" && c.fields.event === "fallback_http.retry",
+  );
+  // 3 retry warns (before attempts 2, 3, 4).
+  expect(retryWarns).toHaveLength(3);
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: 404 returned, not retried
+// ---------------------------------------------------------------------------
+
+test("404 is returned to caller without retrying", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      return makeFakeResponse(404);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/missing");
+  expect(res.status).toBe(404);
+  expect(fetchCount).toBe(1);
+
+  const retryWarns = calls.filter((c) => c.fields.event === "fallback_http.retry");
+  expect(retryWarns).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// Test 11: Rate limit ceiling — second call sleeps the remainder
+// ---------------------------------------------------------------------------
+
+test("second get call sleeps the remainder of the 1s window", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  // Deterministic clock: first call at t=0, second call at t=300ms.
+  let mockTime = 0;
+  const sleepArgs: number[] = [];
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      // Simulate 100ms passing per fetch.
+      mockTime += 100;
+      return makeFakeResponse(200);
+    };
+
+  const fakeSleep = async (ms: number) => {
+    sleepArgs.push(ms);
+    // Advance clock by the sleep amount.
+    mockTime += ms;
+  };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: fakeSleep,
+    now: () => mockTime,
+  });
+
+  // First request — no throttle needed.
+  await client.get("https://example.com/1");
+
+  // Advance clock by 300ms (simulate caller overhead).
+  mockTime += 300;
+
+  // Second request should sleep ~600ms (1000 - 400ms elapsed [100ms fetch + 300ms caller]).
+  await client.get("https://example.com/2");
+
+  // At least one sleep was issued for the throttle.
+  expect(sleepArgs.length).toBeGreaterThanOrEqual(1);
+  // The throttle sleep should be > 0.
+  const throttleSleep = sleepArgs[0];
+  expect(throttleSleep).toBeGreaterThan(0);
+  expect(throttleSleep).toBeLessThanOrEqual(1000);
+});
+
+// ---------------------------------------------------------------------------
+// Test 12: Concurrent gets serialize through the throttle
+// ---------------------------------------------------------------------------
+
+test("concurrent gets serialize so 1 req/s ceiling holds globally", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let mockTime = 0;
+  const fetchTimestamps: number[] = [];
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchTimestamps.push(mockTime);
+      return makeFakeResponse(200);
+    };
+
+  const fakeSleep = async (ms: number) => {
+    mockTime += ms;
+  };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: fakeSleep,
+    now: () => mockTime,
+  });
+
+  // Fire two requests concurrently.
+  await Promise.all([client.get("https://example.com/a"), client.get("https://example.com/b")]);
+
+  expect(fetchTimestamps).toHaveLength(2);
+
+  // The second fetch must have started at least 1000ms after the first.
+  const gap = (fetchTimestamps[1] ?? 0) - (fetchTimestamps[0] ?? 0);
+  expect(gap).toBeGreaterThanOrEqual(1000);
+});

--- a/src/integrations/fallback-http/fallback-http.test.ts
+++ b/src/integrations/fallback-http/fallback-http.test.ts
@@ -35,14 +35,14 @@ const VALID_SESSION = {
 let tmpDir: string;
 
 beforeEach(async () => {
-  tmpDir = await mkdtemp(join(tmpdir(), "fallback-http-test-"));
+  tmpDir = await makeTempDir(join(tmpdir(), "fallback-http-test-"));
 });
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true });
 });
 
-async function mkdtemp(path: string): Promise<string> {
+async function makeTempDir(path: string): Promise<string> {
   await mkdir(path, { recursive: true });
   return path;
 }

--- a/src/integrations/fallback-http/fallback-http.test.ts
+++ b/src/integrations/fallback-http/fallback-http.test.ts
@@ -320,6 +320,39 @@ test("permanent 5xx exhausts all attempts and throws with 3 retry warns", async 
   );
   // 3 retry warns (before attempts 2, 3, 4).
   expect(retryWarns).toHaveLength(3);
+
+  // P2 #4: Assert structured payload on each retry warn.
+  const expectedUrl = "https://example.com/";
+  expect(retryWarns[0]).toMatchObject({
+    fields: {
+      event: "fallback_http.retry",
+      context: "fallback-http",
+      attempt: 1,
+      status: 500,
+      url: expectedUrl,
+      waitMs: expect.any(Number),
+    },
+  });
+  expect(retryWarns[1]).toMatchObject({
+    fields: {
+      event: "fallback_http.retry",
+      context: "fallback-http",
+      attempt: 2,
+      status: 500,
+      url: expectedUrl,
+      waitMs: expect.any(Number),
+    },
+  });
+  expect(retryWarns[2]).toMatchObject({
+    fields: {
+      event: "fallback_http.retry",
+      context: "fallback-http",
+      attempt: 3,
+      status: 500,
+      url: expectedUrl,
+      waitMs: expect.any(Number),
+    },
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -440,4 +473,190 @@ test("concurrent gets serialize so 1 req/s ceiling holds globally", async () => 
   // The second fetch must have started at least 1000ms after the first.
   const gap = (fetchTimestamps[1] ?? 0) - (fetchTimestamps[0] ?? 0);
   expect(gap).toBeGreaterThanOrEqual(1000);
+});
+
+// ---------------------------------------------------------------------------
+// Test 13 (P2 #3): Three concurrent gets serialize with ≥1000ms gaps
+// ---------------------------------------------------------------------------
+
+test("three concurrent gets serialize through the throttle (≥1000ms gaps)", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let mockTime = 0;
+  const fetchTimestamps: number[] = [];
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchTimestamps.push(mockTime);
+      return makeFakeResponse(200);
+    };
+
+  const fakeSleep = async (ms: number) => {
+    mockTime += ms;
+  };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: fakeSleep,
+    now: () => mockTime,
+  });
+
+  // Fire three requests concurrently.
+  await Promise.all([
+    client.get("https://example.com/a"),
+    client.get("https://example.com/b"),
+    client.get("https://example.com/c"),
+  ]);
+
+  expect(fetchTimestamps).toHaveLength(3);
+
+  const t1 = fetchTimestamps[0] ?? 0;
+  const t2 = fetchTimestamps[1] ?? 0;
+  const t3 = fetchTimestamps[2] ?? 0;
+
+  expect(t1).toBeLessThan(t2);
+  expect(t2).toBeLessThan(t3);
+  expect(t2 - t1).toBeGreaterThanOrEqual(1000);
+  expect(t3 - t2).toBeGreaterThanOrEqual(1000);
+});
+
+// ---------------------------------------------------------------------------
+// Test 14 (P2 #2): 400 — returned to caller, no retry
+// ---------------------------------------------------------------------------
+
+test("400 — returned to caller, no retry", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      return makeFakeResponse(400);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/bad-request");
+  expect(res.status).toBe(400);
+  expect(fetchCount).toBe(1);
+  expect(calls.filter((c) => c.fields.event === "fallback_http.retry")).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// Test 15 (P2 #2): 401 — returned to caller, no retry
+// ---------------------------------------------------------------------------
+
+test("401 — returned to caller, no retry", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      return makeFakeResponse(401);
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/unauthorized");
+  expect(res.status).toBe(401);
+  expect(fetchCount).toBe(1);
+  expect(calls.filter((c) => c.fields.event === "fallback_http.retry")).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// Test 16 (P2 #2): 429 — returned to caller, no retry, no rate-limit handling
+// ---------------------------------------------------------------------------
+
+test("429 — returned to caller, no retry, no special handling", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      // Include Retry-After header to prove we don't parse it.
+      return new Response(null, {
+        status: 429,
+        headers: { "Retry-After": "60", "x-ratelimit-retry-after": "60" },
+      });
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/rate-limited");
+  expect(res.status).toBe(429);
+  // Exactly one fetch — no retry logic fires.
+  expect(fetchCount).toBe(1);
+  // No retry warns and no rate-limit event.
+  expect(calls.filter((c) => c.fields.event === "fallback_http.retry")).toHaveLength(0);
+  // The sleep injector was never called with a rate-limit derived value.
+  // (sleep is async ()=>{} above — if it were called we'd still pass, but
+  //  fetchCount===1 already proves no retry path was taken.)
+});
+
+// ---------------------------------------------------------------------------
+// Test 17 (P2 #1): Empty cookies {} — valid session, Cookie header omitted
+// ---------------------------------------------------------------------------
+
+test("empty cookies {} — get omits Cookie header, sends User-Agent, no throw", async () => {
+  const { logger, calls } = makeLogger();
+  const emptyCookiesSession = {
+    cookies: {},
+    userAgent: "Mozilla/5.0 TestUA",
+    savedAt: 1700000000000,
+  };
+  const path = await writeAuth(tmpDir, emptyCookiesSession);
+
+  const capturedHeaders: Record<string, string> = {};
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> = async (
+    _url,
+    init,
+  ) => {
+    Object.assign(capturedHeaders, init?.headers as Record<string, string>);
+    return makeFakeResponse(200);
+  };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/page");
+  expect(res.status).toBe(200);
+
+  // User-Agent is present.
+  expect(capturedHeaders["user-agent"]).toBe(emptyCookiesSession.userAgent);
+  // Cookie header must NOT be present (not even as empty string).
+  expect("cookie" in capturedHeaders).toBe(false);
+
+  // No warn or error emitted.
+  expect(calls.filter((c) => c.level === "warn" || c.level === "error")).toHaveLength(0);
 });

--- a/src/integrations/fallback-http/index.ts
+++ b/src/integrations/fallback-http/index.ts
@@ -1,0 +1,3 @@
+export { createFallbackHttp } from "./service.ts";
+export { CloudflareError, MissingAuthError } from "./types.ts";
+export type { FallbackHttpClient, FallbackHttpOptions } from "./types.ts";

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -6,7 +6,7 @@ import { readFile } from "node:fs/promises";
 import type { AuthSession } from "@integrations/mangakakalot/browser/types.ts";
 import { resolveAuthPath } from "@plugins/auth-path/index.ts";
 import { CloudflareError, MissingAuthError } from "./types.ts";
-import type { FallbackHttpClient, FallbackHttpOptions } from "./types.ts";
+import type { FallbackHttpClient, FallbackHttpOptions, FetchFn } from "./types.ts";
 
 const MAX_ATTEMPTS = 4; // 1 initial + 3 retries
 const BASE_BACKOFF_MS = 500;
@@ -30,13 +30,12 @@ function isValidAuthSession(v: unknown): v is AuthSession {
 
 export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<FallbackHttpClient> {
   const { logger } = opts;
-  const fetchFn: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
-    opts.fetch ?? globalThis.fetch.bind(globalThis);
+  const fetchFn: FetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
   const sleep = opts.sleep ?? defaultSleep;
   const now = opts.now ?? Date.now;
 
   // Resolve path once — either from opts or XDG.
-  const path = opts.authPath ?? resolveAuthPath({});
+  const path = opts.authPath ?? resolveAuthPath();
 
   // Read auth.json eagerly — fail fast if missing or corrupt.
   let raw: string;
@@ -139,12 +138,8 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
         throw new CloudflareError(url);
       }
 
-      // 2xx or 4xx (non-403) — return to caller.
-      if (res && res.status >= 200 && res.status < 400) {
-        return res;
-      }
-      if (res && res.status >= 400 && res.status < 500) {
-        // 4xx other than 403 — caller decides.
+      // 2xx, 3xx, and 4xx other than 403: return to caller (no retry).
+      if (res && res.status < 500) {
         return res;
       }
 
@@ -160,6 +155,7 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
       }
 
       const status = res ? res.status : 0;
+      // Math.random is fine here — jitter only, no security relevance.
       const waitMs = BASE_BACKOFF_MS * 2 ** attempt + Math.floor(Math.random() * JITTER_MS);
 
       logger.warn(
@@ -177,8 +173,8 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
       await sleep(waitMs);
     }
 
-    // Unreachable — loop always returns or throws.
-    throw new Error(`Fallback HTTP unexpected exit: ${url}`);
+    // invariant: every iteration returns or throws — this line is unreachable.
+    throw new Error("invariant: retry loop exited without returning or throwing");
   }
 
   return { get };

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -37,11 +37,7 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
 
   // Resolve path once — either from opts or XDG.
   // resolveAuthPath requires a logger; pass through.
-  const path =
-    opts.authPath ??
-    resolveAuthPath({
-      logger,
-    });
+  const path = opts.authPath ?? resolveAuthPath({});
 
   // Read auth.json eagerly — fail fast if missing or corrupt.
   let raw: string;
@@ -81,9 +77,14 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
   );
 
   // Build cookie header string once — session is immutable for process lifetime.
-  const cookieHeader = Object.entries(session.cookies)
-    .map(([k, v]) => `${k}=${v}`)
-    .join("; ");
+  // cookieHeader is undefined (not "") when cookies is empty so the header is
+  // omitted entirely from the request — sending "Cookie: " confuses some servers.
+  const cookieHeader =
+    Object.keys(session.cookies).length > 0
+      ? Object.entries(session.cookies)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("; ")
+      : undefined;
 
   const userAgent = session.userAgent;
 
@@ -114,18 +115,18 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
     }
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      // Throttle is per-fetch (per attempt), not per dispatch.
+      // Retries already exceed the 1s window via exponential backoff, so
+      // marking each attempt keeps the throttle conservative and correct.
       lastRequestAt = now();
 
       let res: Response | undefined;
       let fetchError: unknown;
 
       try {
-        res = await fetchFn(url, {
-          headers: {
-            cookie: cookieHeader,
-            "user-agent": userAgent,
-          },
-        });
+        const headers: Record<string, string> = { "user-agent": userAgent };
+        if (cookieHeader !== undefined) headers.cookie = cookieHeader;
+        res = await fetchFn(url, { headers });
       } catch (err) {
         fetchError = err;
       }

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -36,7 +36,6 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
   const now = opts.now ?? Date.now;
 
   // Resolve path once — either from opts or XDG.
-  // resolveAuthPath requires a logger; pass through.
   const path = opts.authPath ?? resolveAuthPath({});
 
   // Read auth.json eagerly — fail fast if missing or corrupt.

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -1,0 +1,185 @@
+// Fallback HTTP client factory.
+// Reads the captured auth session once at construction time, then replays
+// cookies + UA on every request per ADR-001.
+
+import { readFile } from "node:fs/promises";
+import type { AuthSession } from "@integrations/mangakakalot/browser/types.ts";
+import { resolveAuthPath } from "@plugins/auth-path/index.ts";
+import { CloudflareError, MissingAuthError } from "./types.ts";
+import type { FallbackHttpClient, FallbackHttpOptions } from "./types.ts";
+
+const MAX_ATTEMPTS = 4; // 1 initial + 3 retries
+const BASE_BACKOFF_MS = 500;
+const JITTER_MS = 200;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isValidAuthSession(v: unknown): v is AuthSession {
+  if (!v || typeof v !== "object") return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    obj.cookies !== null &&
+    typeof obj.cookies === "object" &&
+    !Array.isArray(obj.cookies) &&
+    typeof obj.userAgent === "string" &&
+    typeof obj.savedAt === "number"
+  );
+}
+
+export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<FallbackHttpClient> {
+  const { logger } = opts;
+  const fetchFn: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    opts.fetch ?? globalThis.fetch.bind(globalThis);
+  const sleep = opts.sleep ?? defaultSleep;
+  const now = opts.now ?? Date.now;
+
+  // Resolve path once — either from opts or XDG.
+  // resolveAuthPath requires a logger; pass through.
+  const path =
+    opts.authPath ??
+    resolveAuthPath({
+      logger,
+    });
+
+  // Read auth.json eagerly — fail fast if missing or corrupt.
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    logger.warn(
+      { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "missing" },
+      "auth.json not found",
+    );
+    throw new MissingAuthError(path);
+  }
+
+  let session: AuthSession;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidAuthSession(parsed)) {
+      throw new Error("shape mismatch");
+    }
+    session = parsed;
+  } catch {
+    logger.warn(
+      { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "corrupt" },
+      `auth session at ${path} is corrupt; re-run scanldr auth`,
+    );
+    throw new MissingAuthError(path);
+  }
+
+  logger.info(
+    {
+      event: "fallback_http.session_loaded",
+      context: "fallback-http",
+      path,
+      savedAt: session.savedAt,
+    },
+    "auth session loaded",
+  );
+
+  // Build cookie header string once — session is immutable for process lifetime.
+  const cookieHeader = Object.entries(session.cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ");
+
+  const userAgent = session.userAgent;
+
+  // Throttle state — serialized via promise chain so concurrent calls queue up.
+  // null = no request made yet; number = timestamp of last request start.
+  let lastRequestAt: number | null = null;
+  // Pending chain for sequential dispatch (satisfies concurrency test #12).
+  let chain: Promise<void> = Promise.resolve();
+
+  async function get(url: string): Promise<Response> {
+    // Enqueue behind prior requests — enforces 1 req/s globally.
+    const result = chain.then(() => dispatch(url));
+    // Swallow errors on chain to prevent unhandled rejection bleed between calls.
+    chain = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  }
+
+  async function dispatch(url: string): Promise<Response> {
+    // Throttle: sleep if last request was < 1000ms ago.
+    if (lastRequestAt !== null) {
+      const elapsed = now() - lastRequestAt;
+      if (elapsed < 1000) {
+        await sleep(1000 - elapsed);
+      }
+    }
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      lastRequestAt = now();
+
+      let res: Response | undefined;
+      let fetchError: unknown;
+
+      try {
+        res = await fetchFn(url, {
+          headers: {
+            cookie: cookieHeader,
+            "user-agent": userAgent,
+          },
+        });
+      } catch (err) {
+        fetchError = err;
+      }
+
+      // 403 — Cloudflare rejection, do NOT retry.
+      if (res && res.status === 403) {
+        logger.warn(
+          { event: "fallback_http.cloudflare_rejected", context: "fallback-http", url },
+          "Cloudflare rejected the request",
+        );
+        throw new CloudflareError(url);
+      }
+
+      // 2xx or 4xx (non-403) — return to caller.
+      if (res && res.status >= 200 && res.status < 400) {
+        return res;
+      }
+      if (res && res.status >= 400 && res.status < 500) {
+        // 4xx other than 403 — caller decides.
+        return res;
+      }
+
+      // 5xx or network error — retry if attempts remain.
+      const isLast = attempt === MAX_ATTEMPTS - 1;
+      if (isLast) {
+        if (fetchError) {
+          throw fetchError instanceof Error
+            ? fetchError
+            : new Error(`Fallback HTTP network error: ${url}`);
+        }
+        throw new Error(`Fallback HTTP ${res?.status}: ${url}`);
+      }
+
+      const status = res ? res.status : 0;
+      const waitMs = BASE_BACKOFF_MS * 2 ** attempt + Math.floor(Math.random() * JITTER_MS);
+
+      logger.warn(
+        {
+          event: "fallback_http.retry",
+          context: "fallback-http",
+          attempt: attempt + 1,
+          status,
+          url,
+          waitMs,
+        },
+        `retrying after ${waitMs}ms`,
+      );
+
+      await sleep(waitMs);
+    }
+
+    // Unreachable — loop always returns or throws.
+    throw new Error(`Fallback HTTP unexpected exit: ${url}`);
+  }
+
+  return { get };
+}

--- a/src/integrations/fallback-http/types.ts
+++ b/src/integrations/fallback-http/types.ts
@@ -3,6 +3,9 @@
 
 import type { Logger } from "@plugins/logger/index.ts";
 
+/** Matches the signature of globalThis.fetch and test doubles. */
+export type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
 export class MissingAuthError extends Error {
   override readonly name = "MissingAuthError";
   constructor(public readonly path: string) {
@@ -24,7 +27,7 @@ export interface FallbackHttpOptions {
   authPath?: string;
   logger: Logger;
   /** Override fetch for testing. Defaults to globalThis.fetch. */
-  fetch?: (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  fetch?: FetchFn;
   /** Override sleep for testing. Defaults to setTimeout-based. */
   sleep?: (ms: number) => Promise<void>;
   /** Override the clock for testing. Defaults to Date.now. */

--- a/src/integrations/fallback-http/types.ts
+++ b/src/integrations/fallback-http/types.ts
@@ -1,0 +1,36 @@
+// Types and error classes for the fallback HTTP client.
+// Per ADR-001: replays all captured cookies + UA on every request.
+
+import type { Logger } from "@plugins/logger/index.ts";
+
+export class MissingAuthError extends Error {
+  override readonly name = "MissingAuthError";
+  constructor(public readonly path: string) {
+    super(`Auth session not found at ${path}. Run \`scanldr auth\` to capture one.`);
+  }
+}
+
+export class CloudflareError extends Error {
+  override readonly name = "CloudflareError";
+  constructor(public readonly url: string) {
+    super(
+      `Cloudflare rejected the request to ${url}. Run \`scanldr auth\` to refresh the session.`,
+    );
+  }
+}
+
+export interface FallbackHttpOptions {
+  /** Path to auth.json. If omitted, resolves via the same XDG logic used by `scanldr auth`. */
+  authPath?: string;
+  logger: Logger;
+  /** Override fetch for testing. Defaults to globalThis.fetch. */
+  fetch?: (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  /** Override sleep for testing. Defaults to setTimeout-based. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Override the clock for testing. Defaults to Date.now. */
+  now?: () => number;
+}
+
+export interface FallbackHttpClient {
+  get(url: string): Promise<Response>;
+}

--- a/src/integrations/mangakakalot/browser/browser.test.ts
+++ b/src/integrations/mangakakalot/browser/browser.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AuthError, pageHasRealContent, pollForClearance, resolveAuthPath } from "./index.ts";
-import type { CookieLike, RunAuthOptions } from "./types.ts";
+import { resolveAuthPath } from "@plugins/auth-path/index.ts";
+import { AuthError, pageHasRealContent, pollForClearance } from "./index.ts";
+import type { CookieLike } from "./types.ts";
 
 // ---------------------------------------------------------------------------
 // pageHasRealContent — CF challenge detection
@@ -64,24 +65,14 @@ describe("AuthError", () => {
 // resolveAuthPath — XDG layout
 // ---------------------------------------------------------------------------
 
-const noopLogger: RunAuthOptions["logger"] = {
-  error: () => {},
-  warn: () => {},
-  info: () => {},
-};
-
 describe("resolveAuthPath", () => {
   test("uses explicit dataHome when provided", () => {
-    const p = resolveAuthPath({
-      logger: noopLogger,
-      dataHome: "/tmp/explicit-data",
-    });
+    const p = resolveAuthPath({ dataHome: "/tmp/explicit-data" });
     expect(p).toBe(join("/tmp/explicit-data", "scanldr", "auth.json"));
   });
 
   test("dataHome wins over $XDG_DATA_HOME and home", () => {
     const p = resolveAuthPath({
-      logger: noopLogger,
       dataHome: "/tmp/explicit",
       env: { XDG_DATA_HOME: "/tmp/xdg" } as NodeJS.ProcessEnv,
       home: "/tmp/home",
@@ -91,7 +82,6 @@ describe("resolveAuthPath", () => {
 
   test("falls back to $XDG_DATA_HOME when set", () => {
     const p = resolveAuthPath({
-      logger: noopLogger,
       env: { XDG_DATA_HOME: "/tmp/xdg" } as NodeJS.ProcessEnv,
       home: "/tmp/ignored-home",
     });
@@ -100,7 +90,6 @@ describe("resolveAuthPath", () => {
 
   test("falls back to home/.local/share when XDG_DATA_HOME is empty", () => {
     const p = resolveAuthPath({
-      logger: noopLogger,
       env: { XDG_DATA_HOME: "" } as NodeJS.ProcessEnv,
       home: "/tmp/home",
     });
@@ -109,7 +98,6 @@ describe("resolveAuthPath", () => {
 
   test("falls back to home/.local/share when XDG_DATA_HOME is unset", () => {
     const p = resolveAuthPath({
-      logger: noopLogger,
       env: {} as NodeJS.ProcessEnv,
       home: "/tmp/home",
     });
@@ -117,19 +105,12 @@ describe("resolveAuthPath", () => {
   });
 
   test("never returns a path under cwd (security P2 — was previously CWD/.scanldr-auth.json)", () => {
-    const p = resolveAuthPath({
-      logger: noopLogger,
-      env: {} as NodeJS.ProcessEnv,
-      home: "/tmp/home",
-    });
+    const p = resolveAuthPath({ env: {} as NodeJS.ProcessEnv, home: "/tmp/home" });
     expect(p.startsWith(process.cwd())).toBe(false);
   });
 
   test("filename is auth.json (not the legacy .scanldr-auth.json)", () => {
-    const p = resolveAuthPath({
-      logger: noopLogger,
-      dataHome: "/tmp/d",
-    });
+    const p = resolveAuthPath({ dataHome: "/tmp/d" });
     expect(p.endsWith("/scanldr/auth.json")).toBe(true);
     expect(p.includes(".scanldr-auth.json")).toBe(false);
   });
@@ -234,7 +215,7 @@ describe("session persistence (mode 0600 + atomic write)", () => {
 
   test("writeFile with mode 0o600 produces a 0600 file", async () => {
     const { mkdir, writeFile } = await import("node:fs/promises");
-    const path = resolveAuthPath({ logger: noopLogger, dataHome: tmpDir });
+    const path = resolveAuthPath({ dataHome: tmpDir });
     const dir = path.substring(0, path.lastIndexOf("/"));
 
     await mkdir(dir, { recursive: true, mode: 0o700 });

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -4,40 +4,22 @@
 // Per ADR-001: no stealth — cookie replay is the strategy.
 
 import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
+// resolveAuthPath lives in @plugins/auth-path — shared with fallback-http and future integrations.
+import { resolveAuthPath } from "@plugins/auth-path/index.ts";
 import { chromium } from "playwright";
 import { AuthError } from "./types.ts";
 import type { AuthSession, PollForClearanceOptions, RunAuthOptions } from "./types.ts";
 
 export { AuthError } from "./types.ts";
 export type { AuthSession, PollForClearanceOptions, RunAuthOptions } from "./types.ts";
+// Re-export so existing callers importing resolveAuthPath from here continue to work.
+export { resolveAuthPath } from "@plugins/auth-path/index.ts";
 
-const AUTH_FILENAME = "auth.json";
-const APP_DIR = "scanldr";
 const SITE_ROOT = "https://mangakakalot.gg";
 const CF_COOKIE_TIMEOUT_MS = 120_000;
 const CF_COOKIE_INTERVAL_MS = 1_000;
 const VERIFY_TIMEOUT_MS = 15_000;
-
-/**
- * Resolves the absolute path where the auth session is persisted.
- *
- * Order:
- * 1. `opts.dataHome` (test override) → `<dataHome>/scanldr/auth.json`
- * 2. `$XDG_DATA_HOME/scanldr/auth.json`
- * 3. `<home>/.local/share/scanldr/auth.json`
- */
-export function resolveAuthPath(opts: RunAuthOptions): string {
-  const env = opts.env ?? process.env;
-  const home = opts.home ?? homedir();
-  const base =
-    opts.dataHome ??
-    (env.XDG_DATA_HOME && env.XDG_DATA_HOME.length > 0
-      ? env.XDG_DATA_HOME
-      : join(home, ".local", "share"));
-  return join(base, APP_DIR, AUTH_FILENAME);
-}
 
 const SITE_TITLE_MARKER = "MangaKakalot";
 

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -13,8 +13,6 @@ import type { AuthSession, PollForClearanceOptions, RunAuthOptions } from "./typ
 
 export { AuthError } from "./types.ts";
 export type { AuthSession, PollForClearanceOptions, RunAuthOptions } from "./types.ts";
-// Re-export so existing callers importing resolveAuthPath from here continue to work.
-export { resolveAuthPath } from "@plugins/auth-path/index.ts";
 
 const SITE_ROOT = "https://mangakakalot.gg";
 const CF_COOKIE_TIMEOUT_MS = 120_000;

--- a/src/plugins/auth-path/index.ts
+++ b/src/plugins/auth-path/index.ts
@@ -19,7 +19,7 @@ const APP_DIR = "scanldr";
  * 2. `$XDG_DATA_HOME/scanldr/auth.json`
  * 3. `<home>/.local/share/scanldr/auth.json`
  */
-export function resolveAuthPath(opts: ResolveAuthPathOptions): string {
+export function resolveAuthPath(opts: ResolveAuthPathOptions = {}): string {
   const env = opts.env ?? process.env;
   const home = opts.home ?? homedir();
   const base =

--- a/src/plugins/auth-path/index.ts
+++ b/src/plugins/auth-path/index.ts
@@ -1,0 +1,31 @@
+// XDG-aware auth.json path resolver.
+// Lifted from src/integrations/mangakakalot/browser/index.ts so multiple
+// integrations share a single source of truth.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ResolveAuthPathOptions } from "./types.ts";
+
+export type { ResolveAuthPathOptions } from "./types.ts";
+
+const AUTH_FILENAME = "auth.json";
+const APP_DIR = "scanldr";
+
+/**
+ * Resolves the absolute path where the auth session is persisted.
+ *
+ * Order:
+ * 1. `opts.dataHome` (test override) → `<dataHome>/scanldr/auth.json`
+ * 2. `$XDG_DATA_HOME/scanldr/auth.json`
+ * 3. `<home>/.local/share/scanldr/auth.json`
+ */
+export function resolveAuthPath(opts: ResolveAuthPathOptions): string {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homedir();
+  const base =
+    opts.dataHome ??
+    (env.XDG_DATA_HOME && env.XDG_DATA_HOME.length > 0
+      ? env.XDG_DATA_HOME
+      : join(home, ".local", "share"));
+  return join(base, APP_DIR, AUTH_FILENAME);
+}

--- a/src/plugins/auth-path/types.ts
+++ b/src/plugins/auth-path/types.ts
@@ -3,10 +3,7 @@
 // multiple integrations (mangakakalot, fallback-http, etc.) can resolve
 // the same XDG-aware auth.json path without cross-integration imports.
 
-import type { Logger } from "@plugins/logger/index.ts";
-
 export interface ResolveAuthPathOptions {
-  logger: Logger;
   /**
    * Base data directory override. Defaults to `$XDG_DATA_HOME` or `~/.local/share`.
    * Mostly for tests — production callers should rely on the default.

--- a/src/plugins/auth-path/types.ts
+++ b/src/plugins/auth-path/types.ts
@@ -1,0 +1,19 @@
+// Types for the auth-path resolver plugin.
+// Lifted from src/integrations/mangakakalot/browser/types.ts so that
+// multiple integrations (mangakakalot, fallback-http, etc.) can resolve
+// the same XDG-aware auth.json path without cross-integration imports.
+
+import type { Logger } from "@plugins/logger/index.ts";
+
+export interface ResolveAuthPathOptions {
+  logger: Logger;
+  /**
+   * Base data directory override. Defaults to `$XDG_DATA_HOME` or `~/.local/share`.
+   * Mostly for tests — production callers should rely on the default.
+   */
+  dataHome?: string;
+  /** Override for `process.env`. Tests only. */
+  env?: NodeJS.ProcessEnv;
+  /** Override for `os.homedir()`. Tests only. */
+  home?: string;
+}


### PR DESCRIPTION
## What this PR does

Foundation for the fallback trail (#22 mangakakalot client → #23 fallback in download). New module `src/integrations/fallback-http/` reads the `auth.json` captured by `scanldr auth` and exposes a single-purpose HTTP client that replays cookies + UA on every request, with retry/throttle/typed-error semantics.

## Why it exists

Per ADR-001 (cookie replay strategy), every fallback-site request must replay the captured Cloudflare-cleared session. Without a centralized client, each site module would reinvent the cookie jar, retry, and error handling — and the inconsistencies would leak into hard-to-debug bugs.

Ref: #21

## How it works internally

### `createFallbackHttp(opts: FallbackHttpOptions): FallbackHttpClient`

Pure factory function (no class). Eager work at construction time:

1. Resolves `authPath` (`opts.authPath` or via the lifted `resolveAuthPath` from `@plugins/auth-path`).
2. Reads `auth.json` synchronously. Missing file → `MissingAuthError`. Unparseable JSON or wrong shape → `MissingAuthError` (caller doesn't need to distinguish — both mean "re-run scanldr auth").
3. Caches the parsed `AuthSession` in the closure for the process lifetime. Re-reading on each `get()` would be wasteful — `auth` is run separately, not concurrent with downloads.
4. Emits one `info` log: `fallback_http.session_loaded` with `path` and `savedAt` only. **Cookies and UA never appear in any log payload.**

### `get(url): Promise<Response>`

1. **Throttle:** 1 req/s ceiling. `lastRequestAt` is updated per-fetch-attempt (documented inline) — retries already exceed the throttle window via exponential backoff. Concurrent calls (`Promise.all([get, get, get])`) serialize through the single `lastRequestAt` so the global rate is preserved.
2. **Headers:** `Cookie: name=val; ...` joined from the cookies map (omitted when empty), `User-Agent` from the saved UA. Empty cookies are accepted (matches the #50 round-4 decision: verify is the source of truth, not the cookie count).
3. **Status routing:**
   - 2xx, 3xx, 4xx-non-403 → return Response (caller decides).
   - **403** → `CloudflareError(url)`. No retry. Warn `fallback_http.cloudflare_rejected` before throw.
   - **5xx + network errors** → up to 4 total attempts (1 initial + 3 retries) with exponential backoff `500ms × 2^attempt + jitter`. Each retry emits a `warn` with `attempt`, `status`, `url`, `waitMs`. After exhaustion, throws an Error with the underlying status.
   - **429** is not specially handled — fallback sites have no published rate limits; the spec says no token bucket. Just return the Response.

### `resolveAuthPath` lift

Moved from `src/integrations/mangakakalot/browser/` to `src/plugins/auth-path/` since both `runAuth` (writer) and `createFallbackHttp` (reader) need it. `ResolveAuthPathOptions` is now optional (defaults to `{}`); `runAuth`'s `RunAuthOptions` retains its own `logger` field. The old re-export from `mangakakalot/browser/index.ts` was dropped — `browser.test.ts` updated to import from the new path.

### Errors

- `MissingAuthError` — auth.json missing, unparseable, or wrong shape. Carries `path`.
- `CloudflareError` — server returned 403 (session no longer cleared). Carries `url`.

Both extend `Error` with `name` set; trivially typed for `instanceof` branching at the CLI surface (#23 will catch and format these).

## What did not change

- `auth.json` file format, mode bits (0600), or location semantics.
- `runAuth` flow — only its `resolveAuthPath` import path.
- The MangaDex http client / at-home / list / download flows.
- Any existing test (the 294 from #15 still pass).

## ACs satisfied

- [x] Constructor reads `AuthSession` from disk; missing file throws `MissingAuthError`
- [x] Corrupt or wrong-shape file throws `MissingAuthError`
- [x] Empty cookies map accepted (verify is the source of truth — Cookie header omitted entirely)
- [x] Every request includes all captured cookies + UA in headers
- [x] `403` → `CloudflareError`, no retry
- [x] 5xx and network errors retried up to 3 additional times (4 total attempts) with backoff + jitter
- [x] 4xx-non-403 (400, 401, 429) returned to caller, no retry, no rate-limit parsing
- [x] 1 req/s throttle ceiling enforced globally — sequential AND concurrent calls
- [x] Cookie values and UA never appear in any log payload (sentinel test)
- [x] `resolveAuthPath` lifted to `@plugins/auth-path`; single declaration in the codebase

## Test checklist

- [x] Construction: missing / corrupt / wrong-shape / valid (4 tests)
- [x] `get()`: cookies + UA in headers, 200 returns Response (1 test)
- [x] Sentinel test: no cookie value or UA appears in any log payload
- [x] 403 → CloudflareError, no retry, warn fired
- [x] 5xx + 5xx + 5xx + 5xx → throws after 3 retries; payload of all 3 retry warns asserted (`attempt`, `status`, `url`, `waitMs: expect.any(Number)`)
- [x] 5xx → 200 resolves; 1 retry warn
- [x] Network error → 200 resolves; 1 retry warn
- [x] 400, 401, 429 → return Response, no retry (3 tests)
- [x] 404 → return Response, no retry
- [x] Empty cookies — Cookie header omitted entirely
- [x] Throttle: two sequential calls — second sleeps to reach 1000ms gap
- [x] Throttle: two concurrent calls serialize
- [x] Throttle: three concurrent calls — request times spaced ≥1000ms apart globally
- [x] `bun test` — 312 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- The `lastRequestAt` is updated per-fetch-attempt (not per-dispatch). Documented inline. If the throttle semantics ever need to change to per-dispatch, the test patterns are deterministic enough to update.
- Empty-cookies behavior matches the decision from PR #50 round 4: `runAuth` is the source of truth for session validity; the fallback client doesn't second-guess by re-imposing a cookie-count guard.
- `FetchFn` lives in `fallback-http/types.ts` rather than importing from `mangadex/http/types.ts` — keeping integrations decoupled. They're each one line.
- The retry loop has a defensive invariant `throw` after the loop body. The compiler can't statically prove the loop always returns/throws on the final iteration; the throw signals "programmer error / file a bug" rather than a user-facing case.

## Closes

Ref: #21

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/` (no doc changes needed — ADR-001 + auth_model.md already specified the behavior this PR implements)