### PR TITLE
feat(mangakakalot): client and parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "scanldr",
       "dependencies": {
+        "cheerio": "^1.2.0",
         "fflate": "^0.8.2",
         "playwright": "^1.59.1",
       },
@@ -38,18 +39,64 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
+    "cheerio": "^1.2.0",
     "fflate": "^0.8.2",
     "playwright": "^1.59.1"
   }

--- a/src/integrations/_shared/manga.ts
+++ b/src/integrations/_shared/manga.ts
@@ -1,0 +1,26 @@
+// Shared manga domain types used across integrations (mangadex, mangakakalot, etc.).
+// Both integration clients depend on this module — never import types from one integration into another.
+
+export interface MangaCandidate {
+  id: string;
+  title: string;
+  originalLanguage: string;
+  year: number | null;
+}
+
+export interface VolumeRef {
+  volume: string;
+  numeric: number;
+  chapterIds: string[];
+}
+
+export interface ChapterRef {
+  id: string;
+  volume: string | null;
+  chapter: string | null;
+  title: string | null;
+  translatedLanguage: string;
+  scanlationGroup: string | null;
+  readableAt: string;
+  externalUrl: string | null;
+}

--- a/src/integrations/mangadex/client/types.ts
+++ b/src/integrations/mangadex/client/types.ts
@@ -1,29 +1,10 @@
 // Internal types for the MangaDex client layer.
 // API response shapes (MdX*) stay here and never leak past parser.ts.
+// Domain types (MangaCandidate, ChapterRef, VolumeRef) live in _shared/manga.ts — re-exported here for backwards compat.
 
-export interface MangaCandidate {
-  id: string;
-  title: string;
-  originalLanguage: string;
-  year: number | null;
-}
+import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/_shared/manga.ts";
 
-export interface VolumeRef {
-  volume: string;
-  numeric: number;
-  chapterIds: string[];
-}
-
-export interface ChapterRef {
-  id: string;
-  volume: string | null;
-  chapter: string | null;
-  title: string | null;
-  translatedLanguage: string;
-  scanlationGroup: string | null;
-  readableAt: string;
-  externalUrl: string | null;
-}
+export type { ChapterRef, MangaCandidate, VolumeRef };
 
 // --- MangaDex REST response shapes ---
 

--- a/src/integrations/mangakakalot/client/client.test.ts
+++ b/src/integrations/mangakakalot/client/client.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+import { createMangakakalotClient } from "./index.ts";
+import {
+  parseChapterImages,
+  parseChapterList,
+  parseChapterListPagination,
+  parseSearchResults,
+} from "./parser.ts";
+
+const fixturesDir = join(import.meta.dir, "../../../../tests/fixtures/mangakakalot");
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixturesDir, name), "utf-8");
+}
+
+function makeLogger(): Logger {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+  } as unknown as Logger;
+}
+
+function makeHttp(responses: Record<string, string>): FallbackHttpClient {
+  return {
+    get: mock(async (url: string) => {
+      const body = responses[url];
+      if (body === undefined) throw new Error(`Unexpected URL in test: ${url}`);
+      return new Response(body, { status: 200, headers: { "content-type": "text/html" } });
+    }),
+  };
+}
+
+// ─── parseSearchResults ───────────────────────────────────────────────────────
+
+describe("parseSearchResults", () => {
+  it("returns candidates from search fixture", () => {
+    const html = readFixture("search-naruto.html");
+    const results = parseSearchResults(html);
+    expect(results.length).toBe(3);
+    expect(results[0]).toMatchObject({
+      id: "naruto",
+      title: "Naruto",
+      originalLanguage: "en",
+      year: null,
+    });
+    expect(results[1]?.id).toBe("naruto-shippuden");
+  });
+
+  it("returns empty array when no results", () => {
+    const html = "<html><body><div class='panel_story_list'></div></body></html>";
+    expect(parseSearchResults(html)).toEqual([]);
+  });
+});
+
+// ─── parseChapterList ─────────────────────────────────────────────────────────
+
+describe("parseChapterList", () => {
+  it("parses chapter list from manga fixture", () => {
+    const html = readFixture("manga-naruto.html");
+    const chapters = parseChapterList(html, "naruto");
+    expect(chapters.length).toBe(3);
+
+    if (!chapters[0]) throw new Error("Expected chapter at index 0");
+    const ch700 = chapters[0];
+    expect(ch700.chapter).toBe("700");
+    expect(ch700.volume).toBeNull();
+    expect(ch700.translatedLanguage).toBe("en");
+    expect(ch700.scanlationGroup).toBeNull();
+    expect(ch700.externalUrl).toBeNull();
+    expect(ch700.readableAt).toBe(new Date("Dec 10, 2014 00:00").toISOString());
+    expect(ch700.id).toContain("chapter/naruto/chapter-700");
+  });
+
+  it("returns single chapter correctly", () => {
+    const html = `
+      <div class="chapter-list">
+        <div class="row">
+          <span><a href="https://mangakakalot.gg/chapter/test/chapter-1">Chapter 1</a></span>
+          <span title="Jan 01, 2020 00:00">Jan 01,2020</span>
+        </div>
+      </div>`;
+    const chapters = parseChapterList(html, "test");
+    expect(chapters.length).toBe(1);
+    expect(chapters[0]?.chapter).toBe("1");
+  });
+
+  it("returns empty array when no chapter rows", () => {
+    const html = "<html><body></body></html>";
+    expect(parseChapterList(html, "empty")).toEqual([]);
+  });
+
+  it("uses epoch when date is missing", () => {
+    const html = `
+      <div class="chapter-list">
+        <div class="row">
+          <span><a href="https://mangakakalot.gg/chapter/test/chapter-5">Chapter 5</a></span>
+          <span></span>
+        </div>
+      </div>`;
+    const chapters = parseChapterList(html, "test");
+    expect(chapters[0]?.readableAt).toBe(new Date(0).toISOString());
+  });
+});
+
+// ─── parseChapterImages ───────────────────────────────────────────────────────
+
+describe("parseChapterImages", () => {
+  it("parses images from chapter fixture, preferring data-src", () => {
+    const html = readFixture("chapter-naruto-1.html");
+    const images = parseChapterImages(html);
+    expect(images.length).toBe(3);
+    // Page 1: both src and data-src — data-src wins
+    expect(images[0]).toEqual({ url: "https://cdn.example.com/naruto/ch1/page-1.jpg", page: 1 });
+    // Page 2: src only
+    expect(images[1]).toEqual({ url: "https://cdn.example.com/naruto/ch1/page-2.jpg", page: 2 });
+    // Page 3: data-src only
+    expect(images[2]).toEqual({ url: "https://cdn.example.com/naruto/ch1/page-3.jpg", page: 3 });
+  });
+
+  it("returns empty array when no images", () => {
+    const html = "<html><body><div class='container-chapter-reader'></div></body></html>";
+    expect(parseChapterImages(html)).toEqual([]);
+  });
+
+  it("handles src-only images", () => {
+    const html = `
+      <div class="container-chapter-reader">
+        <img src="https://cdn.example.com/p1.jpg" />
+        <img src="https://cdn.example.com/p2.jpg" />
+      </div>`;
+    const images = parseChapterImages(html);
+    expect(images).toEqual([
+      { url: "https://cdn.example.com/p1.jpg", page: 1 },
+      { url: "https://cdn.example.com/p2.jpg", page: 2 },
+    ]);
+  });
+
+  it("handles data-src-only images", () => {
+    const html = `
+      <div class="container-chapter-reader">
+        <img data-src="https://cdn.example.com/lazy.jpg" />
+      </div>`;
+    const images = parseChapterImages(html);
+    expect(images).toEqual([{ url: "https://cdn.example.com/lazy.jpg", page: 1 }]);
+  });
+});
+
+// ─── parseChapterListPagination ───────────────────────────────────────────────
+
+describe("parseChapterListPagination", () => {
+  it("returns next URL from paginated fixture", () => {
+    const html = readFixture("manga-paginated.html");
+    const next = parseChapterListPagination(html);
+    expect(next).toBe("https://mangakakalot.gg/manga/bleach?page=2");
+  });
+
+  it("returns null when no pagination panel", () => {
+    expect(parseChapterListPagination("<html><body></body></html>")).toBeNull();
+  });
+
+  it("returns null when no next page link after active page", () => {
+    const html = `
+      <div class="panel_page_number">
+        <a href="/manga/test?page=1">1</a>
+        <a href="/manga/test?page=2" class="page_select">2</a>
+      </div>`;
+    expect(parseChapterListPagination(html)).toBeNull();
+  });
+});
+
+// ─── MangakakalotClient ───────────────────────────────────────────────────────
+
+describe("createMangakakalotClient", () => {
+  describe("searchManga", () => {
+    it("fetches search URL and returns parsed results", async () => {
+      const html = readFixture("search-naruto.html");
+      const http = makeHttp({ "https://mangakakalot.gg/search/story/naruto": html });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      const results = await client.searchManga("naruto");
+      expect(results.length).toBe(3);
+      expect(results[0]?.id).toBe("naruto");
+      // @ts-ignore — logger is a mock
+      expect(logger.info).toHaveBeenCalledTimes(1);
+    });
+
+    it("encodes multi-word title with underscores", async () => {
+      const http = makeHttp({
+        "https://mangakakalot.gg/search/story/one_piece": "<html><body></body></html>",
+      });
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+      const results = await client.searchManga("One Piece");
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("getChapterList", () => {
+    it("returns chapters from a single-page manga", async () => {
+      const html = readFixture("manga-naruto.html");
+      const http = makeHttp({ "https://mangakakalot.gg/manga/naruto": html });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      const chapters = await client.getChapterList("naruto");
+      expect(chapters.length).toBe(3);
+      // @ts-ignore
+      expect(logger.info).toHaveBeenCalledTimes(1);
+    });
+
+    it("follows pagination and concatenates chapters", async () => {
+      const page1 = readFixture("manga-paginated.html");
+      const page2 = `
+        <div class="chapter-list">
+          <div class="row">
+            <span><a href="https://mangakakalot.gg/chapter/bleach/chapter-685">Chapter 685</a></span>
+            <span title="Aug 15, 2016 00:00">Aug 15,2016</span>
+          </div>
+        </div>`;
+      const http = makeHttp({
+        "https://mangakakalot.gg/manga/bleach": page1,
+        "https://mangakakalot.gg/manga/bleach?page=2": page2,
+      });
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+
+      const chapters = await client.getChapterList("bleach");
+      expect(chapters.length).toBe(2);
+      expect(chapters[0]?.chapter).toBe("686");
+      expect(chapters[1]?.chapter).toBe("685");
+      // @ts-ignore
+      expect(http.get).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates CloudflareError without swallowing", async () => {
+      const { CloudflareError } = await import("@integrations/fallback-http/types.ts");
+      const http: FallbackHttpClient = {
+        get: mock(async () => {
+          throw new CloudflareError("https://mangakakalot.gg/manga/naruto");
+        }),
+      };
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+      await expect(client.getChapterList("naruto")).rejects.toBeInstanceOf(CloudflareError);
+    });
+  });
+
+  describe("getChapterImages", () => {
+    it("accepts a full URL", async () => {
+      const html = readFixture("chapter-naruto-1.html");
+      const http = makeHttp({ "https://mangakakalot.gg/chapter/naruto/chapter-1": html });
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+
+      const images = await client.getChapterImages(
+        "https://mangakakalot.gg/chapter/naruto/chapter-1",
+      );
+      expect(images.length).toBe(3);
+    });
+
+    it("accepts a path-style id", async () => {
+      const html = readFixture("chapter-naruto-1.html");
+      const http = makeHttp({ "https://mangakakalot.gg/chapter/naruto/chapter-1": html });
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+
+      const images = await client.getChapterImages("chapter/naruto/chapter-1");
+      expect(images.length).toBe(3);
+    });
+
+    it("logs mangakakalot.fetch event", async () => {
+      const html = readFixture("chapter-naruto-1.html");
+      const http = makeHttp({ "https://mangakakalot.gg/chapter/naruto/chapter-1": html });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      await client.getChapterImages("chapter/naruto/chapter-1");
+      // @ts-ignore
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.fetch" }),
+        expect.any(String),
+      );
+    });
+  });
+});

--- a/src/integrations/mangakakalot/client/client.test.ts
+++ b/src/integrations/mangakakalot/client/client.test.ts
@@ -10,6 +10,7 @@ import {
   parseChapterListPagination,
   parseSearchResults,
 } from "./parser.ts";
+import { MangakakalotParseError } from "./types.ts";
 
 const fixturesDir = join(import.meta.dir, "../../../../tests/fixtures/mangakakalot");
 
@@ -51,9 +52,33 @@ describe("parseSearchResults", () => {
     expect(results[1]?.id).toBe("naruto-shippuden");
   });
 
-  it("returns empty array when no results", () => {
+  it("returns empty array when panel_story_list present but empty", () => {
     const html = "<html><body><div class='panel_story_list'></div></body></html>";
     expect(parseSearchResults(html)).toEqual([]);
+  });
+
+  it("throws MangakakalotParseError when search container is missing from a live page", () => {
+    // A real page body with no search container = DOM drifted, not "no results"
+    const html =
+      "<html><body><header>Site Header</header><main>Some other content</main></body></html>";
+    expect(() => parseSearchResults(html, "https://mangakakalot.gg/search/story/naruto")).toThrow(
+      MangakakalotParseError,
+    );
+  });
+
+  it("MangakakalotParseError carries the correct url and selector", () => {
+    const url = "https://mangakakalot.gg/search/story/naruto";
+    const html = "<html><body><header>Site Header</header><main>content</main></body></html>";
+    let caught: unknown;
+    try {
+      parseSearchResults(html, url);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MangakakalotParseError);
+    const e = caught as MangakakalotParseError;
+    expect(e.url).toBe(url);
+    expect(e.selector).toContain(".story_item");
   });
 });
 
@@ -89,9 +114,31 @@ describe("parseChapterList", () => {
     expect(chapters[0]?.chapter).toBe("1");
   });
 
-  it("returns empty array when no chapter rows", () => {
-    const html = "<html><body></body></html>";
-    expect(parseChapterList(html, "empty")).toEqual([]);
+  it("returns empty array when chapter rows absent but title present (manga has no releases)", () => {
+    // Title present + no chapter rows = valid empty state
+    const html = "<html><body><div class='manga-info-text'><h1>Test Manga</h1></div></body></html>";
+    expect(parseChapterList(html, "test-manga")).toEqual([]);
+  });
+
+  it("throws MangakakalotParseError when both chapter list and title selectors are missing", () => {
+    const url = "https://mangakakalot.gg/manga/test-manga";
+    const html = "<html><body>404 not found</body></html>";
+    expect(() => parseChapterList(html, "test-manga", url)).toThrow(MangakakalotParseError);
+  });
+
+  it("MangakakalotParseError from chapter list carries url and selector", () => {
+    const url = "https://mangakakalot.gg/manga/test-manga";
+    const html = "<html><body>404 not found</body></html>";
+    let caught: unknown;
+    try {
+      parseChapterList(html, "test-manga", url);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MangakakalotParseError);
+    const e = caught as MangakakalotParseError;
+    expect(e.url).toBe(url);
+    expect(e.selector).toContain(".chapter-list");
   });
 
   it("uses epoch when date is missing", () => {
@@ -122,9 +169,25 @@ describe("parseChapterImages", () => {
     expect(images[2]).toEqual({ url: "https://cdn.example.com/naruto/ch1/page-3.jpg", page: 3 });
   });
 
-  it("returns empty array when no images", () => {
+  it("throws MangakakalotParseError when reader container has no images", () => {
+    const url = "https://mangakakalot.gg/chapter/naruto/chapter-1";
     const html = "<html><body><div class='container-chapter-reader'></div></body></html>";
-    expect(parseChapterImages(html)).toEqual([]);
+    expect(() => parseChapterImages(html, url)).toThrow(MangakakalotParseError);
+  });
+
+  it("MangakakalotParseError from images carries url and selector", () => {
+    const url = "https://mangakakalot.gg/chapter/naruto/chapter-1";
+    const html = "<html><body>404 not found</body></html>";
+    let caught: unknown;
+    try {
+      parseChapterImages(html, url);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MangakakalotParseError);
+    const e = caught as MangakakalotParseError;
+    expect(e.url).toBe(url);
+    expect(e.selector).toContain(".container-chapter-reader");
   });
 
   it("handles src-only images", () => {
@@ -163,7 +226,7 @@ describe("parseChapterListPagination", () => {
     expect(parseChapterListPagination("<html><body></body></html>")).toBeNull();
   });
 
-  it("returns null when no next page link after active page", () => {
+  it("returns null when no next page link after active page (last page)", () => {
     const html = `
       <div class="panel_page_number">
         <a href="/manga/test?page=1">1</a>
@@ -192,11 +255,40 @@ describe("createMangakakalotClient", () => {
 
     it("encodes multi-word title with underscores", async () => {
       const http = makeHttp({
-        "https://mangakakalot.gg/search/story/one_piece": "<html><body></body></html>",
+        "https://mangakakalot.gg/search/story/one_piece":
+          "<html><body><div class='panel_story_list'></div></body></html>",
       });
       const client = createMangakakalotClient({ http, logger: makeLogger() });
       const results = await client.searchManga("One Piece");
       expect(results).toEqual([]);
+    });
+
+    it("propagates CloudflareError from http.get without swallowing", async () => {
+      const { CloudflareError } = await import("@integrations/fallback-http/types.ts");
+      const http: FallbackHttpClient = {
+        get: mock(async () => {
+          throw new CloudflareError("https://mangakakalot.gg/search/story/naruto");
+        }),
+      };
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+      await expect(client.searchManga("naruto")).rejects.toBeInstanceOf(CloudflareError);
+    });
+
+    it("logs warn and propagates MangakakalotParseError when DOM is broken", async () => {
+      // Broken page: has body content but no search results container
+      const brokenHtml =
+        "<html><body><header>Site Header</header><main>Completely different layout</main></body></html>";
+      const url = "https://mangakakalot.gg/search/story/naruto";
+      const http = makeHttp({ [url]: brokenHtml });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      await expect(client.searchManga("naruto")).rejects.toBeInstanceOf(MangakakalotParseError);
+      // @ts-ignore
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.parse_failed" }),
+        expect.any(String),
+      );
     });
   });
 
@@ -216,6 +308,7 @@ describe("createMangakakalotClient", () => {
     it("follows pagination and concatenates chapters", async () => {
       const page1 = readFixture("manga-paginated.html");
       const page2 = `
+        <div class="manga-info-text"><h1>Bleach</h1></div>
         <div class="chapter-list">
           <div class="row">
             <span><a href="https://mangakakalot.gg/chapter/bleach/chapter-685">Chapter 685</a></span>
@@ -245,6 +338,23 @@ describe("createMangakakalotClient", () => {
       };
       const client = createMangakakalotClient({ http, logger: makeLogger() });
       await expect(client.getChapterList("naruto")).rejects.toBeInstanceOf(CloudflareError);
+    });
+
+    it("logs warn and propagates MangakakalotParseError when DOM is broken", async () => {
+      const brokenHtml = "<html><body>404 not found</body></html>";
+      const url = "https://mangakakalot.gg/manga/test-manga";
+      const http = makeHttp({ [url]: brokenHtml });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      await expect(client.getChapterList("test-manga")).rejects.toBeInstanceOf(
+        MangakakalotParseError,
+      );
+      // @ts-ignore
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.parse_failed" }),
+        expect.any(String),
+      );
     });
   });
 
@@ -279,6 +389,34 @@ describe("createMangakakalotClient", () => {
       // @ts-ignore
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({ event: "mangakakalot.fetch" }),
+        expect.any(String),
+      );
+    });
+
+    it("propagates CloudflareError from http.get without swallowing", async () => {
+      const { CloudflareError } = await import("@integrations/fallback-http/types.ts");
+      const http: FallbackHttpClient = {
+        get: mock(async () => {
+          throw new CloudflareError("https://mangakakalot.gg/chapter/naruto/chapter-1");
+        }),
+      };
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+      await expect(client.getChapterImages("chapter/naruto/chapter-1")).rejects.toBeInstanceOf(
+        CloudflareError,
+      );
+    });
+
+    it("logs warn and propagates MangakakalotParseError when reader has no images", async () => {
+      const brokenHtml = "<html><body><div class='container-chapter-reader'></div></body></html>";
+      const url = "https://mangakakalot.gg/chapter/naruto/chapter-1";
+      const http = makeHttp({ [url]: brokenHtml });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      await expect(client.getChapterImages(url)).rejects.toBeInstanceOf(MangakakalotParseError);
+      // @ts-ignore
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.parse_failed" }),
         expect.any(String),
       );
     });

--- a/src/integrations/mangakakalot/client/client.test.ts
+++ b/src/integrations/mangakakalot/client/client.test.ts
@@ -41,7 +41,7 @@ function makeHttp(responses: Record<string, string>): FallbackHttpClient {
 describe("parseSearchResults", () => {
   it("returns candidates from search fixture", () => {
     const html = readFixture("search-naruto.html");
-    const results = parseSearchResults(html);
+    const results = parseSearchResults(html, "https://mangakakalot.gg/search/story/naruto");
     expect(results.length).toBe(3);
     expect(results[0]).toMatchObject({
       id: "naruto",
@@ -54,7 +54,7 @@ describe("parseSearchResults", () => {
 
   it("returns empty array when panel_story_list present but empty", () => {
     const html = "<html><body><div class='panel_story_list'></div></body></html>";
-    expect(parseSearchResults(html)).toEqual([]);
+    expect(parseSearchResults(html, "https://mangakakalot.gg/search/story/test")).toEqual([]);
   });
 
   it("throws MangakakalotParseError when search container is missing from a live page", () => {
@@ -87,7 +87,7 @@ describe("parseSearchResults", () => {
 describe("parseChapterList", () => {
   it("parses chapter list from manga fixture", () => {
     const html = readFixture("manga-naruto.html");
-    const chapters = parseChapterList(html, "naruto");
+    const chapters = parseChapterList(html, "https://mangakakalot.gg/manga/naruto");
     expect(chapters.length).toBe(3);
 
     if (!chapters[0]) throw new Error("Expected chapter at index 0");
@@ -109,7 +109,7 @@ describe("parseChapterList", () => {
           <span title="Jan 01, 2020 00:00">Jan 01,2020</span>
         </div>
       </div>`;
-    const chapters = parseChapterList(html, "test");
+    const chapters = parseChapterList(html, "https://mangakakalot.gg/manga/test");
     expect(chapters.length).toBe(1);
     expect(chapters[0]?.chapter).toBe("1");
   });
@@ -117,13 +117,13 @@ describe("parseChapterList", () => {
   it("returns empty array when chapter rows absent but title present (manga has no releases)", () => {
     // Title present + no chapter rows = valid empty state
     const html = "<html><body><div class='manga-info-text'><h1>Test Manga</h1></div></body></html>";
-    expect(parseChapterList(html, "test-manga")).toEqual([]);
+    expect(parseChapterList(html, "https://mangakakalot.gg/manga/test-manga")).toEqual([]);
   });
 
   it("throws MangakakalotParseError when both chapter list and title selectors are missing", () => {
     const url = "https://mangakakalot.gg/manga/test-manga";
     const html = "<html><body>404 not found</body></html>";
-    expect(() => parseChapterList(html, "test-manga", url)).toThrow(MangakakalotParseError);
+    expect(() => parseChapterList(html, url)).toThrow(MangakakalotParseError);
   });
 
   it("MangakakalotParseError from chapter list carries url and selector", () => {
@@ -131,7 +131,7 @@ describe("parseChapterList", () => {
     const html = "<html><body>404 not found</body></html>";
     let caught: unknown;
     try {
-      parseChapterList(html, "test-manga", url);
+      parseChapterList(html, url);
     } catch (err) {
       caught = err;
     }
@@ -149,7 +149,7 @@ describe("parseChapterList", () => {
           <span></span>
         </div>
       </div>`;
-    const chapters = parseChapterList(html, "test");
+    const chapters = parseChapterList(html, "https://mangakakalot.gg/manga/test");
     expect(chapters[0]?.readableAt).toBe(new Date(0).toISOString());
   });
 });
@@ -159,7 +159,7 @@ describe("parseChapterList", () => {
 describe("parseChapterImages", () => {
   it("parses images from chapter fixture, preferring data-src", () => {
     const html = readFixture("chapter-naruto-1.html");
-    const images = parseChapterImages(html);
+    const images = parseChapterImages(html, "https://mangakakalot.gg/chapter/naruto/chapter-1");
     expect(images.length).toBe(3);
     // Page 1: both src and data-src — data-src wins
     expect(images[0]).toEqual({ url: "https://cdn.example.com/naruto/ch1/page-1.jpg", page: 1 });
@@ -196,7 +196,7 @@ describe("parseChapterImages", () => {
         <img src="https://cdn.example.com/p1.jpg" />
         <img src="https://cdn.example.com/p2.jpg" />
       </div>`;
-    const images = parseChapterImages(html);
+    const images = parseChapterImages(html, "https://mangakakalot.gg/chapter/test/chapter-1");
     expect(images).toEqual([
       { url: "https://cdn.example.com/p1.jpg", page: 1 },
       { url: "https://cdn.example.com/p2.jpg", page: 2 },
@@ -208,7 +208,7 @@ describe("parseChapterImages", () => {
       <div class="container-chapter-reader">
         <img data-src="https://cdn.example.com/lazy.jpg" />
       </div>`;
-    const images = parseChapterImages(html);
+    const images = parseChapterImages(html, "https://mangakakalot.gg/chapter/test/chapter-1");
     expect(images).toEqual([{ url: "https://cdn.example.com/lazy.jpg", page: 1 }]);
   });
 });
@@ -355,6 +355,56 @@ describe("createMangakakalotClient", () => {
         expect.objectContaining({ event: "mangakakalot.parse_failed" }),
         expect.any(String),
       );
+    });
+
+    it("emits pagination_capped warn exactly once when chapter list exceeds MAX_PAGINATION_PAGES", async () => {
+      // Build 21 synthetic pages: pages 1-20 each point to the next, page 21 would be fetched if no cap.
+      // The cap is 20 — after fetching pages 0-19 (20 fetches), the loop sees url !== null and pagesFollowed === 20, warns and breaks.
+      const BASE = "https://mangakakalot.gg/manga/long-manga";
+      const chapterHtml = (chapterNum: number, nextPageNum: number) => `
+        <div class="manga-info-text"><h1>Long Manga</h1></div>
+        <div class="chapter-list">
+          <div class="row">
+            <span><a href="https://mangakakalot.gg/chapter/long-manga/chapter-${chapterNum}">Chapter ${chapterNum}</a></span>
+            <span title="Jan 01, 2020 00:00">Jan 01,2020</span>
+          </div>
+        </div>
+        <div class="panel_page_number">
+          <a href="${BASE}?page=${nextPageNum - 1}" class="page_select">${nextPageNum - 1}</a>
+          <a href="${BASE}?page=${nextPageNum}">${nextPageNum}</a>
+        </div>`;
+
+      // Page with no next link (last page — never fetched due to cap)
+      const lastPageHtml = `
+        <div class="manga-info-text"><h1>Long Manga</h1></div>
+        <div class="chapter-list">
+          <div class="row">
+            <span><a href="https://mangakakalot.gg/chapter/long-manga/chapter-21">Chapter 21</a></span>
+            <span title="Jan 01, 2020 00:00">Jan 01,2020</span>
+          </div>
+        </div>`;
+
+      const responses: Record<string, string> = { [BASE]: chapterHtml(1, 2) };
+      for (let p = 2; p <= 20; p++) {
+        responses[`${BASE}?page=${p}`] = chapterHtml(p, p + 1);
+      }
+      responses[`${BASE}?page=21`] = lastPageHtml;
+
+      const http = makeHttp(responses);
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      const chapters = await client.getChapterList("long-manga");
+      expect(chapters.length).toBe(20); // 20 pages fetched, 1 chapter each
+      // @ts-ignore
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      // @ts-ignore
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.pagination_capped", slug: "long-manga" }),
+        expect.any(String),
+      );
+      // @ts-ignore
+      expect(http.get).toHaveBeenCalledTimes(20); // page 21 never fetched
     });
   });
 

--- a/src/integrations/mangakakalot/client/index.ts
+++ b/src/integrations/mangakakalot/client/index.ts
@@ -2,9 +2,7 @@
 // Wraps a FallbackHttpClient (cookie-replay, handles Cloudflare) and returns parsed domain types.
 // Callers are responsible for creating the FallbackHttpClient via createFallbackHttp().
 
-import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
-import type { ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import {
   parseChapterImages,
@@ -12,9 +10,12 @@ import {
   parseChapterListPagination,
   parseSearchResults,
 } from "./parser.ts";
+import type { ChapterRef, ImageRef, MangaCandidate, MangakakalotClient } from "./types.ts";
+import { MangakakalotParseError } from "./types.ts";
 
 export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 export type { ImageRef } from "@modules/downloader/types.ts";
+export type { MangakakalotClient } from "./types.ts";
 export { MangakakalotParseError } from "./types.ts";
 
 const SITE_ROOT = "https://mangakakalot.gg";
@@ -23,12 +24,6 @@ const MANGA_URL = (slug: string) => `${SITE_ROOT}/manga/${slug}`;
 
 /** Maximum pages to follow when paginating a chapter list — guards against misparsed links. */
 const MAX_PAGINATION_PAGES = 20;
-
-export interface MangakakalotClient {
-  searchManga(title: string): Promise<MangaCandidate[]>;
-  getChapterList(slug: string): Promise<ChapterRef[]>;
-  getChapterImages(chapterIdOrUrl: string): Promise<ImageRef[]>;
-}
 
 export function createMangakakalotClient(opts: {
   http: FallbackHttpClient;
@@ -42,13 +37,34 @@ export function createMangakakalotClient(opts: {
     return res.text();
   }
 
+  /** Runs a parser function and wraps MangakakalotParseError with a warn log before re-throwing. */
+  function runParser<T>(url: string, fn: () => T): T {
+    try {
+      return fn();
+    } catch (err) {
+      if (err instanceof MangakakalotParseError) {
+        logger.warn(
+          {
+            event: "mangakakalot.parse_failed",
+            context: "mangakakalot",
+            url,
+            selector: err.selector,
+            err,
+          },
+          "mangakakalot DOM parse failed",
+        );
+      }
+      throw err;
+    }
+  }
+
   async function searchManga(title: string): Promise<MangaCandidate[]> {
     // URL: https://mangakakalot.gg/search/story/<encoded-title>
     // Words separated by underscores per mangakakalot's search convention.
     const encoded = encodeURIComponent(title.toLowerCase().replace(/\s+/g, "_"));
     const url = `${SEARCH_URL}/${encoded}`;
     const html = await fetchHtml(url);
-    return parseSearchResults(html);
+    return runParser(url, () => parseSearchResults(html, url));
   }
 
   async function getChapterList(slug: string): Promise<ChapterRef[]> {
@@ -57,8 +73,9 @@ export function createMangakakalotClient(opts: {
     let pagesFollowed = 0;
 
     while (url !== null && pagesFollowed < MAX_PAGINATION_PAGES) {
-      const html = await fetchHtml(url);
-      const pageChapters = parseChapterList(html, slug);
+      const currentUrl = url;
+      const html = await fetchHtml(currentUrl);
+      const pageChapters = runParser(currentUrl, () => parseChapterList(html, slug, currentUrl));
       allChapters = allChapters.concat(pageChapters);
 
       const nextUrl = parseChapterListPagination(html);
@@ -78,7 +95,7 @@ export function createMangakakalotClient(opts: {
       url = `${SITE_ROOT}/${chapterIdOrUrl}`;
     }
     const html = await fetchHtml(url);
-    return parseChapterImages(html);
+    return runParser(url, () => parseChapterImages(html, url));
   }
 
   return { searchManga, getChapterList, getChapterImages };

--- a/src/integrations/mangakakalot/client/index.ts
+++ b/src/integrations/mangakakalot/client/index.ts
@@ -2,7 +2,9 @@
 // Wraps a FallbackHttpClient (cookie-replay, handles Cloudflare) and returns parsed domain types.
 // Callers are responsible for creating the FallbackHttpClient via createFallbackHttp().
 
+import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
+import type { ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import {
   parseChapterImages,
@@ -10,7 +12,7 @@ import {
   parseChapterListPagination,
   parseSearchResults,
 } from "./parser.ts";
-import type { ChapterRef, ImageRef, MangaCandidate, MangakakalotClient } from "./types.ts";
+import type { MangakakalotClient } from "./types.ts";
 import { MangakakalotParseError } from "./types.ts";
 
 export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
@@ -72,10 +74,23 @@ export function createMangakakalotClient(opts: {
     let allChapters: ChapterRef[] = [];
     let pagesFollowed = 0;
 
-    while (url !== null && pagesFollowed < MAX_PAGINATION_PAGES) {
+    while (url !== null) {
+      if (pagesFollowed >= MAX_PAGINATION_PAGES) {
+        logger.warn(
+          {
+            event: "mangakakalot.pagination_capped",
+            context: "mangakakalot",
+            slug,
+            cap: MAX_PAGINATION_PAGES,
+          },
+          "pagination cap reached; chapter list may be incomplete",
+        );
+        break;
+      }
+
       const currentUrl = url;
       const html = await fetchHtml(currentUrl);
-      const pageChapters = runParser(currentUrl, () => parseChapterList(html, slug, currentUrl));
+      const pageChapters = runParser(currentUrl, () => parseChapterList(html, currentUrl));
       allChapters = allChapters.concat(pageChapters);
 
       const nextUrl = parseChapterListPagination(html);

--- a/src/integrations/mangakakalot/client/index.ts
+++ b/src/integrations/mangakakalot/client/index.ts
@@ -1,0 +1,85 @@
+// Mangakakalot site client.
+// Wraps a FallbackHttpClient (cookie-replay, handles Cloudflare) and returns parsed domain types.
+// Callers are responsible for creating the FallbackHttpClient via createFallbackHttp().
+
+import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
+import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
+import type { ImageRef } from "@modules/downloader/types.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+import {
+  parseChapterImages,
+  parseChapterList,
+  parseChapterListPagination,
+  parseSearchResults,
+} from "./parser.ts";
+
+export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
+export type { ImageRef } from "@modules/downloader/types.ts";
+export { MangakakalotParseError } from "./types.ts";
+
+const SITE_ROOT = "https://mangakakalot.gg";
+const SEARCH_URL = `${SITE_ROOT}/search/story`;
+const MANGA_URL = (slug: string) => `${SITE_ROOT}/manga/${slug}`;
+
+/** Maximum pages to follow when paginating a chapter list — guards against misparsed links. */
+const MAX_PAGINATION_PAGES = 20;
+
+export interface MangakakalotClient {
+  searchManga(title: string): Promise<MangaCandidate[]>;
+  getChapterList(slug: string): Promise<ChapterRef[]>;
+  getChapterImages(chapterIdOrUrl: string): Promise<ImageRef[]>;
+}
+
+export function createMangakakalotClient(opts: {
+  http: FallbackHttpClient;
+  logger: Logger;
+}): MangakakalotClient {
+  const { http, logger } = opts;
+
+  async function fetchHtml(url: string): Promise<string> {
+    logger.info({ event: "mangakakalot.fetch", context: "mangakakalot", url }, "fetching page");
+    const res = await http.get(url);
+    return res.text();
+  }
+
+  async function searchManga(title: string): Promise<MangaCandidate[]> {
+    // URL: https://mangakakalot.gg/search/story/<encoded-title>
+    // Words separated by underscores per mangakakalot's search convention.
+    const encoded = encodeURIComponent(title.toLowerCase().replace(/\s+/g, "_"));
+    const url = `${SEARCH_URL}/${encoded}`;
+    const html = await fetchHtml(url);
+    return parseSearchResults(html);
+  }
+
+  async function getChapterList(slug: string): Promise<ChapterRef[]> {
+    let url: string | null = MANGA_URL(slug);
+    let allChapters: ChapterRef[] = [];
+    let pagesFollowed = 0;
+
+    while (url !== null && pagesFollowed < MAX_PAGINATION_PAGES) {
+      const html = await fetchHtml(url);
+      const pageChapters = parseChapterList(html, slug);
+      allChapters = allChapters.concat(pageChapters);
+
+      const nextUrl = parseChapterListPagination(html);
+      url = nextUrl;
+      pagesFollowed++;
+    }
+
+    return allChapters;
+  }
+
+  async function getChapterImages(chapterIdOrUrl: string): Promise<ImageRef[]> {
+    // Accept either a full URL or a path-style id like "chapter/manga-slug/chapter-1".
+    let url: string;
+    if (chapterIdOrUrl.startsWith("http://") || chapterIdOrUrl.startsWith("https://")) {
+      url = chapterIdOrUrl;
+    } else {
+      url = `${SITE_ROOT}/${chapterIdOrUrl}`;
+    }
+    const html = await fetchHtml(url);
+    return parseChapterImages(html);
+  }
+
+  return { searchManga, getChapterList, getChapterImages };
+}

--- a/src/integrations/mangakakalot/client/parser.ts
+++ b/src/integrations/mangakakalot/client/parser.ts
@@ -4,6 +4,7 @@
 import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
 import * as cheerio from "cheerio";
+import { MangakakalotParseError } from "./types.ts";
 
 const SELECTORS = {
   // Search results page
@@ -21,6 +22,10 @@ const SELECTORS = {
 
   // Chapter reader page
   chapterReaderImage: ".container-chapter-reader img",
+
+  // Structural site markers used to distinguish DOM drift from no-content pages
+  siteHeader: "header, .header, .navbar, body",
+  paginationPanel: ".panel_page_number",
 } as const;
 
 /** Extracts manga slug from a mangakakalot URL like https://mangakakalot.gg/manga/some-slug */
@@ -71,11 +76,44 @@ function parseUploadDate(raw: string | undefined): string {
   return new Date(0).toISOString();
 }
 
-export function parseSearchResults(html: string): MangaCandidate[] {
+/**
+ * Parses search results from a mangakakalot search page.
+ *
+ * Returns [] on a genuine "no results" page (search container present but empty).
+ * Throws MangakakalotParseError when the search container is absent entirely AND
+ * the page contains structural site markup (body tag present) — this indicates DOM
+ * drift, not an empty search result set.
+ *
+ * Heuristic: if `.story_item` root has zero matches AND `<body>` exists with content,
+ * the search results container structure has changed.
+ */
+export function parseSearchResults(html: string, url = ""): MangaCandidate[] {
   const $ = cheerio.load(html);
   const results: MangaCandidate[] = [];
 
-  $(SELECTORS.searchResultItem).each((_, el) => {
+  const items = $(SELECTORS.searchResultItem);
+
+  // Distinguish "no results" (panel_story_list present but empty) from "DOM changed"
+  // (neither .story_item nor any results panel can be found in a page that has a body).
+  if (items.length === 0) {
+    const hasBody = $("body").length > 0 && $("body").text().trim().length > 0;
+    const hasResultsPanel =
+      $(".panel_story_list").length > 0 ||
+      $(".story_item_right").length > 0 ||
+      $(".panel-search-story").length > 0;
+
+    // If there's a live page (non-empty body) but no results container at all, DOM drifted.
+    if (hasBody && !hasResultsPanel) {
+      throw new MangakakalotParseError(
+        SELECTORS.searchResultItem,
+        url,
+        "search results container missing from page; DOM may have changed",
+      );
+    }
+    return [];
+  }
+
+  items.each((_, el) => {
     const anchor = $(el).find(SELECTORS.searchResultLink).first();
     const href = anchor.attr("href") ?? "";
     const title = anchor.text().trim();
@@ -88,11 +126,32 @@ export function parseSearchResults(html: string): MangaCandidate[] {
   return results;
 }
 
-export function parseChapterList(html: string, mangaSlug: string): ChapterRef[] {
+/**
+ * Parses the chapter list from a manga detail page.
+ *
+ * A manga with one chapter row is valid (return it).
+ * An empty chapter list root with a present title is valid (manga exists, no releases yet).
+ *
+ * Throws MangakakalotParseError only when BOTH the chapter list root AND the manga title
+ * selector are missing — two missing selectors is a reliable signal of DOM drift.
+ */
+export function parseChapterList(html: string, mangaSlug: string, url = ""): ChapterRef[] {
   const $ = cheerio.load(html);
   const chapters: ChapterRef[] = [];
 
-  $(SELECTORS.mangaPageChapterRow).each((_, el) => {
+  const chapterRows = $(SELECTORS.mangaPageChapterRow);
+  const titleEl = $(SELECTORS.mangaPageTitle);
+
+  // Both selectors missing → DOM changed, not an empty chapter list.
+  if (chapterRows.length === 0 && titleEl.length === 0) {
+    throw new MangakakalotParseError(
+      `${SELECTORS.mangaPageChapterRow}, ${SELECTORS.mangaPageTitle}`,
+      url,
+      "neither chapter list nor manga title found on page; DOM may have changed",
+    );
+  }
+
+  chapterRows.each((_, el) => {
     const anchor = $(el).find(SELECTORS.mangaPageChapterLink).first();
     const href = anchor.attr("href") ?? "";
     const text = anchor.text().trim();
@@ -132,33 +191,54 @@ export function parseChapterList(html: string, mangaSlug: string): ChapterRef[] 
   return chapters;
 }
 
-export function parseChapterImages(html: string): ImageRef[] {
+/**
+ * Parses chapter image URLs from a mangakakalot reader page.
+ *
+ * Throws MangakakalotParseError when zero images are found inside the reader container.
+ * A chapter MUST have at least one image by definition — zero images means the parser broke.
+ */
+export function parseChapterImages(html: string, url = ""): ImageRef[] {
   const $ = cheerio.load(html);
   const images: ImageRef[] = [];
 
   $(SELECTORS.chapterReaderImage).each((i, el) => {
     // Prefer data-src (lazy-loaded canonical URL); fall back to src.
-    const url = $(el).attr("data-src") ?? $(el).attr("src") ?? "";
-    if (!url) return;
-    images.push({ url: url.trim(), page: i + 1 });
+    const imgUrl = $(el).attr("data-src") ?? $(el).attr("src") ?? "";
+    if (!imgUrl) return;
+    images.push({ url: imgUrl.trim(), page: i + 1 });
   });
+
+  if (images.length === 0) {
+    throw new MangakakalotParseError(
+      SELECTORS.chapterReaderImage,
+      url,
+      "no images found in chapter reader container; DOM may have changed",
+    );
+  }
 
   return images;
 }
 
 /**
  * Returns the URL of the next chapter-list page, or null if this is the last page.
- * Mangakakalot uses a pagination panel with "Last" link pointing to the final page
- * and numbered page links. We look for the next sequential page link.
+ * Mangakakalot uses a pagination panel with numbered page links and marks the active
+ * page with class `page_select`.
+ *
+ * Algorithm: iterate anchors in order; once we see the active (page_select) anchor,
+ * the very next anchor with an href is the next page. Returns null if no next anchor
+ * follows — normal for the last page.
+ *
+ * DOM shape reference: tests/fixtures/mangakakalot/manga-paginated.html
+ * Active page anchor comes first, immediately followed by the next-page anchor.
  */
 export function parseChapterListPagination(html: string): string | null {
   const $ = cheerio.load(html);
 
-  // Find active page and check if there's a next one.
-  // The pagination panel has .page_select for active and numbered links around it.
   const pagePanel = $(".panel_page_number");
   if (pagePanel.length === 0) return null;
 
+  // We check foundActive BEFORE setting it so that we capture the anchor
+  // that comes AFTER the active one (not the active anchor itself).
   let foundActive = false;
   let nextUrl: string | null = null;
 

--- a/src/integrations/mangakakalot/client/parser.ts
+++ b/src/integrations/mangakakalot/client/parser.ts
@@ -1,0 +1,177 @@
+// Pure HTML parsing functions for mangakakalot.gg.
+// All cheerio selectors live here as named constants — fix DOM drift in one place.
+
+import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
+import type { ImageRef } from "@modules/downloader/types.ts";
+import * as cheerio from "cheerio";
+
+const SELECTORS = {
+  // Search results page
+  searchResultItem: ".story_item",
+  searchResultTitle: ".story_name a",
+  searchResultLink: ".story_name a",
+
+  // Manga detail page
+  mangaPageTitle: ".manga-info-text h1",
+  mangaPageChapterRow: ".chapter-list .row",
+  mangaPageChapterLink: "a",
+  mangaPageChapterDate: "span[title]",
+  mangaPageNextPage:
+    ".panel_page_number .page_select a.page_last, .panel_page_number a.page_select",
+
+  // Chapter reader page
+  chapterReaderImage: ".container-chapter-reader img",
+} as const;
+
+/** Extracts manga slug from a mangakakalot URL like https://mangakakalot.gg/manga/some-slug */
+function slugFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    // /manga/<slug> or /chapter/<slug>/chapter-N
+    const mangaIdx = parts.indexOf("manga");
+    if (mangaIdx >= 0 && parts[mangaIdx + 1]) return parts[mangaIdx + 1] as string;
+    // For chapter URLs: /chapter/<manga-slug>/chapter-N
+    const chapterIdx = parts.indexOf("chapter");
+    if (chapterIdx >= 0 && parts[chapterIdx + 1]) return parts[chapterIdx + 1] as string;
+    return parts[parts.length - 1] ?? url;
+  } catch {
+    return url;
+  }
+}
+
+/** Parses chapter number from link text like "Chapter 1.5 : Some Title" or from URL path. */
+function parseChapterNumber(text: string, href: string): string {
+  // Try URL first: /chapter/<manga>/chapter-1.5
+  const urlMatch = href.match(/chapter-(\d+(?:\.\d+)?)/i);
+  if (urlMatch?.[1]) return urlMatch[1];
+  // Try text: "Chapter 1.5" or "Vol.3 Chapter 1.5"
+  const textMatch = text.match(/chapter[\s:]+(\d+(?:\.\d+)?)/i);
+  if (textMatch?.[1]) return textMatch[1];
+  return "0";
+}
+
+/** Strips the leading chapter number/label from link text to get the chapter title. */
+function parseChapterTitle(text: string): string | null {
+  // "Chapter 1 : Some Title" → "Some Title"
+  const m = text.match(/chapter[\s\d.]+[:\-]?\s*(.+)/i);
+  const candidate = m?.[1]?.trim() ?? null;
+  return candidate && candidate.length > 0 ? candidate : null;
+}
+
+/**
+ * Parses upload date from a span[title] attribute.
+ * Attribute may be "Dec 25, 2023 00:00" or just a date.
+ * Returns ISO string (UTC). Falls back to epoch if unparseable.
+ */
+function parseUploadDate(raw: string | undefined): string {
+  if (!raw) return new Date(0).toISOString();
+  const parsed = new Date(raw);
+  if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  return new Date(0).toISOString();
+}
+
+export function parseSearchResults(html: string): MangaCandidate[] {
+  const $ = cheerio.load(html);
+  const results: MangaCandidate[] = [];
+
+  $(SELECTORS.searchResultItem).each((_, el) => {
+    const anchor = $(el).find(SELECTORS.searchResultLink).first();
+    const href = anchor.attr("href") ?? "";
+    const title = anchor.text().trim();
+    if (!title || !href) return;
+
+    const id = slugFromUrl(href);
+    results.push({ id, title, originalLanguage: "en", year: null });
+  });
+
+  return results;
+}
+
+export function parseChapterList(html: string, mangaSlug: string): ChapterRef[] {
+  const $ = cheerio.load(html);
+  const chapters: ChapterRef[] = [];
+
+  $(SELECTORS.mangaPageChapterRow).each((_, el) => {
+    const anchor = $(el).find(SELECTORS.mangaPageChapterLink).first();
+    const href = anchor.attr("href") ?? "";
+    const text = anchor.text().trim();
+    const dateSpan = $(el).find(SELECTORS.mangaPageChapterDate).first();
+    const rawDate = dateSpan.attr("title") ?? dateSpan.text().trim();
+
+    if (!href) return;
+
+    // Use the chapter-specific slug from URL as the id to keep it unique.
+    // e.g. https://mangakakalot.gg/chapter/manga-slug/chapter-1 → "chapter/manga-slug/chapter-1"
+    let id: string;
+    try {
+      const parsed = new URL(href);
+      id = parsed.pathname.replace(/^\//, "");
+    } catch {
+      id = href;
+    }
+
+    const chapterNum = parseChapterNumber(text, href);
+    const title = parseChapterTitle(text);
+    const readableAt = parseUploadDate(rawDate);
+
+    chapters.push({
+      id,
+      volume: null,
+      chapter: chapterNum,
+      title,
+      translatedLanguage: "en",
+      scanlationGroup: null,
+      readableAt,
+      externalUrl: null,
+    });
+
+    void mangaSlug; // available if needed for future logging; not used in output
+  });
+
+  return chapters;
+}
+
+export function parseChapterImages(html: string): ImageRef[] {
+  const $ = cheerio.load(html);
+  const images: ImageRef[] = [];
+
+  $(SELECTORS.chapterReaderImage).each((i, el) => {
+    // Prefer data-src (lazy-loaded canonical URL); fall back to src.
+    const url = $(el).attr("data-src") ?? $(el).attr("src") ?? "";
+    if (!url) return;
+    images.push({ url: url.trim(), page: i + 1 });
+  });
+
+  return images;
+}
+
+/**
+ * Returns the URL of the next chapter-list page, or null if this is the last page.
+ * Mangakakalot uses a pagination panel with "Last" link pointing to the final page
+ * and numbered page links. We look for the next sequential page link.
+ */
+export function parseChapterListPagination(html: string): string | null {
+  const $ = cheerio.load(html);
+
+  // Find active page and check if there's a next one.
+  // The pagination panel has .page_select for active and numbered links around it.
+  const pagePanel = $(".panel_page_number");
+  if (pagePanel.length === 0) return null;
+
+  let foundActive = false;
+  let nextUrl: string | null = null;
+
+  pagePanel.find("a").each((_, el) => {
+    const href = $(el).attr("href");
+    if (!href) return;
+    if (foundActive && !nextUrl) {
+      nextUrl = href;
+    }
+    if ($(el).hasClass("page_select")) {
+      foundActive = true;
+    }
+  });
+
+  return nextUrl;
+}

--- a/src/integrations/mangakakalot/client/parser.ts
+++ b/src/integrations/mangakakalot/client/parser.ts
@@ -87,7 +87,7 @@ function parseUploadDate(raw: string | undefined): string {
  * Heuristic: if `.story_item` root has zero matches AND `<body>` exists with content,
  * the search results container structure has changed.
  */
-export function parseSearchResults(html: string, url = ""): MangaCandidate[] {
+export function parseSearchResults(html: string, url: string): MangaCandidate[] {
   const $ = cheerio.load(html);
   const results: MangaCandidate[] = [];
 
@@ -135,7 +135,7 @@ export function parseSearchResults(html: string, url = ""): MangaCandidate[] {
  * Throws MangakakalotParseError only when BOTH the chapter list root AND the manga title
  * selector are missing — two missing selectors is a reliable signal of DOM drift.
  */
-export function parseChapterList(html: string, mangaSlug: string, url = ""): ChapterRef[] {
+export function parseChapterList(html: string, url: string): ChapterRef[] {
   const $ = cheerio.load(html);
   const chapters: ChapterRef[] = [];
 
@@ -184,8 +184,6 @@ export function parseChapterList(html: string, mangaSlug: string, url = ""): Cha
       readableAt,
       externalUrl: null,
     });
-
-    void mangaSlug; // available if needed for future logging; not used in output
   });
 
   return chapters;
@@ -197,7 +195,7 @@ export function parseChapterList(html: string, mangaSlug: string, url = ""): Cha
  * Throws MangakakalotParseError when zero images are found inside the reader container.
  * A chapter MUST have at least one image by definition — zero images means the parser broke.
  */
-export function parseChapterImages(html: string, url = ""): ImageRef[] {
+export function parseChapterImages(html: string, url: string): ImageRef[] {
   const $ = cheerio.load(html);
   const images: ImageRef[] = [];
 

--- a/src/integrations/mangakakalot/client/types.ts
+++ b/src/integrations/mangakakalot/client/types.ts
@@ -1,5 +1,8 @@
 // Public types and domain errors for the mangakakalot client.
 
+import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
+import type { ImageRef } from "@modules/downloader/types.ts";
+
 export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 export type { ImageRef } from "@modules/downloader/types.ts";
 
@@ -12,4 +15,10 @@ export class MangakakalotParseError extends Error {
   ) {
     super(`[mangakakalot] parse failed at selector "${selector}" on ${url}: ${message}`);
   }
+}
+
+export interface MangakakalotClient {
+  searchManga(title: string): Promise<MangaCandidate[]>;
+  getChapterList(slug: string): Promise<ChapterRef[]>;
+  getChapterImages(chapterIdOrUrl: string): Promise<ImageRef[]>;
 }

--- a/src/integrations/mangakakalot/client/types.ts
+++ b/src/integrations/mangakakalot/client/types.ts
@@ -1,10 +1,8 @@
-// Public types and domain errors for the mangakakalot client.
+// Internal types and domain errors for the mangakakalot client.
+// Public re-exports (ChapterRef, MangaCandidate, ImageRef, MangakakalotClient) live in index.ts.
 
 import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
-
-export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
-export type { ImageRef } from "@modules/downloader/types.ts";
 
 export class MangakakalotParseError extends Error {
   override readonly name = "MangakakalotParseError";

--- a/src/integrations/mangakakalot/client/types.ts
+++ b/src/integrations/mangakakalot/client/types.ts
@@ -1,0 +1,15 @@
+// Public types and domain errors for the mangakakalot client.
+
+export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
+export type { ImageRef } from "@modules/downloader/types.ts";
+
+export class MangakakalotParseError extends Error {
+  override readonly name = "MangakakalotParseError";
+  constructor(
+    public readonly selector: string,
+    public readonly url: string,
+    message: string,
+  ) {
+    super(`[mangakakalot] parse failed at selector "${selector}" on ${url}: ${message}`);
+  }
+}

--- a/tests/fixtures/mangakakalot/chapter-naruto-1.html
+++ b/tests/fixtures/mangakakalot/chapter-naruto-1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics mangakakalot.gg chapter reader for naruto chapter 1.
+     Includes both src and data-src attributes to test lazy-load handling.
+     Structural HTML only — no tracking pixels, no session tokens, no ad scripts. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Naruto Chapter 1</title></head>
+<body>
+<div class="container-chapter-reader">
+  <!-- data-src takes priority over src when both are present -->
+  <img src="https://cdn.example.com/naruto/ch1/page-1-thumb.jpg" data-src="https://cdn.example.com/naruto/ch1/page-1.jpg" alt="Page 1" />
+  <!-- src only -->
+  <img src="https://cdn.example.com/naruto/ch1/page-2.jpg" alt="Page 2" />
+  <!-- data-src only (fully lazy) -->
+  <img data-src="https://cdn.example.com/naruto/ch1/page-3.jpg" alt="Page 3" />
+</div>
+</body>
+</html>

--- a/tests/fixtures/mangakakalot/manga-naruto.html
+++ b/tests/fixtures/mangakakalot/manga-naruto.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics mangakakalot.gg manga detail page for "naruto".
+     Structural HTML only — no tracking pixels, no session tokens, no ad scripts. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Naruto</title></head>
+<body>
+<div class="manga-info-text">
+  <h1>Naruto</h1>
+</div>
+<div class="chapter-list">
+  <div class="row">
+    <span><a href="https://mangakakalot.gg/chapter/naruto/chapter-700">Chapter 700 : Uzumaki Naruto!!</a></span>
+    <span title="Dec 10, 2014 00:00">Dec 10,2014</span>
+  </div>
+  <div class="row">
+    <span><a href="https://mangakakalot.gg/chapter/naruto/chapter-699">Chapter 699 : The Message</a></span>
+    <span title="Dec 03, 2014 00:00">Dec 03,2014</span>
+  </div>
+  <div class="row">
+    <span><a href="https://mangakakalot.gg/chapter/naruto/chapter-1">Chapter 1 : Uzumaki Naruto</a></span>
+    <span title="Jan 01, 2000 00:00">Jan 01,2000</span>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/fixtures/mangakakalot/manga-paginated.html
+++ b/tests/fixtures/mangakakalot/manga-paginated.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics a manga detail page with pagination (page 1 of 2).
+     Structural HTML only — no tracking pixels, no session tokens, no ad scripts. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Bleach - Page 1</title></head>
+<body>
+<div class="manga-info-text">
+  <h1>Bleach</h1>
+</div>
+<div class="chapter-list">
+  <div class="row">
+    <span><a href="https://mangakakalot.gg/chapter/bleach/chapter-686">Chapter 686 : Death and Strawberry</a></span>
+    <span title="Aug 22, 2016 00:00">Aug 22,2016</span>
+  </div>
+</div>
+<div class="panel_page_number">
+  <a href="https://mangakakalot.gg/manga/bleach?page=1" class="page_select">1</a>
+  <a href="https://mangakakalot.gg/manga/bleach?page=2">2</a>
+</div>
+</body>
+</html>

--- a/tests/fixtures/mangakakalot/search-naruto.html
+++ b/tests/fixtures/mangakakalot/search-naruto.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics mangakakalot.gg search result page for "naruto".
+     Structural HTML only — no tracking pixels, no session tokens, no ad scripts. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Search Naruto</title></head>
+<body>
+<div class="panel_story_list">
+  <div class="story_item">
+    <div class="story_name">
+      <a href="https://mangakakalot.gg/manga/naruto">Naruto</a>
+    </div>
+    <p class="story_author">Masashi Kishimoto</p>
+    <p class="story_chapter">Latest: Chapter 700</p>
+  </div>
+  <div class="story_item">
+    <div class="story_name">
+      <a href="https://mangakakalot.gg/manga/naruto-shippuden">Naruto Shippuden</a>
+    </div>
+    <p class="story_author">Masashi Kishimoto</p>
+    <p class="story_chapter">Latest: Chapter 500</p>
+  </div>
+  <div class="story_item">
+    <div class="story_name">
+      <a href="https://mangakakalot.gg/manga/naruto-spinoff">Naruto Spin-Off: Rock Lee's Springtime of Youth</a>
+    </div>
+    <p class="story_author">Kenji Taira</p>
+    <p class="story_chapter">Latest: Chapter 58</p>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What this PR does

Second piece of the fallback trail (`#21 → #22 → #23`). Site-specific HTML scraping client for `mangakakalot.gg`, wired to consume the `FallbackHttpClient` from #21. Turns the mangakakalot search/manga/chapter-reader pages into the canonical `MangaCandidate[]` / `ChapterRef[]` / `ImageRef[]` types that the rest of the codebase already speaks.

## Why it exists

Per ADR-002 ("Per-Site Strategy") + overviewer §8, every fallback site gets its own integration module. With the cookie-replayed HTTP foundation merged in #21, this PR adds the parsing layer. After this lands, #23 can wire `download` to offer mangakakalot when MangaDex doesn't have the content.

Ref: #22

## How it works internally

### 1. Shared canonical types lifted

`MangaCandidate`, `ChapterRef`, and `VolumeRef` were declared in `src/integrations/mangadex/client/types.ts`. With a second integration consuming them, they moved to `src/integrations/_shared/manga.ts`. The mangadex client re-exports for backward compat. This is a pure rename — no shape changes — and prevents mangakakalot from importing across integration boundaries (which would create a layering oddity and a future circular-import risk).

### 2. `src/integrations/mangakakalot/client/`

```
client/
├── types.ts      // MangakakalotClient interface, MangakakalotParseError
├── parser.ts     // pure functions; SELECTORS const at the top
├── index.ts      // createMangakakalotClient(opts) factory, runParser wrapper
└── client.test.ts // 32 tests
```

**`parser.ts`** is pure — no `fetch`, no logger, no I/O. All CSS selectors live in a single `SELECTORS` const at the top of the file (so DOM drift is fixed in one place). Functions:

- `parseSearchResults(html, url): MangaCandidate[]`
- `parseChapterList(html, url): ChapterRef[]`
- `parseChapterImages(html, url): ImageRef[]`
- `parseChapterListPagination(html): string | null`

`url` is required on every parser that throws — `MangakakalotParseError` carries it for actionable error messages.

**`MangakakalotParseError`** is thrown when the DOM has structurally drifted (e.g. search container missing entirely, manga title AND chapter list both missing, chapter reader with zero `<img>` matched). Empty result sets ("manga has no releases", "no search matches") return `[]` and don't throw — those are valid empty states distinct from "parser broke".

**`createMangakakalotClient(opts: { http: FallbackHttpClient; logger: Logger })`** is a factory function (no class). The `FallbackHttpClient` is injected — the client never calls `createFallbackHttp` itself. Each public method:

1. Logs `mangakakalot.fetch` once per HTTP request (URL only — never cookies/UA).
2. Issues a GET via the injected `http`.
3. Wraps the parser call in `runParser(url, fn)` which catches `MangakakalotParseError`, emits `logger.warn` with `{event: "mangakakalot.parse_failed", url, selector, err}`, then re-throws. Pure parser stays pure; the warn-before-throw convention is preserved at the integration layer.
4. Propagates `CloudflareError` from `http.get` — does NOT swallow. The CLI surface (#23) will catch and prompt re-auth.

`getChapterList(slug)` follows pagination transparently up to a cap of 20 pages. When the cap is hit, `mangakakalot.pagination_capped` is logged once with the slug + cap so downstream debugging has a signal.

`parseChapterImages` reads BOTH `src` and `data-src`, preferring `data-src` when both are present (handles the lazy-load case mangakakalot uses on some pages).

### 3. Cheerio dep

Added `cheerio@1.2.0` to `dependencies`. Only new dep in this PR. Used via the modern `cheerio.load(html)` API.

### 4. Fixtures

Four synthetic HTML fixtures under `tests/fixtures/mangakakalot/`:

- `search-naruto.html` — search results page
- `manga-naruto.html` — single-page manga with chapter list
- `manga-paginated.html` — manga page with `next` pagination
- `chapter-naruto-1.html` — chapter reader with both `src` and `data-src`

**Synthetic, not live-captured.** Real HTML from mangakakalot would require committing live session content — hard to scrub safely. Synthetic fixtures are deterministic, offline-runnable, and let the test suite be CI-safe. The trade-off is they may not catch real-world DOM drift; pagination logic in particular has a comment in `parser.ts` referencing the fixture as the canonical reference, with a note that the live site should be verified manually before going to production.

## ACs satisfied

- [x] All three functions return canonical types (`MangaCandidate[]`, `ChapterRef[]`, `ImageRef[]`)
- [x] Volume metadata not populated (`volume: null`, per ADR-002 — chapters are flat)
- [x] Selectors isolated in `parser.ts` as a single `SELECTORS` const
- [x] `cheerio@1.2.0` added as a dep
- [x] Fixture tests for search / manga page (single + paginated) / chapter page
- [x] Pagination follows `next` links transparently with a 20-page cap
- [x] `data-src` preferred over `src` in `parseChapterImages`
- [x] `MangakakalotParseError` thrown on DOM drift; `logger.warn` fires before re-throw
- [x] `CloudflareError` propagated across all three methods (no swallowing)
- [x] Type lift to `_shared/manga.ts`; mangadex re-exports preserve compat

## What did not change

- The `FallbackHttpClient` API surface (#21).
- The MangaDex client (only its `types.ts` re-exports were touched).
- The `list` / `download` commands. Wiring mangakakalot into them is #23.
- The `ChapterRef` shape — only its declaration moved.

## Test checklist

- [x] Parser: search happy / no-results returns [] / DOM drift throws
- [x] Parser: chapter list happy / single-chapter / pagination follows / drift throws
- [x] Parser: chapter images happy / src-only / data-src-only / both-present (data-src wins) / zero-images throws
- [x] Parser: pagination missing returns null
- [x] Client: `mangakakalot.fetch` log per request (URL only)
- [x] Client: `mangakakalot.parse_failed` warn fires before re-throw on DOM drift
- [x] Client: `CloudflareError` propagates from all three methods (no swallow)
- [x] Client: pagination cap hit logs `mangakakalot.pagination_capped` once
- [x] Type lift: existing mangadex/list/download tests still resolve types
- [x] `bun test` — 344 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- Synthetic fixtures will likely need a real-world cross-check pass once live mangakakalot HTML is captured. That's a follow-up: parser logic might need micro-adjustments to match the actual DOM (active-page anchor sibling-relationship, date format edge cases). Worth opening as a follow-up issue if you'd like it tracked.
- `MAX_PAGINATION_PAGES = 20` is a guard against runaway loops on misparsed `next` links. Real mangakakalot manga rarely paginate; the cap is conservative. If a real series ever exceeds it, the warn lands and we can bump the constant.
- `MangakakalotParseError` distinguishes "DOM changed" from "empty result". This is intentional — the empty-result case is normal user-facing data; the DOM-changed case is a developer signal worth alerting on.

## Closes

Ref: #22

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/` (no doc changes — ADR-002 + overviewer §8 already specify the per-site strategy this PR implements)