### PR TITLE
feat(cli): fallback path in download with user-prompted choice

### DIFF
--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import { AtHomeError } from "@integrations/mangadex/at-home/index.ts";
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
+import { TitleNotFoundError } from "@integrations/mangadex/client/index.ts";
 import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import type { MangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
@@ -1012,7 +1013,7 @@ describe("fallback — title not on MangaDex, mangakakalot has it", () => {
       createFallbackHttp: async () => fallbackHttp,
       createMangakakalotClient: () => mkClient,
       // biome-ignore lint/style/noNonNullAssertion: test stub — sites always has 1 entry
-      _promptFallbackSite: async (sites) => sites[0]!,
+      promptSite: async (sites) => sites[0]!,
     });
 
     const cbzPath = join(tmpDir, "dandadan", "dandadan-chapter-001.cbz");
@@ -1084,7 +1085,7 @@ describe("fallback — MangaDex aggregate reused for volume mode", () => {
       createFallbackHttp: async () => fallbackHttp,
       createMangakakalotClient: () => mkClient,
       // biome-ignore lint/style/noNonNullAssertion: test stub — sites always has 1 entry
-      _promptFallbackSite: async (sites) => sites[0]!,
+      promptSite: async (sites) => sites[0]!,
     });
 
     const cbzPath = join(tmpDir, "witch-hat-atelier", "witch-hat-atelier-volume-003.cbz");
@@ -1139,7 +1140,7 @@ describe("fallback — non-TTY with title_not_found → CliError", () => {
   test("throws CliError pointing at auth and interactive use (--chapter mode)", async () => {
     const clientNoResults = makeClient({
       resolveTitleToId: async () => {
-        throw new Error("No manga found for: Nonexistent");
+        throw new TitleNotFoundError("Nonexistent");
       },
     });
 
@@ -1159,7 +1160,7 @@ describe("fallback — non-TTY with title_not_found → CliError", () => {
   test("throws CliError with --chapter hint when title_not_found in --volume mode", async () => {
     const clientNoResults = makeClient({
       resolveTitleToId: async () => {
-        throw new Error("No manga found for: Nonexistent");
+        throw new TitleNotFoundError("Nonexistent");
       },
     });
 

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -2,16 +2,21 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import { AtHomeError } from "@integrations/mangadex/at-home/index.ts";
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
 import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
+import type { MangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
+import type { ImageRef } from "@modules/downloader/types.ts";
 import { listHistory } from "@modules/history/index.ts";
 import { openDb, runMigrations } from "@plugins/db/index.ts";
 import type { Db } from "@plugins/db/index.ts";
 import { CliError } from "@plugins/errors/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { unzipSync } from "fflate";
+import type { MangaDexResolveResult } from "./fallback-types.ts";
+import { runFallbackDownload } from "./fallback.ts";
 import { runDownload } from "./index.ts";
 import type { DownloadArgs, DownloadContext } from "./types.ts";
 
@@ -278,7 +283,11 @@ describe("runDownload — force", () => {
 });
 
 describe("runDownload — external chapter", () => {
-  test("throws CliError for external chapters", async () => {
+  // When ALL chapters in the chosen language are external, runDownload now routes to the
+  // fallback path (reason: all_external) per ADR-002. In non-TTY mode the fallback prompt
+  // throws a CliError pointing at interactive use + auth setup.
+
+  test("throws CliError when all chapters are external (non-TTY)", async () => {
     const externalChapter = makeChapterRef({
       id: "ch-ext",
       volume: "1",
@@ -295,13 +304,12 @@ describe("runDownload — external chapter", () => {
     ).rejects.toBeInstanceOf(CliError);
   });
 
-  test("CliError message contains the external URL", async () => {
-    const extUrl = "https://mangaplus.shueisha.co.jp/viewer/456";
+  test("CliError from fallback non-TTY path mentions auth", async () => {
     const externalChapter = makeChapterRef({
       id: "ch-ext",
       volume: "1",
       chapter: "2",
-      externalUrl: extUrl,
+      externalUrl: "https://mangaplus.shueisha.co.jp/viewer/456",
     });
 
     const clientWithExternal = makeClient({
@@ -313,31 +321,32 @@ describe("runDownload — external chapter", () => {
       throw new Error("expected to throw");
     } catch (err) {
       expect(err).toBeInstanceOf(CliError);
-      expect((err as CliError).message).toContain(extUrl);
+      // Now routes via fallback path → non-TTY → "auth" hint in message
+      expect((err as CliError).message).toContain("auth");
     }
   });
 
-  test("emits logger.warn with download.external_chapter event before throwing", async () => {
-    const extUrl = "https://mangaplus.shueisha.co.jp/viewer/789";
+  test("emits fallback_triggered event when all chapters are external", async () => {
     const externalChapter = makeChapterRef({
       id: "ch-ext-warn",
       volume: "1",
       chapter: "3",
-      externalUrl: extUrl,
+      externalUrl: "https://mangaplus.shueisha.co.jp/viewer/789",
     });
 
     const clientWithExternal = makeClient({
       feedChapters: async () => [externalChapter],
     });
 
-    let warnEvent: string | undefined;
+    let triggeredEvent: string | undefined;
     const spyLogger: Logger = {
-      info: () => {},
-      warn: (obj: unknown) => {
+      info: (obj: unknown) => {
         if (typeof obj === "object" && obj !== null && "event" in obj) {
-          warnEvent = (obj as Record<string, unknown>).event as string;
+          const e = (obj as Record<string, unknown>).event as string;
+          if (e === "download.fallback_triggered") triggeredEvent = e;
         }
       },
+      warn: () => {},
       error: () => {},
     };
 
@@ -352,7 +361,38 @@ describe("runDownload — external chapter", () => {
       // expected
     }
 
-    expect(warnEvent).toBe("download.external_chapter");
+    expect(triggeredEvent).toBe("download.fallback_triggered");
+  });
+
+  test("mixed external+normal chapters still refuse via processBundle external check", async () => {
+    // Only ONE chapter is external, another is normal — not all_external → MangaDex path
+    // → processBundle sees the external chapter and throws with the URL in the message
+    const normalCh = makeChapterRef({ id: "ch-ok", volume: "1", chapter: "1" });
+    const externalCh = makeChapterRef({
+      id: "ch-ext",
+      volume: "1",
+      chapter: "2",
+      externalUrl: "https://mangaplus.shueisha.co.jp/viewer/999",
+    });
+
+    const clientMixed = makeClient({
+      feedChapters: async () => [normalCh, externalCh],
+    });
+
+    // Request vol 1 which includes both — processBundle will hit ch-ok first (fine)
+    // then ch-ext → throws with external URL
+    // Actually volumes are filtered per chapter, so both chapters are in vol 1
+    let errorMsg = "";
+    try {
+      await withMockedImageFetch(async () => {
+        await runDownload(baseArgs(), baseCtx(), clientMixed, makeFullHttpClient());
+      });
+    } catch (err) {
+      errorMsg = (err as Error).message;
+    }
+
+    // processBundle external check fires
+    expect(errorMsg).toContain("mangaplus.shueisha.co.jp");
   });
 });
 
@@ -839,8 +879,10 @@ describe("runDownload — mutual exclusion", () => {
   });
 });
 
-describe("runDownload --chapter — external chapter refused", () => {
-  test("external chapter in --chapter mode throws CliError", async () => {
+describe("runDownload --chapter — external chapter routes to fallback", () => {
+  // When all chapters in feed are external (in --chapter mode the feed still has externalUrl set),
+  // isFallbackEligible returns all_external and we route to fallback.
+  test("external chapter in --chapter mode throws CliError (via fallback non-TTY)", async () => {
     const extUrl = "https://mangaplus.shueisha.co.jp/viewer/999";
     const ch = makeChapterRef({ id: "ch-ext", volume: "1", chapter: "5", externalUrl: extUrl });
     const client = makeClient({
@@ -848,6 +890,7 @@ describe("runDownload --chapter — external chapter refused", () => {
       feedChapters: async () => [ch],
     });
 
+    // All chapters are external → fallback → non-TTY → CliError
     await expect(
       runDownload(
         baseArgs({ volume: undefined, chapter: "5" }),
@@ -858,7 +901,7 @@ describe("runDownload --chapter — external chapter refused", () => {
     ).rejects.toBeInstanceOf(CliError);
   });
 
-  test("external chapter warn event emitted before throw in --chapter mode", async () => {
+  test("fallback_triggered event emitted in --chapter mode when all external", async () => {
     const extUrl = "https://mangaplus.shueisha.co.jp/viewer/999";
     const ch = makeChapterRef({ id: "ch-ext", volume: "1", chapter: "5", externalUrl: extUrl });
     const client = makeClient({
@@ -866,14 +909,15 @@ describe("runDownload --chapter — external chapter refused", () => {
       feedChapters: async () => [ch],
     });
 
-    let warnEvent: string | undefined;
+    let triggeredEvent: string | undefined;
     const spyLogger: Logger = {
-      info: () => {},
-      warn: (obj: unknown) => {
+      info: (obj: unknown) => {
         if (typeof obj === "object" && obj !== null && "event" in obj) {
-          warnEvent = (obj as Record<string, unknown>).event as string;
+          const e = (obj as Record<string, unknown>).event as string;
+          if (e === "download.fallback_triggered") triggeredEvent = e;
         }
       },
+      warn: () => {},
       error: () => {},
     };
 
@@ -888,6 +932,277 @@ describe("runDownload --chapter — external chapter refused", () => {
       // expected
     }
 
-    expect(warnEvent).toBe("download.external_chapter");
+    expect(triggeredEvent).toBe("download.fallback_triggered");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback integration helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal 1×1 PNG bytes — distinct from JPEG_BYTES so we can assert source */
+const MK_PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+  0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+  0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+function makeMkChapterRef(overrides: Partial<ChapterRef> & { id: string }): ChapterRef {
+  return {
+    volume: null,
+    chapter: "1",
+    title: null,
+    translatedLanguage: "en",
+    scanlationGroup: null,
+    readableAt: "2024-01-01T00:00:00Z",
+    externalUrl: null,
+    ...overrides,
+  };
+}
+
+function makeFallbackHttp(): FallbackHttpClient {
+  return {
+    get: async (_url: string) =>
+      new Response(MK_PNG_BYTES, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+  };
+}
+
+function makeMkClient(overrides?: Partial<MangakakalotClient>): MangakakalotClient {
+  const ch1 = makeMkChapterRef({ id: "mk-ch-1", chapter: "1" });
+  return {
+    searchManga: async () => [
+      { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+    ],
+    getChapterList: async () => [ch1],
+    getChapterImages: async (_id: string): Promise<ImageRef[]> => [
+      { url: "https://cdn.mangakakalot.gg/img/1.png", page: 1 },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fallback integration tests
+// ---------------------------------------------------------------------------
+
+describe("fallback — title not on MangaDex, mangakakalot has it", () => {
+  test("produces .cbz and records history with source=mangakakalot", async () => {
+    const ch1 = makeMkChapterRef({ id: "mk-ch-1", chapter: "1" });
+    const mkClient: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => [ch1],
+      getChapterImages: async (_id: string): Promise<ImageRef[]> => [
+        { url: "https://cdn.mk.gg/img/1.png", page: 1 },
+      ],
+    };
+
+    const fallbackHttp = makeFallbackHttp();
+
+    await runFallbackDownload({
+      args: baseArgs({ manga: "Dandadan", volume: undefined, chapter: "1" }),
+      ctx: baseCtx(),
+      mangadexResolve: null,
+      createFallbackHttp: async () => fallbackHttp,
+      createMangakakalotClient: () => mkClient,
+      // biome-ignore lint/style/noNonNullAssertion: test stub — sites always has 1 entry
+      _promptFallbackSite: async (sites) => sites[0]!,
+    });
+
+    const cbzPath = join(tmpDir, "dandadan", "dandadan-chapter-001.cbz");
+    expect(await Bun.file(cbzPath).exists()).toBe(true);
+
+    const history = listHistory(db);
+    expect(history.length).toBe(1);
+    expect(history[0]).toMatchObject({
+      mangaId: "dandadan",
+      mangaTitle: "Dandadan",
+      chapterId: "mk-ch-1",
+      chapterNum: "1",
+      source: "mangakakalot",
+      language: "en",
+    });
+  });
+});
+
+describe("fallback — MangaDex aggregate reused for volume mode", () => {
+  test("vol3 = ch18-21 from MangaDex maps to mangakakalot ch18-21, one archive produced", async () => {
+    const mangadexResolve: MangaDexResolveResult = {
+      candidate: {
+        id: "md-manga-id",
+        title: "Witch Hat Atelier",
+        originalLanguage: "ja",
+        year: 2016,
+      },
+      volumes: [{ volume: "3", numeric: 3, chapterIds: ["md-18", "md-19", "md-20", "md-21"] }],
+      chaptersInLang: [
+        makeMkChapterRef({ id: "md-18", chapter: "18", translatedLanguage: "en" }),
+        makeMkChapterRef({ id: "md-19", chapter: "19", translatedLanguage: "en" }),
+        makeMkChapterRef({ id: "md-20", chapter: "20", translatedLanguage: "en" }),
+        makeMkChapterRef({ id: "md-21", chapter: "21", translatedLanguage: "en" }),
+      ],
+      language: null,
+    };
+
+    const mkClient: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "witch-hat", title: "Witch Hat Atelier", originalLanguage: "ja", year: 2016 },
+      ],
+      getChapterList: async () => [
+        makeMkChapterRef({ id: "mk-18", chapter: "18" }),
+        makeMkChapterRef({ id: "mk-19", chapter: "19" }),
+        makeMkChapterRef({ id: "mk-20", chapter: "20" }),
+        makeMkChapterRef({ id: "mk-21", chapter: "21" }),
+      ],
+      getChapterImages: async (_id: string): Promise<ImageRef[]> => [
+        { url: "https://cdn.mk.gg/img/1.png", page: 1 },
+      ],
+    };
+
+    const fallbackHttp = makeFallbackHttp();
+
+    await runFallbackDownload({
+      args: baseArgs({ manga: "Witch Hat Atelier", volume: "3" }),
+      ctx: baseCtx(),
+      mangadexResolve,
+      createFallbackHttp: async () => fallbackHttp,
+      createMangakakalotClient: () => mkClient,
+      // biome-ignore lint/style/noNonNullAssertion: test stub — sites always has 1 entry
+      _promptFallbackSite: async (sites) => sites[0]!,
+    });
+
+    const cbzPath = join(tmpDir, "witch-hat-atelier", "witch-hat-atelier-volume-003.cbz");
+    expect(await Bun.file(cbzPath).exists()).toBe(true);
+
+    const history = listHistory(db);
+    expect(history.length).toBe(4);
+    expect(history.every((r) => r.source === "mangakakalot")).toBe(true);
+    expect(history.every((r) => r.volume === "3")).toBe(true);
+  });
+});
+
+describe("fallback — all MangaDex chapters external (Dandadan/MangaPlus scenario)", () => {
+  test("triggers fallback with reason=all_external, non-TTY → CliError with auth hint", async () => {
+    const externalCh = makeChapterRef({
+      id: "ch-ext",
+      volume: "1",
+      chapter: "1",
+      externalUrl: "https://mangaplus.shueisha.co.jp/viewer/1",
+    });
+
+    const clientAllExternal = makeClient({ feedChapters: async () => [externalCh] });
+
+    let fallbackReason: string | undefined;
+    const spyLogger: Logger = {
+      info: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          const o = obj as Record<string, unknown>;
+          if (o.event === "download.fallback_triggered") {
+            fallbackReason = o.reason as string;
+          }
+        }
+      },
+      warn: () => {},
+      error: () => {},
+    };
+
+    const err = await runDownload(
+      baseArgs({ nonTty: true }),
+      { ...baseCtx(), logger: spyLogger },
+      clientAllExternal,
+      makeFullHttpClient(),
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("auth");
+    expect(fallbackReason).toBe("all_external");
+  });
+});
+
+describe("fallback — non-TTY with title_not_found → CliError", () => {
+  test("throws CliError pointing at auth and interactive use (--chapter mode)", async () => {
+    const clientNoResults = makeClient({
+      resolveTitleToId: async () => {
+        throw new Error("No manga found for: Nonexistent");
+      },
+    });
+
+    // --volume with no MangaDex aggregate → hits "--chapter" error before "auth" error
+    // Use --chapter to reach the site-picker prompt which requires TTY
+    const err = await runDownload(
+      baseArgs({ nonTty: true, volume: undefined, chapter: "1" }),
+      baseCtx(),
+      clientNoResults,
+      makeFullHttpClient(),
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("auth");
+  });
+
+  test("throws CliError with --chapter hint when title_not_found in --volume mode", async () => {
+    const clientNoResults = makeClient({
+      resolveTitleToId: async () => {
+        throw new Error("No manga found for: Nonexistent");
+      },
+    });
+
+    // --volume mode + no MangaDex resolve → volume metadata check fires first
+    const err = await runDownload(
+      baseArgs({ nonTty: true, volume: "1" }),
+      baseCtx(),
+      clientNoResults,
+      makeFullHttpClient(),
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("--chapter");
+  });
+});
+
+describe("fallback — volume mode without MangaDex aggregate", () => {
+  test("mangadexResolve null + volume → CliError with --chapter hint", async () => {
+    const fallbackHttp = makeFallbackHttp();
+    const mkClient = makeMkClient();
+
+    const err = await runFallbackDownload({
+      args: baseArgs({ volume: "1" }),
+      ctx: baseCtx(),
+      mangadexResolve: null,
+      createFallbackHttp: async () => fallbackHttp,
+      createMangakakalotClient: () => mkClient,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("--chapter");
+  });
+
+  test("mangadexResolve with empty volumes + volume mode → CliError with --chapter hint", async () => {
+    const fallbackHttp = makeFallbackHttp();
+    const mkClient = makeMkClient();
+
+    const resolve: MangaDexResolveResult = {
+      candidate: { id: "md-id", title: "Test", originalLanguage: "ja", year: 2020 },
+      volumes: [],
+      chaptersInLang: [],
+      language: null,
+    };
+
+    const err = await runFallbackDownload({
+      args: baseArgs({ volume: "1" }),
+      ctx: baseCtx(),
+      mangadexResolve: resolve,
+      createFallbackHttp: async () => fallbackHttp,
+      createMangakakalotClient: () => mkClient,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("--chapter");
   });
 });

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -1018,6 +1018,16 @@ describe("fallback — title not on MangaDex, mangakakalot has it", () => {
     const cbzPath = join(tmpDir, "dandadan", "dandadan-chapter-001.cbz");
     expect(await Bun.file(cbzPath).exists()).toBe(true);
 
+    // Verify the .cbz contents came from mangakakalot (MK_PNG_BYTES sentinel)
+    const raw = await Bun.file(cbzPath).arrayBuffer();
+    const entries = unzipSync(new Uint8Array(raw));
+    const entryNames = Object.keys(entries);
+    expect(entryNames).toHaveLength(1);
+    // Filename follows zero-pad pattern 0001.<ext>
+    expect(entryNames[0]).toMatch(/^0001\.\w+$/);
+    // Bytes match the sentinel MK_PNG_BYTES from the mock fetcher
+    expect(entries[entryNames[0] as string]).toEqual(MK_PNG_BYTES);
+
     const history = listHistory(db);
     expect(history.length).toBe(1);
     expect(history[0]).toMatchObject({

--- a/src/commands/download/fallback-types.ts
+++ b/src/commands/download/fallback-types.ts
@@ -1,0 +1,27 @@
+// Types for the fallback download path.
+// Keep separate from types.ts to avoid circular-import risk between fallback.ts and index.ts.
+
+import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/_shared/manga.ts";
+
+export interface FallbackSiteOption {
+  name: string; // "mangakakalot"
+  display: string; // "mangakakalot.gg"
+}
+
+/**
+ * Result of the tryMangaDexPipeline step.
+ * language is null when no chapters matched the preferred languages.
+ */
+export interface MangaDexResolveResult {
+  candidate: MangaCandidate;
+  volumes: VolumeRef[];
+  chaptersInLang: ChapterRef[];
+  language: string | null;
+}
+
+export interface FallbackBundle {
+  kind: "volume" | "chapter";
+  bundleNumber: string;
+  volumeForHistory: string;
+  chapters: ChapterRef[];
+}

--- a/src/commands/download/fallback.test.ts
+++ b/src/commands/download/fallback.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from "bun:test";
+import type { ChapterRef, VolumeRef } from "@integrations/_shared/manga.ts";
+import { CliError } from "@plugins/errors/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+import type { FallbackSiteOption, MangaDexResolveResult } from "./fallback-types.ts";
+import { buildFallbackBundles, isFallbackEligible, promptFallbackSite } from "./fallback.ts";
+import type { DownloadArgs } from "./types.ts";
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const SITES: FallbackSiteOption[] = [{ name: "mangakakalot", display: "mangakakalot.gg" }];
+
+function makeChapterRef(overrides: Partial<ChapterRef> & { id: string }): ChapterRef {
+  return {
+    volume: "1",
+    chapter: "1",
+    title: null,
+    translatedLanguage: "en",
+    scanlationGroup: null,
+    readableAt: "2024-01-01T00:00:00Z",
+    externalUrl: null,
+    ...overrides,
+  };
+}
+
+function makeVolumeRef(volume: string, chapterIds: string[]): VolumeRef {
+  return { volume, numeric: Number(volume), chapterIds };
+}
+
+function makeResolveResult(overrides?: Partial<MangaDexResolveResult>): MangaDexResolveResult {
+  return {
+    candidate: { id: "manga-1", title: "Test", originalLanguage: "ja", year: 2020 },
+    volumes: [makeVolumeRef("1", ["ch-1"])],
+    chaptersInLang: [makeChapterRef({ id: "ch-1" })],
+    language: "en",
+    ...overrides,
+  };
+}
+
+function baseArgs(overrides?: Partial<DownloadArgs>): DownloadArgs {
+  return {
+    manga: "Test Manga",
+    volume: "1",
+    format: "cbz",
+    outDir: "/tmp",
+    quality: "data",
+    concurrency: 1,
+    delayMs: 0,
+    force: false,
+    noTrack: false,
+    dryRun: false,
+    nonTty: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isFallbackEligible
+// ---------------------------------------------------------------------------
+
+describe("isFallbackEligible", () => {
+  test("null → title_not_found", () => {
+    expect(isFallbackEligible(null)).toEqual({ eligible: true, reason: "title_not_found" });
+  });
+
+  test("empty chaptersInLang → no_chapters_in_lang", () => {
+    const result = makeResolveResult({ chaptersInLang: [], language: null });
+    expect(isFallbackEligible(result)).toEqual({ eligible: true, reason: "no_chapters_in_lang" });
+  });
+
+  test("all chapters with externalUrl → all_external", () => {
+    const result = makeResolveResult({
+      chaptersInLang: [
+        makeChapterRef({ id: "ch-1", externalUrl: "https://mangaplus.shueisha.co.jp/viewer/1" }),
+        makeChapterRef({ id: "ch-2", externalUrl: "https://mangaplus.shueisha.co.jp/viewer/2" }),
+      ],
+    });
+    expect(isFallbackEligible(result)).toEqual({ eligible: true, reason: "all_external" });
+  });
+
+  test("mix of external and normal chapters → not eligible", () => {
+    const result = makeResolveResult({
+      chaptersInLang: [
+        makeChapterRef({ id: "ch-1", externalUrl: null }),
+        makeChapterRef({ id: "ch-2", externalUrl: "https://mangaplus.shueisha.co.jp/viewer/2" }),
+      ],
+    });
+    expect(isFallbackEligible(result)).toEqual({ eligible: false, reason: null });
+  });
+
+  test("normal chapter (no externalUrl) → not eligible", () => {
+    expect(isFallbackEligible(makeResolveResult())).toEqual({ eligible: false, reason: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptFallbackSite
+// ---------------------------------------------------------------------------
+
+describe("promptFallbackSite", () => {
+  test("non-TTY throws CliError with auth hint", async () => {
+    await expect(promptFallbackSite(SITES, true, noopLogger)).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("non-TTY error message mentions auth", async () => {
+    try {
+      await promptFallbackSite(SITES, true, noopLogger);
+    } catch (err) {
+      expect((err as CliError).message).toContain("auth");
+    }
+  });
+
+  test("non-TTY emits logger.warn with download.fallback_non_tty event", async () => {
+    let warnEvent: string | undefined;
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvent = (obj as Record<string, unknown>).event as string;
+        }
+      },
+      error: () => {},
+    };
+
+    try {
+      await promptFallbackSite(SITES, true, spyLogger);
+    } catch {
+      // expected
+    }
+
+    expect(warnEvent).toBe("download.fallback_non_tty");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFallbackBundles — volume mode
+// ---------------------------------------------------------------------------
+
+describe("buildFallbackBundles — volume mode", () => {
+  test("maps MangaDex volume → chapter numbers → mangakakalot chapters", () => {
+    const mangadexVolumes = [makeVolumeRef("3", ["md-ch18", "md-ch19", "md-ch20", "md-ch21"])];
+    const mangadexChapters: ChapterRef[] = [
+      makeChapterRef({ id: "md-ch18", chapter: "18", volume: "3" }),
+      makeChapterRef({ id: "md-ch19", chapter: "19", volume: "3" }),
+      makeChapterRef({ id: "md-ch20", chapter: "20", volume: "3" }),
+      makeChapterRef({ id: "md-ch21", chapter: "21", volume: "3" }),
+    ];
+    const mkChapters: ChapterRef[] = [
+      makeChapterRef({ id: "mk-18", chapter: "18", volume: null }),
+      makeChapterRef({ id: "mk-19", chapter: "19", volume: null }),
+      makeChapterRef({ id: "mk-20", chapter: "20", volume: null }),
+      makeChapterRef({ id: "mk-21", chapter: "21", volume: null }),
+    ];
+
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: "3" }),
+      requestedTokens: new Set(["3"]),
+      mangadexVolumes,
+      mangadexChapters,
+      mkChapters,
+      logger: noopLogger,
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]?.kind).toBe("volume");
+    expect(bundles[0]?.bundleNumber).toBe("3");
+    expect(bundles[0]?.chapters.map((c) => c.id).sort()).toEqual([
+      "mk-18",
+      "mk-19",
+      "mk-20",
+      "mk-21",
+    ]);
+  });
+
+  test("warns and skips chapters missing from fallback site", () => {
+    const mangadexVolumes = [makeVolumeRef("1", ["md-ch1", "md-ch2"])];
+    const mangadexChapters: ChapterRef[] = [
+      makeChapterRef({ id: "md-ch1", chapter: "1", volume: "1" }),
+      makeChapterRef({ id: "md-ch2", chapter: "2", volume: "1" }),
+    ];
+    // mangakakalot only has ch1
+    const mkChapters: ChapterRef[] = [makeChapterRef({ id: "mk-1", chapter: "1", volume: null })];
+
+    const warnEvents: string[] = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvents.push((obj as Record<string, unknown>).event as string);
+        }
+      },
+      error: () => {},
+    };
+
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: "1" }),
+      requestedTokens: new Set(["1"]),
+      mangadexVolumes,
+      mangadexChapters,
+      mkChapters,
+      logger: spyLogger,
+    });
+
+    // bundle still produced with only available chapters
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]?.chapters).toHaveLength(1);
+    expect(warnEvents).toContain("download.fallback_chapters_missing");
+  });
+
+  test("skips volume entirely when MangaDex has no record of it", () => {
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: "99" }),
+      requestedTokens: new Set(["99"]),
+      mangadexVolumes: [],
+      mangadexChapters: [],
+      mkChapters: [makeChapterRef({ id: "mk-1", chapter: "1", volume: null })],
+      logger: noopLogger,
+    });
+    expect(bundles).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFallbackBundles — chapter mode
+// ---------------------------------------------------------------------------
+
+describe("buildFallbackBundles — chapter mode", () => {
+  test("maps requested chapter token directly to mangakakalot chapter", () => {
+    const mkChapters: ChapterRef[] = [makeChapterRef({ id: "mk-5", chapter: "5", volume: null })];
+
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: undefined, chapter: "5" }),
+      requestedTokens: new Set(["5"]),
+      mangadexVolumes: [],
+      mangadexChapters: [],
+      mkChapters,
+      logger: noopLogger,
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]?.kind).toBe("chapter");
+    expect(bundles[0]?.chapters[0]?.id).toBe("mk-5");
+    // no MangaDex data → "none"
+    expect(bundles[0]?.volumeForHistory).toBe("none");
+  });
+
+  test("uses MangaDex volume as volumeForHistory when available", () => {
+    const mangadexChapters: ChapterRef[] = [
+      makeChapterRef({ id: "md-ch5", chapter: "5", volume: "2" }),
+    ];
+    const mkChapters: ChapterRef[] = [makeChapterRef({ id: "mk-5", chapter: "5", volume: null })];
+
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: undefined, chapter: "5" }),
+      requestedTokens: new Set(["5"]),
+      mangadexVolumes: [],
+      mangadexChapters,
+      mkChapters,
+      logger: noopLogger,
+    });
+
+    expect(bundles[0]?.volumeForHistory).toBe("2");
+  });
+
+  test("warns and skips chapter when not found on fallback site", () => {
+    const warnEvents: string[] = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvents.push((obj as Record<string, unknown>).event as string);
+        }
+      },
+      error: () => {},
+    };
+
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: undefined, chapter: "99" }),
+      requestedTokens: new Set(["99"]),
+      mangadexVolumes: [],
+      mangadexChapters: [],
+      mkChapters: [],
+      logger: spyLogger,
+    });
+
+    expect(bundles).toHaveLength(0);
+    expect(warnEvents).toContain("download.fallback_chapter_missing");
+  });
+});

--- a/src/commands/download/fallback.test.ts
+++ b/src/commands/download/fallback.test.ts
@@ -393,7 +393,7 @@ describe("runFallbackDownload — MissingAuthError propagates unwrapped", () => 
         throw new Error("should not be called");
       },
       // biome-ignore lint/style/noNonNullAssertion: test stub
-      _promptFallbackSite: async (sites) => sites[0]!,
+      promptSite: async (sites) => sites[0]!,
     }).catch((e) => e);
 
     db.close();
@@ -465,7 +465,7 @@ describe("runFallbackDownload — searchManga returns empty", () => {
       createFallbackHttp: async () => fakeFallbackHttp,
       createMangakakalotClient: () => mkClientNoResults,
       // biome-ignore lint/style/noNonNullAssertion: test stub
-      _promptFallbackSite: async (sites) => sites[0]!,
+      promptSite: async (sites) => sites[0]!,
     }).catch((e) => e);
 
     db.close();

--- a/src/commands/download/fallback.test.ts
+++ b/src/commands/download/fallback.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import type { ChapterRef, VolumeRef } from "@integrations/_shared/manga.ts";
+import { MissingAuthError } from "@integrations/fallback-http/index.ts";
+import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
+import type { MangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
 import { CliError } from "@plugins/errors/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import type { FallbackSiteOption, MangaDexResolveResult } from "./fallback-types.ts";
-import { buildFallbackBundles, isFallbackEligible, promptFallbackSite } from "./fallback.ts";
+import {
+  buildFallbackBundles,
+  isFallbackEligible,
+  promptFallbackSite,
+  runFallbackDownload,
+} from "./fallback.ts";
 import type { DownloadArgs } from "./types.ts";
 
 const noopLogger: Logger = {
@@ -289,5 +298,229 @@ describe("buildFallbackBundles — chapter mode", () => {
 
     expect(bundles).toHaveLength(0);
     expect(warnEvents).toContain("download.fallback_chapter_missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFallbackBundles — total-zero-match path (P2 #1)
+// ---------------------------------------------------------------------------
+
+describe("buildFallbackBundles — total zero match for volume", () => {
+  test("returns [] and warns for each missing chapter when mangakakalot has none of the MangaDex chapters", () => {
+    const mangadexVolumes = [makeVolumeRef("3", ["md-ch18", "md-ch19", "md-ch20", "md-ch21"])];
+    const mangadexChapters: ChapterRef[] = [
+      makeChapterRef({ id: "md-ch18", chapter: "18", volume: "3" }),
+      makeChapterRef({ id: "md-ch19", chapter: "19", volume: "3" }),
+      makeChapterRef({ id: "md-ch20", chapter: "20", volume: "3" }),
+      makeChapterRef({ id: "md-ch21", chapter: "21", volume: "3" }),
+    ];
+    // mangakakalot has NONE of ch18-21
+    const mkChapters: ChapterRef[] = [makeChapterRef({ id: "mk-99", chapter: "99", volume: null })];
+
+    const warnEvents: Array<{ event: string; missing?: unknown }> = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          const o = obj as Record<string, unknown>;
+          warnEvents.push({ event: o.event as string, missing: o.missing });
+        }
+      },
+      error: () => {},
+    };
+
+    const bundles = buildFallbackBundles({
+      args: baseArgs({ volume: "3" }),
+      requestedTokens: new Set(["3"]),
+      mangadexVolumes,
+      mangadexChapters,
+      mkChapters,
+      logger: spyLogger,
+    });
+
+    expect(bundles).toHaveLength(0);
+    // The warn fires once with all missing chapters listed (partial-match path)
+    const missingWarn = warnEvents.find((e) => e.event === "download.fallback_chapters_missing");
+    expect(missingWarn).toBeDefined();
+    expect(missingWarn?.missing).toEqual(expect.arrayContaining(["18", "19", "20", "21"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runFallbackDownload — MissingAuthError propagation (P2 #2)
+// ---------------------------------------------------------------------------
+
+describe("runFallbackDownload — MissingAuthError propagates unwrapped", () => {
+  test("MissingAuthError from createFallbackHttp is not wrapped as CliError", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const authError = new MissingAuthError("/nonexistent/auth.json");
+
+    const err = await runFallbackDownload({
+      args: {
+        manga: "Test",
+        volume: undefined,
+        chapter: "1",
+        format: "cbz",
+        outDir: "/tmp",
+        quality: "data",
+        concurrency: 1,
+        delayMs: 0,
+        force: false,
+        noTrack: false,
+        dryRun: false,
+        nonTty: false,
+      },
+      ctx: {
+        logger: noopLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve: null,
+      createFallbackHttp: async () => {
+        throw authError;
+      },
+      createMangakakalotClient: () => {
+        throw new Error("should not be called");
+      },
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      _promptFallbackSite: async (sites) => sites[0]!,
+    }).catch((e) => e);
+
+    db.close();
+
+    expect(err).toBeInstanceOf(MissingAuthError);
+    expect(err).not.toBeInstanceOf(CliError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runFallbackDownload — search returns zero results (P3 #2)
+// ---------------------------------------------------------------------------
+
+describe("runFallbackDownload — searchManga returns empty", () => {
+  test("throws CliError with title not found message when search returns []", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const fakeFallbackHttp: FallbackHttpClient = {
+      get: async () => new Response(new Uint8Array([]), { status: 200 }),
+    };
+
+    const mkClientNoResults: MangakakalotClient = {
+      searchManga: async () => [],
+      getChapterList: async () => [],
+      getChapterImages: async () => [],
+    };
+
+    const warnEvents: string[] = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvents.push((obj as Record<string, unknown>).event as string);
+        }
+      },
+      error: () => {},
+    };
+
+    const err = await runFallbackDownload({
+      args: {
+        manga: "Nonexistent Manga",
+        volume: undefined,
+        chapter: "1",
+        format: "cbz",
+        outDir: "/tmp",
+        quality: "data",
+        concurrency: 1,
+        delayMs: 0,
+        force: false,
+        noTrack: false,
+        dryRun: false,
+        nonTty: false,
+      },
+      ctx: {
+        logger: spyLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve: null,
+      createFallbackHttp: async () => fakeFallbackHttp,
+      createMangakakalotClient: () => mkClientNoResults,
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      _promptFallbackSite: async (sites) => sites[0]!,
+    }).catch((e) => e);
+
+    db.close();
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("Nonexistent Manga");
+    expect(warnEvents).toContain("download.fallback_not_found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptFallbackSite — TTY readline mock (P3 #3)
+// ---------------------------------------------------------------------------
+
+describe("promptFallbackSite — TTY readline mock", () => {
+  afterAll(() => mock.restore());
+
+  test("valid input '1' returns the single site", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (event: string, cb: (line: string) => void) => {
+          if (event === "line") cb("1");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const result = await promptFallbackSite(SITES, false, noopLogger);
+    // biome-ignore lint/style/noNonNullAssertion: SITES[0] always defined
+    expect(result).toEqual(SITES[0]!);
+  });
+
+  test("out-of-range input '99' → throws CliError", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (event: string, cb: (line: string) => void) => {
+          if (event === "line") cb("99");
+        },
+        close: () => {},
+      }),
+    }));
+
+    await expect(promptFallbackSite(SITES, false, noopLogger)).rejects.toBeInstanceOf(CliError);
+  });
+
+  test("non-numeric input 'abc' → throws CliError", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (event: string, cb: (line: string) => void) => {
+          if (event === "line") cb("abc");
+        },
+        close: () => {},
+      }),
+    }));
+
+    await expect(promptFallbackSite(SITES, false, noopLogger)).rejects.toBeInstanceOf(CliError);
   });
 });

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -4,7 +4,6 @@
 
 import { createInterface } from "node:readline";
 import type { ChapterRef, VolumeRef } from "@integrations/_shared/manga.ts";
-import { MissingAuthError } from "@integrations/fallback-http/index.ts";
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import type { createMangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
 import { downloadBundle } from "@modules/downloader/index.ts";
@@ -28,6 +27,10 @@ export type {
   FallbackSiteOption,
   MangaDexResolveResult,
 } from "./fallback-types.ts";
+
+// mangakakalot is EN-only by design (ADR-002 per-site strategy).
+// History rows from this source always carry language: "en".
+const MANGAKAKALOT_LANGUAGE = "en";
 
 // ---------------------------------------------------------------------------
 // isFallbackEligible
@@ -283,23 +286,10 @@ export async function runFallbackDownload(opts: {
     ? await _promptFallbackSite(sites)
     : await promptFallbackSite(sites, args.nonTty, logger);
 
-  // Bootstrap fallback HTTP + mangakakalot client (createFallbackHttp is async — reads auth.json)
-  let fallbackHttp: FallbackHttpClient;
-  try {
-    fallbackHttp = await mkFallbackHttp({ logger });
-  } catch (err) {
-    if (err instanceof MissingAuthError) {
-      logger.warn(
-        { event: "download.fallback_missing_auth", context: "download", err },
-        "missing auth.json for fallback site",
-      );
-      throw new CliError(
-        `${err.message} Run \`scanldr auth\` to capture a session before using fallback sites.`,
-        2,
-      );
-    }
-    throw err;
-  }
+  // Bootstrap fallback HTTP + mangakakalot client (createFallbackHttp is async — reads auth.json).
+  // MissingAuthError and CloudflareError propagate as-is so the entry point can handle them
+  // with their typed messages (the user needs to see the original message).
+  const fallbackHttp: FallbackHttpClient = await mkFallbackHttp({ logger });
 
   const mkClient = mkClientFactory({ http: fallbackHttp, logger });
 
@@ -398,7 +388,7 @@ async function processFallbackBundle(opts: {
     const fullyDownloaded = isVolumeFullyDownloaded(db, {
       mangaId,
       volume: volumeForHistory,
-      language: "en",
+      language: MANGAKAKALOT_LANGUAGE,
       expectedChapterIds: chapterIdSet,
     });
 
@@ -474,7 +464,7 @@ async function processFallbackBundle(opts: {
       chapterId: ch.id,
       chapterNum: ch.chapter ?? "0",
       source: site,
-      language: "en",
+      language: MANGAKAKALOT_LANGUAGE,
       downloadedAt: Date.now(),
     }));
     recordDownloadedChapters(db, rows);

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -2,7 +2,6 @@
 // Handles site-picker prompt, mangakakalot client bootstrap, bundle construction,
 // image fetching, and history recording.
 
-import { createInterface } from "node:readline";
 import type { ChapterRef, VolumeRef } from "@integrations/_shared/manga.ts";
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import type { createMangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
@@ -18,6 +17,7 @@ import type {
   FallbackSiteOption,
   MangaDexResolveResult,
 } from "./fallback-types.ts";
+import { promptNumericChoice } from "./prompt.ts";
 import { parseRangeSet } from "./range.ts";
 import { toSlug } from "./slug.ts";
 import type { DownloadArgs, DownloadContext } from "./types.ts";
@@ -76,20 +76,13 @@ export async function promptFallbackSite(
     );
   }
 
-  return new Promise((resolve, reject) => {
-    const rl = createInterface({ input: process.stdin, output: process.stderr });
-    const list = sites.map((s, i) => `  [${i + 1}] ${s.display}`).join("\n");
-    process.stderr.write(`MangaDex unavailable. Choose a fallback site:\n${list}\nPick one: `);
-    rl.once("line", (line) => {
-      rl.close();
-      const n = Number.parseInt(line.trim(), 10);
-      if (Number.isNaN(n) || n < 1 || n > sites.length) {
-        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
-      } else {
-        resolve(sites[n - 1] as FallbackSiteOption);
-      }
-    });
+  const idx = await promptNumericChoice({
+    header: "MangaDex unavailable. Choose a fallback site:",
+    items: sites.map((s) => ({ display: s.display })),
+    logger,
+    event: "download.invalid_selection",
   });
+  return sites[idx] as FallbackSiteOption;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,20 +109,13 @@ async function pickCandidate(
     );
   }
 
-  return new Promise((resolve, reject) => {
-    const rl = createInterface({ input: process.stdin, output: process.stderr });
-    const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
-    process.stderr.write(`Multiple results on ${siteName}:\n${list}\nPick one: `);
-    rl.once("line", (line) => {
-      rl.close();
-      const n = Number.parseInt(line.trim(), 10);
-      if (Number.isNaN(n) || n < 1 || n > candidates.length) {
-        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
-      } else {
-        resolve(candidates[n - 1] as { id: string; title: string });
-      }
-    });
+  const idx = await promptNumericChoice({
+    header: `Multiple results on ${siteName}:`,
+    items: candidates.map((c) => ({ display: c.title })),
+    logger,
+    event: "download.invalid_selection",
   });
+  return candidates[idx] as { id: string; title: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -257,7 +243,7 @@ export async function runFallbackDownload(opts: {
     logger: Logger;
   }) => import("@integrations/mangakakalot/client/types.ts").MangakakalotClient;
   /** Override for tests — bypasses stdin prompt. When provided, nonTty check is skipped. */
-  _promptFallbackSite?: (sites: FallbackSiteOption[]) => Promise<FallbackSiteOption>;
+  promptSite?: (sites: FallbackSiteOption[]) => Promise<FallbackSiteOption>;
 }): Promise<void> {
   const {
     args,
@@ -265,7 +251,7 @@ export async function runFallbackDownload(opts: {
     mangadexResolve,
     createFallbackHttp: mkFallbackHttp,
     createMangakakalotClient: mkClientFactory,
-    _promptFallbackSite,
+    promptSite,
   } = opts;
   const { logger } = ctx;
 
@@ -282,8 +268,8 @@ export async function runFallbackDownload(opts: {
   }
 
   const sites: FallbackSiteOption[] = [{ name: "mangakakalot", display: "mangakakalot.gg" }];
-  const site = _promptFallbackSite
-    ? await _promptFallbackSite(sites)
+  const site = promptSite
+    ? await promptSite(sites)
     : await promptFallbackSite(sites, args.nonTty, logger);
 
   // Bootstrap fallback HTTP + mangakakalot client (createFallbackHttp is async — reads auth.json).

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -1,0 +1,492 @@
+// Fallback download path — entered when MangaDex is unavailable for a title.
+// Handles site-picker prompt, mangakakalot client bootstrap, bundle construction,
+// image fetching, and history recording.
+
+import { createInterface } from "node:readline";
+import type { ChapterRef, VolumeRef } from "@integrations/_shared/manga.ts";
+import { MissingAuthError } from "@integrations/fallback-http/index.ts";
+import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
+import type { createMangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
+import { downloadBundle } from "@modules/downloader/index.ts";
+import type { ImageRef } from "@modules/downloader/types.ts";
+import type { ChapterInput } from "@modules/downloader/types.ts";
+import { isVolumeFullyDownloaded, recordDownloadedChapters } from "@modules/history/index.ts";
+import type { DownloadRow } from "@modules/history/index.ts";
+import { CliError } from "@plugins/errors/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+import type {
+  FallbackBundle,
+  FallbackSiteOption,
+  MangaDexResolveResult,
+} from "./fallback-types.ts";
+import { parseRangeSet } from "./range.ts";
+import { toSlug } from "./slug.ts";
+import type { DownloadArgs, DownloadContext } from "./types.ts";
+
+export type {
+  FallbackBundle,
+  FallbackSiteOption,
+  MangaDexResolveResult,
+} from "./fallback-types.ts";
+
+// ---------------------------------------------------------------------------
+// isFallbackEligible
+// ---------------------------------------------------------------------------
+
+export function isFallbackEligible(result: MangaDexResolveResult | null): {
+  eligible: boolean;
+  reason: "title_not_found" | "no_chapters_in_lang" | "all_external" | null;
+} {
+  if (result === null) {
+    return { eligible: true, reason: "title_not_found" };
+  }
+
+  if (result.chaptersInLang.length === 0) {
+    return { eligible: true, reason: "no_chapters_in_lang" };
+  }
+
+  const allExternal = result.chaptersInLang.every((c) => c.externalUrl !== null);
+  if (allExternal) {
+    return { eligible: true, reason: "all_external" };
+  }
+
+  return { eligible: false, reason: null };
+}
+
+// ---------------------------------------------------------------------------
+// promptFallbackSite
+// ---------------------------------------------------------------------------
+
+export async function promptFallbackSite(
+  sites: FallbackSiteOption[],
+  nonTty: boolean,
+  logger: Logger,
+): Promise<FallbackSiteOption> {
+  if (nonTty) {
+    logger.warn(
+      { event: "download.fallback_non_tty", context: "download" },
+      "fallback site prompt requires a TTY",
+    );
+    throw new CliError(
+      "Fallback site selection requires an interactive terminal. Re-run in a terminal after setting up auth with `scanldr auth`.",
+      2,
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const list = sites.map((s, i) => `  [${i + 1}] ${s.display}`).join("\n");
+    process.stderr.write(`MangaDex unavailable. Choose a fallback site:\n${list}\nPick one: `);
+    rl.once("line", (line) => {
+      rl.close();
+      const n = Number.parseInt(line.trim(), 10);
+      if (Number.isNaN(n) || n < 1 || n > sites.length) {
+        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
+      } else {
+        resolve(sites[n - 1] as FallbackSiteOption);
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// pickCandidate — mirrors resolveTitle's UX for mangakakalot results
+// ---------------------------------------------------------------------------
+
+async function pickCandidate(
+  candidates: Array<{ id: string; title: string }>,
+  nonTty: boolean,
+  logger: Logger,
+  siteName: string,
+): Promise<{ id: string; title: string }> {
+  if (candidates.length === 1) return candidates[0] as { id: string; title: string };
+
+  if (nonTty) {
+    const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
+    logger.warn(
+      { event: "download.fallback_ambiguous_title", context: "download", site: siteName },
+      "multiple candidates on fallback site in non-TTY mode",
+    );
+    throw new CliError(
+      `Multiple results on ${siteName}. Re-run in a terminal to pick one:\n${list}`,
+      2,
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
+    process.stderr.write(`Multiple results on ${siteName}:\n${list}\nPick one: `);
+    rl.once("line", (line) => {
+      rl.close();
+      const n = Number.parseInt(line.trim(), 10);
+      if (Number.isNaN(n) || n < 1 || n > candidates.length) {
+        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
+      } else {
+        resolve(candidates[n - 1] as { id: string; title: string });
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// makeMangakakalotFetcher
+// ---------------------------------------------------------------------------
+
+function makeMangakakalotFetcher(
+  http: FallbackHttpClient,
+  logger: Logger,
+): (ref: ImageRef) => Promise<Uint8Array> {
+  return async (ref) => {
+    logger.info(
+      { event: "mangakakalot.image_fetch", context: "mangakakalot", url: ref.url },
+      "fetching image from mangakakalot",
+    );
+    const res = await http.get(ref.url);
+    if (!res.ok) {
+      throw new Error(`mangakakalot image fetch failed: HTTP ${res.status} for ${ref.url}`);
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildFallbackBundles
+// ---------------------------------------------------------------------------
+
+export function buildFallbackBundles(opts: {
+  args: DownloadArgs;
+  requestedTokens: Set<string>;
+  mangadexVolumes: VolumeRef[];
+  mangadexChapters: ChapterRef[];
+  mkChapters: ChapterRef[];
+  logger: Logger;
+}): FallbackBundle[] {
+  const { args, requestedTokens, mangadexVolumes, mangadexChapters, mkChapters, logger } = opts;
+  const bundles: FallbackBundle[] = [];
+
+  if (args.volume !== undefined) {
+    for (const volToken of requestedTokens) {
+      const mdVolume = mangadexVolumes.find((v) => v.volume === volToken);
+      if (!mdVolume) {
+        logger.warn(
+          { event: "download.fallback_volume_missing", context: "download", volume: volToken },
+          `volume ${volToken} not found in MangaDex aggregate; skipping`,
+        );
+        continue;
+      }
+
+      // MangaDex chapter IDs → chapter numbers via chaptersInLang
+      const mdChapterNums = mdVolume.chapterIds
+        .map((id) => mangadexChapters.find((c) => c.id === id)?.chapter)
+        .filter((n): n is string => n !== null && n !== undefined);
+
+      // Find mangakakalot chapters matching those numbers
+      const mkChaptersForVolume = mkChapters.filter(
+        (c) => c.chapter !== null && mdChapterNums.includes(c.chapter),
+      );
+
+      const missing = mdChapterNums.filter(
+        (n) => !mkChaptersForVolume.some((c) => c.chapter === n),
+      );
+      if (missing.length > 0) {
+        logger.warn(
+          {
+            event: "download.fallback_chapters_missing",
+            context: "download",
+            volume: volToken,
+            missing,
+          },
+          `chapters ${missing.join(", ")} from MangaDex not found on fallback site`,
+        );
+      }
+
+      if (mkChaptersForVolume.length === 0) continue;
+
+      bundles.push({
+        kind: "volume",
+        bundleNumber: volToken,
+        volumeForHistory: volToken,
+        chapters: mkChaptersForVolume,
+      });
+    }
+  } else {
+    // --chapter mode
+    for (const chToken of requestedTokens) {
+      const mkCh = mkChapters.find((c) => c.chapter === chToken);
+      if (!mkCh) {
+        logger.warn(
+          { event: "download.fallback_chapter_missing", context: "download", chapter: chToken },
+          `chapter ${chToken} not found on fallback site; skipping`,
+        );
+        continue;
+      }
+
+      // Look up volume from MangaDex chaptersInLang if possible
+      const mdCh = mangadexChapters.find((c) => c.chapter === chToken);
+      const volumeForHistory = mdCh?.volume ?? "none";
+
+      bundles.push({
+        kind: "chapter",
+        bundleNumber: chToken,
+        volumeForHistory,
+        chapters: [mkCh],
+      });
+    }
+  }
+
+  return bundles;
+}
+
+// ---------------------------------------------------------------------------
+// runFallbackDownload
+// ---------------------------------------------------------------------------
+
+export async function runFallbackDownload(opts: {
+  args: DownloadArgs;
+  ctx: DownloadContext;
+  mangadexResolve: MangaDexResolveResult | null;
+  createFallbackHttp: (
+    opts: import("@integrations/fallback-http/types.ts").FallbackHttpOptions,
+  ) => Promise<import("@integrations/fallback-http/types.ts").FallbackHttpClient>;
+  createMangakakalotClient: (opts: {
+    http: import("@integrations/fallback-http/types.ts").FallbackHttpClient;
+    logger: Logger;
+  }) => import("@integrations/mangakakalot/client/types.ts").MangakakalotClient;
+  /** Override for tests — bypasses stdin prompt. When provided, nonTty check is skipped. */
+  _promptFallbackSite?: (sites: FallbackSiteOption[]) => Promise<FallbackSiteOption>;
+}): Promise<void> {
+  const {
+    args,
+    ctx,
+    mangadexResolve,
+    createFallbackHttp: mkFallbackHttp,
+    createMangakakalotClient: mkClientFactory,
+    _promptFallbackSite,
+  } = opts;
+  const { logger } = ctx;
+
+  // Volume mode requires MangaDex aggregate to map volumes → chapter numbers
+  if (args.volume !== undefined && (!mangadexResolve || mangadexResolve.volumes.length === 0)) {
+    logger.warn(
+      { event: "download.fallback_no_volume_metadata", context: "download" },
+      "MangaDex has no volume data; --chapter is required for fallback",
+    );
+    throw new CliError(
+      "MangaDex doesn't know this title's volumes. Re-run with --chapter <range> to download from a fallback site.",
+      2,
+    );
+  }
+
+  const sites: FallbackSiteOption[] = [{ name: "mangakakalot", display: "mangakakalot.gg" }];
+  const site = _promptFallbackSite
+    ? await _promptFallbackSite(sites)
+    : await promptFallbackSite(sites, args.nonTty, logger);
+
+  // Bootstrap fallback HTTP + mangakakalot client (createFallbackHttp is async — reads auth.json)
+  let fallbackHttp: FallbackHttpClient;
+  try {
+    fallbackHttp = await mkFallbackHttp({ logger });
+  } catch (err) {
+    if (err instanceof MissingAuthError) {
+      logger.warn(
+        { event: "download.fallback_missing_auth", context: "download", err },
+        "missing auth.json for fallback site",
+      );
+      throw new CliError(
+        `${err.message} Run \`scanldr auth\` to capture a session before using fallback sites.`,
+        2,
+      );
+    }
+    throw err;
+  }
+
+  const mkClient = mkClientFactory({ http: fallbackHttp, logger });
+
+  // Resolve title on mangakakalot
+  const titleToSearch = mangadexResolve?.candidate.title ?? args.manga;
+  logger.info(
+    {
+      event: "download.fallback_search",
+      context: "download",
+      title: titleToSearch,
+      site: site.name,
+    },
+    "searching on fallback site",
+  );
+  const mkCandidates = await mkClient.searchManga(titleToSearch);
+  if (mkCandidates.length === 0) {
+    logger.warn(
+      {
+        event: "download.fallback_not_found",
+        context: "download",
+        title: titleToSearch,
+        site: site.name,
+      },
+      "title not found on fallback site",
+    );
+    throw new CliError(`Title "${titleToSearch}" not found on ${site.display}.`, 2);
+  }
+
+  const mkChosen = await pickCandidate(mkCandidates, args.nonTty, logger, site.name);
+
+  logger.info(
+    {
+      event: "download.fallback_resolved",
+      context: "download",
+      id: mkChosen.id,
+      title: mkChosen.title,
+    },
+    "title resolved on fallback site",
+  );
+
+  const mkChapters = await mkClient.getChapterList(mkChosen.id);
+
+  const requestedTokens =
+    args.volume !== undefined
+      ? parseRangeSet(args.volume).values
+      : parseRangeSet(args.chapter as string).values;
+
+  const bundles = buildFallbackBundles({
+    args,
+    requestedTokens,
+    mangadexVolumes: mangadexResolve?.volumes ?? [],
+    mangadexChapters: mangadexResolve?.chaptersInLang ?? [],
+    mkChapters,
+    logger,
+  });
+
+  const slug = toSlug(mkChosen.title, logger);
+
+  for (const bundle of bundles) {
+    await processFallbackBundle({
+      bundle,
+      slug,
+      mangaId: mkChosen.id,
+      mangaTitle: mkChosen.title,
+      args,
+      ctx,
+      mkClient,
+      fallbackHttp,
+      site: site.name,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// processFallbackBundle
+// ---------------------------------------------------------------------------
+
+async function processFallbackBundle(opts: {
+  bundle: FallbackBundle;
+  slug: string;
+  mangaId: string;
+  mangaTitle: string;
+  args: DownloadArgs;
+  ctx: DownloadContext;
+  mkClient: ReturnType<typeof createMangakakalotClient>;
+  fallbackHttp: FallbackHttpClient;
+  site: string;
+}): Promise<void> {
+  const { bundle, slug, mangaId, mangaTitle, args, ctx, mkClient, fallbackHttp, site } = opts;
+  const { logger, db } = ctx;
+  const { kind, bundleNumber, volumeForHistory, chapters } = bundle;
+
+  // History skip check
+  if (!args.force) {
+    const chapterIdSet = new Set(chapters.map((c) => c.id));
+    const fullyDownloaded = isVolumeFullyDownloaded(db, {
+      mangaId,
+      volume: volumeForHistory,
+      language: "en",
+      expectedChapterIds: chapterIdSet,
+    });
+
+    if (fullyDownloaded) {
+      logger.info(
+        { event: "download.bundle_skip", context: "download", kind, bundleNumber },
+        `skipping ${kind} ${bundleNumber}: already in history`,
+      );
+      return;
+    }
+  }
+
+  // Build chapter inputs: each chapter fetches image list then constructs fetcher
+  const chapterInputs: ChapterInput[] = await Promise.all(
+    chapters.map(async (ch) => {
+      const imageRefs = await mkClient.getChapterImages(ch.id);
+      return {
+        id: ch.id,
+        num: Number(ch.chapter ?? "0"),
+        pages: imageRefs,
+        imageFetcher: makeMangakakalotFetcher(fallbackHttp, logger),
+      };
+    }),
+  );
+
+  if (args.dryRun) {
+    const totalPages = chapterInputs.reduce((sum, c) => sum + c.pages.length, 0);
+    logger.info(
+      {
+        event: "download.dry_run",
+        context: "download",
+        slug,
+        kind,
+        bundleNumber,
+        chapters: chapterInputs.length,
+        totalPages,
+      },
+      `dry-run: would download ${kind} ${bundleNumber} from ${site}`,
+    );
+    return;
+  }
+
+  const result = await downloadBundle({
+    outDir: args.outDir,
+    format: args.format,
+    slug,
+    kind,
+    bundleNumber,
+    chapters: chapterInputs,
+    imageConcurrency: args.concurrency,
+    delayMs: args.delayMs,
+    dryRun: false,
+    logger,
+  });
+
+  logger.info(
+    {
+      event: "download.bundle_done",
+      context: "download",
+      kind,
+      bundleNumber,
+      outputPath: result.outputPath,
+      byteSize: result.byteSize,
+    },
+    `${kind} ${bundleNumber} downloaded from ${site}`,
+  );
+
+  if (!args.noTrack) {
+    const rows: DownloadRow[] = chapters.map((ch) => ({
+      mangaId,
+      mangaTitle,
+      volume: volumeForHistory,
+      chapterId: ch.id,
+      chapterNum: ch.chapter ?? "0",
+      source: site,
+      language: "en",
+      downloadedAt: Date.now(),
+    }));
+    recordDownloadedChapters(db, rows);
+    logger.info(
+      {
+        event: "download.history_recorded",
+        context: "download",
+        kind,
+        bundleNumber,
+        rows: rows.length,
+      },
+      "history recorded",
+    );
+  }
+}

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -451,7 +451,7 @@ export async function runDownload(
   }
 
   // Try MangaDex pipeline (soft failure on title-not-found, language-not-matched)
-  // tryMangaDexPipeline already converts "No manga found" to null internally.
+  // TitleNotFoundError is caught inside and converted to null.
   const mangadexResolve: MangaDexResolveResult | null = await tryMangaDexPipeline(
     args,
     ctx,

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -455,21 +455,12 @@ export async function runDownload(
   }
 
   // Try MangaDex pipeline (soft failure on title-not-found, language-not-matched)
-  let mangadexResolve: MangaDexResolveResult | null = null;
-  try {
-    mangadexResolve = await tryMangaDexPipeline(args, ctx, client);
-  } catch (err) {
-    // "No manga found" from resolveTitleToId is a soft failure → fallback
-    if (err instanceof Error && err.message.startsWith("No manga found")) {
-      logger.info(
-        { event: "download.mangadex_title_not_found", context: "download", title: args.manga },
-        "title not found on MangaDex; attempting fallback",
-      );
-      mangadexResolve = null;
-    } else {
-      throw err;
-    }
-  }
+  // tryMangaDexPipeline already converts "No manga found" to null internally.
+  const mangadexResolve: MangaDexResolveResult | null = await tryMangaDexPipeline(
+    args,
+    ctx,
+    client,
+  );
 
   const eligibility = isFallbackEligible(mangadexResolve);
 

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -1,4 +1,3 @@
-import { createInterface } from "node:readline";
 import { createFallbackHttp } from "@integrations/fallback-http/index.ts";
 import {
   AtHomeError,
@@ -7,6 +6,7 @@ import {
 } from "@integrations/mangadex/at-home/index.ts";
 import type { ChapterRef, MangaCandidate } from "@integrations/mangadex/client/index.ts";
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
+import { TitleNotFoundError } from "@integrations/mangadex/client/index.ts";
 import { parseExternalHost } from "@integrations/mangadex/external-host.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import { createMangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
@@ -17,6 +17,7 @@ import type { DownloadRow } from "@modules/history/index.ts";
 import { CliError } from "@plugins/errors/index.ts";
 import type { MangaDexResolveResult } from "./fallback-types.ts";
 import { isFallbackEligible, runFallbackDownload } from "./fallback.ts";
+import { promptNumericChoice } from "./prompt.ts";
 import { parseRangeSet } from "./range.ts";
 import { toSlug } from "./slug.ts";
 import type { Bundle, DownloadArgs, DownloadContext, ProcessBundleArgs } from "./types.ts";
@@ -25,20 +26,15 @@ export type { DownloadArgs, DownloadContext } from "./types.ts";
 export { CliError } from "@plugins/errors/index.ts";
 
 /** Prompt user to pick one from a list of candidates with titles */
-function promptCandidatePick(candidates: { title: string }[]): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const rl = createInterface({ input: process.stdin, output: process.stderr });
-    const list = candidates.map((c, i) => `  [${i + 1}] ${c.title}`).join("\n");
-    process.stderr.write(`Multiple results found:\n${list}\nPick one: `);
-    rl.once("line", (line) => {
-      rl.close();
-      const n = Number.parseInt(line.trim(), 10);
-      if (Number.isNaN(n) || n < 1 || n > candidates.length) {
-        reject(new CliError(`Invalid selection: "${line.trim()}"`, 2));
-      } else {
-        resolve(n - 1);
-      }
-    });
+function promptCandidatePick(
+  candidates: { title: string }[],
+  logger: DownloadContext["logger"],
+): Promise<number> {
+  return promptNumericChoice({
+    header: "Multiple results found:",
+    items: candidates.map((c) => ({ display: c.title })),
+    logger,
+    event: "download.invalid_selection",
   });
 }
 
@@ -74,7 +70,7 @@ async function resolveTitle(
         2,
       );
     }
-    chosenIndex = await promptCandidatePick(candidates);
+    chosenIndex = await promptCandidatePick(candidates, logger);
   }
 
   const chosen = candidates[chosenIndex];
@@ -325,7 +321,7 @@ async function tryMangaDexPipeline(
   try {
     candidate = await resolveTitle(client, args.manga, args.nonTty, logger);
   } catch (err) {
-    if (err instanceof Error && err.message.startsWith("No manga found")) {
+    if (err instanceof TitleNotFoundError) {
       return null;
     }
     // CliError from resolveTitle (ambiguous title non-TTY, etc.) — propagate

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -1,4 +1,5 @@
 import { createInterface } from "node:readline";
+import { createFallbackHttp } from "@integrations/fallback-http/index.ts";
 import {
   AtHomeError,
   getAtHomeServer,
@@ -8,12 +9,14 @@ import type { ChapterRef, MangaCandidate } from "@integrations/mangadex/client/i
 import type { MangaDexClient } from "@integrations/mangadex/client/index.ts";
 import { parseExternalHost } from "@integrations/mangadex/external-host.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
+import { createMangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
 import { downloadBundle } from "@modules/downloader/index.ts";
 import type { ChapterInput } from "@modules/downloader/types.ts";
 import { isVolumeFullyDownloaded, recordDownloadedChapters } from "@modules/history/index.ts";
 import type { DownloadRow } from "@modules/history/index.ts";
 import { CliError } from "@plugins/errors/index.ts";
-import { resolveLanguage } from "./language.ts";
+import type { MangaDexResolveResult } from "./fallback-types.ts";
+import { isFallbackEligible, runFallbackDownload } from "./fallback.ts";
 import { parseRangeSet } from "./range.ts";
 import { toSlug } from "./slug.ts";
 import type { Bundle, DownloadArgs, DownloadContext, ProcessBundleArgs } from "./types.ts";
@@ -115,14 +118,7 @@ async function buildChapterInputs(
 /**
  * Group chapters from the feed into bundles based on args.
  * --volume: one bundle per requested volume token, all chapters in that volume.
- *   Volume mode keeps ALL uploads for a given volume (including multiple scanlation
- *   group versions of the same chapter number), which may produce larger .cbz files
- *   but preserves every available translation.
- * --chapter: one bundle per requested chapter token, one chapter each.
- *   Tiebreak rule: when multiple uploads exist for the same chapter number (different
- *   scanlation groups), the one with the latest `readableAt` wins — newer scanlation
- *   is typically higher quality. Chapters with chapter === null are excluded from the
- *   lookup map; they are not addressable via --chapter.
+ * --chapter: one bundle per requested chapter token, tiebreak: latest readableAt wins.
  */
 function groupChaptersIntoBundles(args: DownloadArgs, chaptersInLang: ChapterRef[]): Bundle[] {
   if (args.volume !== undefined) {
@@ -149,8 +145,6 @@ function groupChaptersIntoBundles(args: DownloadArgs, chaptersInLang: ChapterRef
     return bundles;
   }
 
-  // --chapter mode: deduplicate by chapter number, latest readableAt wins.
-  // Chapters with chapter === null are skipped (not addressable by number).
   const { values: requestedChapters } = parseRangeSet(args.chapter as string);
   const chapterNumToRef = new Map<string, ChapterRef>();
   for (const ch of chaptersInLang) {
@@ -169,7 +163,6 @@ function groupChaptersIntoBundles(args: DownloadArgs, chaptersInLang: ChapterRef
     bundles.push({
       kind: "chapter",
       bundleNumber: chapterToken,
-      // Use the chapter's real volume from MangaDex; null → "none"
       volumeForHistory: ch.volume ?? "none",
       chapters: [ch],
     });
@@ -183,7 +176,6 @@ async function processBundle(input: ProcessBundleArgs): Promise<void> {
   const { logger, db } = ctx;
   const { kind, bundleNumber, volumeForHistory, chapters } = bundle;
 
-  // history check — use volumeForHistory as the volume key (consistent across volume/chapter mode)
   if (!args.force) {
     const chapterIdSet = new Set(chapters.map((c) => c.id));
     const fullyDownloaded = isVolumeFullyDownloaded(db, {
@@ -207,7 +199,6 @@ async function processBundle(input: ProcessBundleArgs): Promise<void> {
     }
   }
 
-  // external-chapter check
   for (const ch of chapters) {
     if (ch.externalUrl !== null) {
       const host = parseExternalHost(ch.externalUrl) ?? ch.externalUrl;
@@ -316,88 +307,80 @@ async function processBundle(input: ProcessBundleArgs): Promise<void> {
   }
 }
 
-export async function runDownload(
+/**
+ * Attempt the MangaDex pipeline.
+ * Returns null when the title resolves to zero candidates (soft failure).
+ * Returns MangaDexResolveResult with language: null when no chapters in preferred languages.
+ * Throws on hard failures (network errors, etc.).
+ */
+async function tryMangaDexPipeline(
   args: DownloadArgs,
   ctx: DownloadContext,
   client: MangaDexClient,
-  http: MangaDexHttpClient,
-): Promise<void> {
+): Promise<MangaDexResolveResult | null> {
   const { logger, config } = ctx;
+  const preferred = config.preferred_languages;
 
-  // Validate: exactly one of volume/chapter must be set
-  if (args.volume !== undefined && args.chapter !== undefined) {
-    logger.warn(
-      { event: "download.mutual_exclusion", context: "download" },
-      "--volume and --chapter are mutually exclusive",
-    );
-    throw new CliError("--volume and --chapter are mutually exclusive", 2);
+  let candidate: MangaCandidate;
+  try {
+    candidate = await resolveTitle(client, args.manga, args.nonTty, logger);
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("No manga found")) {
+      return null;
+    }
+    // CliError from resolveTitle (ambiguous title non-TTY, etc.) — propagate
+    throw err;
   }
 
-  if (args.volume === undefined && args.chapter === undefined) {
-    logger.warn(
-      { event: "download.no_flag_set", context: "download" },
-      "--volume or --chapter is required",
-    );
-    throw new CliError("--volume <range> or --chapter <range> is required", 2);
+  const volumes = await client.aggregateVolumes(candidate.id, preferred);
+  const feedChapters = await client.feedChapters(candidate.id, preferred);
+  const availableLanguages = [...new Set(feedChapters.map((c) => c.translatedLanguage))];
+
+  // Soft language resolution — return null language instead of throwing
+  let language: string | null = null;
+  for (const lang of preferred) {
+    if (availableLanguages.includes(lang)) {
+      language = lang;
+      break;
+    }
   }
 
-  // Parse requested tokens once; reused for none-check and missing-in-feed warning below.
-  // At this point exactly one of volume/chapter is defined (validated above).
+  const chaptersInLang = language
+    ? feedChapters.filter((c) => c.translatedLanguage === language)
+    : [];
+
+  return { candidate, volumes, chaptersInLang, language };
+}
+
+/** MangaDex-only download path (original logic, factored out). */
+async function runMangaDexDownload(
+  args: DownloadArgs,
+  ctx: DownloadContext,
+  http: MangaDexHttpClient,
+  resolve: MangaDexResolveResult,
+): Promise<void> {
+  const { logger } = ctx;
+  const { candidate: chosen, chaptersInLang } = resolve;
+
+  // language is guaranteed non-null here: isFallbackEligible returns eligible when
+  // chaptersInLang is empty (language null) so we only reach this function when
+  // chaptersInLang is non-empty (language non-null).
+  const language = resolve.language as string;
+
+  logger.info(
+    { event: "download.language_resolved", context: "download", language },
+    "language resolved from preferences",
+  );
+
+  const slug = toSlug(chosen.title, logger);
+
   const requestedTokens =
     args.volume !== undefined
       ? parseRangeSet(args.volume).values
       : parseRangeSet(args.chapter as string).values;
 
-  if (args.volume !== undefined) {
-    if (requestedTokens.has("none")) {
-      logger.warn(
-        { event: "download.volume_none_unsupported", context: "download" },
-        "--volume none is not supported",
-      );
-      throw new CliError(
-        "--volume none is not yet supported. Use a numeric volume number instead.",
-        2,
-      );
-    }
-  }
-
-  if (args.chapter !== undefined) {
-    if (requestedTokens.has("none")) {
-      logger.warn(
-        { event: "download.chapter_none_unsupported", context: "download" },
-        "--chapter none is not supported",
-      );
-      throw new CliError(
-        "--chapter none is not yet supported. Use a numeric chapter number instead.",
-        2,
-      );
-    }
-  }
-
-  const chosen = await resolveTitle(client, args.manga, args.nonTty, logger);
-
-  const preferred = config.preferred_languages;
-
-  // aggregateVolumes primes the MangaDex aggregate cache used by feedChapters
-  await client.aggregateVolumes(chosen.id, preferred);
-
-  const feedChapters = await client.feedChapters(chosen.id, preferred);
-  const availableLanguages = [...new Set(feedChapters.map((c) => c.translatedLanguage))];
-
-  const language = await resolveLanguage({
-    preferred,
-    available: availableLanguages,
-    nonTty: args.nonTty,
-    logger,
-  });
-
-  const chaptersInLang = feedChapters.filter((c) => c.translatedLanguage === language);
-
-  const slug = toSlug(chosen.title, logger);
-
   const bundles = groupChaptersIntoBundles(args, chaptersInLang);
 
-  // Warn about requested items missing from feed (reuses requestedTokens parsed above)
   const foundBundleTokens = new Set(bundles.map((b) => b.bundleNumber));
   for (const token of requestedTokens) {
     if (!foundBundleTokens.has(token)) {
@@ -418,4 +401,98 @@ export async function runDownload(
   for (const bundle of bundles) {
     await processBundle({ bundle, chosen, slug, language, args, ctx, http });
   }
+}
+
+export async function runDownload(
+  args: DownloadArgs,
+  ctx: DownloadContext,
+  client: MangaDexClient,
+  http: MangaDexHttpClient,
+): Promise<void> {
+  const { logger } = ctx;
+
+  if (args.volume !== undefined && args.chapter !== undefined) {
+    logger.warn(
+      { event: "download.mutual_exclusion", context: "download" },
+      "--volume and --chapter are mutually exclusive",
+    );
+    throw new CliError("--volume and --chapter are mutually exclusive", 2);
+  }
+
+  if (args.volume === undefined && args.chapter === undefined) {
+    logger.warn(
+      { event: "download.no_flag_set", context: "download" },
+      "--volume or --chapter is required",
+    );
+    throw new CliError("--volume <range> or --chapter <range> is required", 2);
+  }
+
+  const requestedTokens =
+    args.volume !== undefined
+      ? parseRangeSet(args.volume).values
+      : parseRangeSet(args.chapter as string).values;
+
+  if (args.volume !== undefined && requestedTokens.has("none")) {
+    logger.warn(
+      { event: "download.volume_none_unsupported", context: "download" },
+      "--volume none is not supported",
+    );
+    throw new CliError(
+      "--volume none is not yet supported. Use a numeric volume number instead.",
+      2,
+    );
+  }
+
+  if (args.chapter !== undefined && requestedTokens.has("none")) {
+    logger.warn(
+      { event: "download.chapter_none_unsupported", context: "download" },
+      "--chapter none is not supported",
+    );
+    throw new CliError(
+      "--chapter none is not yet supported. Use a numeric chapter number instead.",
+      2,
+    );
+  }
+
+  // Try MangaDex pipeline (soft failure on title-not-found, language-not-matched)
+  let mangadexResolve: MangaDexResolveResult | null = null;
+  try {
+    mangadexResolve = await tryMangaDexPipeline(args, ctx, client);
+  } catch (err) {
+    // "No manga found" from resolveTitleToId is a soft failure → fallback
+    if (err instanceof Error && err.message.startsWith("No manga found")) {
+      logger.info(
+        { event: "download.mangadex_title_not_found", context: "download", title: args.manga },
+        "title not found on MangaDex; attempting fallback",
+      );
+      mangadexResolve = null;
+    } else {
+      throw err;
+    }
+  }
+
+  const eligibility = isFallbackEligible(mangadexResolve);
+
+  if (eligibility.eligible) {
+    logger.info(
+      {
+        event: "download.fallback_triggered",
+        context: "download",
+        reason: eligibility.reason,
+        title: args.manga,
+      },
+      `MangaDex unavailable for "${args.manga}" (reason: ${eligibility.reason}); offering fallback`,
+    );
+    return runFallbackDownload({
+      args,
+      ctx,
+      mangadexResolve,
+      createFallbackHttp,
+      createMangakakalotClient,
+    });
+  }
+
+  // MangaDex path — mangadexResolve is non-null here (isFallbackEligible returned false)
+  // biome-ignore lint/style/noNonNullAssertion: guaranteed non-null when !eligibility.eligible
+  await runMangaDexDownload(args, ctx, http, mangadexResolve!);
 }

--- a/src/commands/download/prompt.test.ts
+++ b/src/commands/download/prompt.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { CliError } from "@plugins/errors/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+
+const noopLogger: Logger = { info: () => {}, warn: () => {}, error: () => {} };
+
+const items = [{ display: "Alpha" }, { display: "Beta" }, { display: "Gamma" }];
+
+describe("promptNumericChoice", () => {
+  afterAll(() => mock.restore());
+
+  test("valid input returns 0-based index", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => cb("2"),
+        close: () => {},
+      }),
+    }));
+    const { promptNumericChoice } = await import("./prompt.ts");
+    const result = await promptNumericChoice({ header: "Choose:", items, logger: noopLogger });
+    expect(result).toBe(1);
+  });
+
+  test("out-of-range input throws CliError and fires logger.warn", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => cb("99"),
+        close: () => {},
+      }),
+    }));
+    let warnFired = false;
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: () => {
+        warnFired = true;
+      },
+      error: () => {},
+    };
+    const { promptNumericChoice } = await import("./prompt.ts");
+    await expect(
+      promptNumericChoice({ header: "Choose:", items, logger: spyLogger }),
+    ).rejects.toBeInstanceOf(CliError);
+    expect(warnFired).toBe(true);
+  });
+
+  test("non-numeric input throws CliError and fires logger.warn", async () => {
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => cb("abc"),
+        close: () => {},
+      }),
+    }));
+    let warnFired = false;
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: () => {
+        warnFired = true;
+      },
+      error: () => {},
+    };
+    const { promptNumericChoice } = await import("./prompt.ts");
+    await expect(
+      promptNumericChoice({ header: "Choose:", items, logger: spyLogger }),
+    ).rejects.toBeInstanceOf(CliError);
+    expect(warnFired).toBe(true);
+  });
+});

--- a/src/commands/download/prompt.ts
+++ b/src/commands/download/prompt.ts
@@ -1,0 +1,42 @@
+import { createInterface } from "node:readline";
+import { CliError } from "@plugins/errors/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+
+export interface NumericChoiceOptions {
+  /** The header line shown above the numbered list. */
+  header: string;
+  /** The items to enumerate. */
+  items: ReadonlyArray<{ display: string }>;
+  /** Logger for warn-before-throw on invalid input. */
+  logger: Logger;
+  /** Optional context label for the warn payload (e.g. "download.candidate"). */
+  event?: string;
+}
+
+/**
+ * Interactive numeric picker. Reads from process.stdin / writes to process.stderr.
+ * Throws CliError on invalid input. Caller is responsible for nonTty gate.
+ * Returns the 0-based index of the chosen item.
+ */
+export function promptNumericChoice(opts: NumericChoiceOptions): Promise<number> {
+  const { header, items, logger, event = "download.invalid_selection" } = opts;
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const list = items.map((item, i) => `  [${i + 1}] ${item.display}`).join("\n");
+    process.stderr.write(`${header}\n${list}\nPick one: `);
+    rl.once("line", (line) => {
+      rl.close();
+      const input = line.trim();
+      const n = Number.parseInt(input, 10);
+      if (Number.isNaN(n) || n < 1 || n > items.length) {
+        logger.warn(
+          { event, context: "download", input, count: items.length },
+          `invalid selection: "${input}"`,
+        );
+        reject(new CliError(`Invalid selection: "${input}"`, 2));
+      } else {
+        resolve(n - 1);
+      }
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from "node:util";
 import { runDownload } from "@commands/download/index.ts";
 import { runList } from "@commands/list/index.ts";
+import { CloudflareError, MissingAuthError } from "@integrations/fallback-http/index.ts";
 import { createMangaDexClient } from "@integrations/mangadex/client/index.ts";
 import { createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
 import { AuthError, runAuth } from "@integrations/mangakakalot/browser/index.ts";
@@ -301,6 +302,14 @@ if (import.meta.main) {
       process.exit(2);
     }
     if (err instanceof AuthError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(1);
+    }
+    if (err instanceof MissingAuthError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(1);
+    }
+    if (err instanceof CloudflareError) {
       process.stderr.write(`${err.message}\n`);
       process.exit(1);
     }

--- a/src/integrations/mangadex/client/client.test.ts
+++ b/src/integrations/mangadex/client/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createMangaDexClient } from "./index.ts";
+import { TitleNotFoundError, createMangaDexClient } from "./index.ts";
 import { normalizeLang, parseAggregate, parseChapterFeed, parseMangaList } from "./parser.ts";
 import type {
   MdxAggregateResponse,
@@ -105,7 +105,7 @@ describe("createMangaDexClient", () => {
       get: async <T>(_path: string, _q?: unknown) => ({ result: "ok", data: [] }) as unknown as T,
     };
     const client = createMangaDexClient(http);
-    await expect(client.resolveTitleToId("nonexistent")).rejects.toThrow("No manga found");
+    await expect(client.resolveTitleToId("nonexistent")).rejects.toBeInstanceOf(TitleNotFoundError);
   });
 
   it("resolveTitleToId returns candidates when found", async () => {

--- a/src/integrations/mangadex/client/index.ts
+++ b/src/integrations/mangadex/client/index.ts
@@ -1,5 +1,6 @@
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import { parseAggregate, parseChapterFeed, parseMangaList } from "./parser.ts";
+import { TitleNotFoundError } from "./types.ts";
 import type {
   ChapterRef,
   MangaCandidate,
@@ -11,6 +12,7 @@ import type {
 } from "./types.ts";
 
 export type { ChapterRef, MangaCandidate, MangaDexClient, VolumeRef } from "./types.ts";
+export { TitleNotFoundError } from "./types.ts";
 
 export function createMangaDexClient(http: MangaDexHttpClient): MangaDexClient {
   async function searchManga(title: string, lang?: string): Promise<MangaCandidate[]> {
@@ -50,7 +52,7 @@ export function createMangaDexClient(http: MangaDexHttpClient): MangaDexClient {
   async function resolveTitleToId(title: string): Promise<MangaCandidate[]> {
     const candidates = await searchManga(title);
     if (candidates.length === 0) {
-      throw new Error(`No manga found for title: "${title}"`);
+      throw new TitleNotFoundError(title);
     }
     return candidates;
   }

--- a/src/integrations/mangadex/client/types.ts
+++ b/src/integrations/mangadex/client/types.ts
@@ -6,6 +6,14 @@ import type { ChapterRef, MangaCandidate, VolumeRef } from "@integrations/_share
 
 export type { ChapterRef, MangaCandidate, VolumeRef };
 
+/** Thrown by resolveTitleToId when the MangaDex search returns zero results. */
+export class TitleNotFoundError extends Error {
+  override readonly name = "TitleNotFoundError";
+  constructor(public readonly title: string) {
+    super(`No manga found for title: "${title}"`);
+  }
+}
+
 // --- MangaDex REST response shapes ---
 
 export interface MdxLocalizedString {

--- a/src/integrations/mangakakalot/browser/browser.test.ts
+++ b/src/integrations/mangakakalot/browser/browser.test.ts
@@ -230,6 +230,154 @@ describe("buildVerifyHeaders", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runAuth — no-challenge path: waitForLoadState ordering
+//
+// These tests use a minimal Playwright-shaped mock. They cannot launch
+// Chromium, so they only exercise the observable ordering of mock calls.
+// ---------------------------------------------------------------------------
+
+import { runAuth } from "./index.ts";
+import type { RunAuthOptions } from "./types.ts";
+
+describe("runAuth no-challenge path — waitForLoadState ordering", () => {
+  // Build a minimal mock that simulates the no-challenge path.
+  // Returns call log so tests can assert ordering.
+  function buildMocks(opts: {
+    cookiesAfterLoad?: Array<{ name: string; value: string }>;
+    loadRejects?: boolean;
+  }) {
+    const callLog: string[] = [];
+    const { cookiesAfterLoad = [{ name: "_ga", value: "GA1.1.1" }], loadRejects = false } = opts;
+
+    let loadStateCalled = false;
+
+    const page = {
+      goto: async () => {},
+      title: async () => "MangaKakalot - Read Manga Online",
+      evaluate: async () => "Mozilla/5.0 (mock)",
+      waitForLoadState: async (_state: string, _opts?: unknown) => {
+        callLog.push("waitForLoadState");
+        loadStateCalled = true;
+        if (loadRejects) throw new Error("timeout");
+      },
+    };
+
+    const context = {
+      newPage: async () => page,
+      cookies: async (_url?: string) => {
+        callLog.push("cookies");
+        // Return cookies only after waitForLoadState has been called — simulates
+        // the real-world race where GA cookies appear after "load".
+        return loadStateCalled ? cookiesAfterLoad : [];
+      },
+    };
+
+    const browser = {
+      on: (_event: string, _cb: () => void) => {},
+      newContext: async () => context,
+      close: async () => {},
+    };
+
+    return { browser, callLog };
+  }
+
+  // Patch chromium.launch so runAuth uses our mock browser.
+  // We import "playwright" at the module level in index.ts, so we monkey-patch
+  // the module object directly — Bun supports this for in-process mocking.
+  async function withMockBrowser(browser: unknown, fn: () => Promise<void>): Promise<void> {
+    const playwright = await import("playwright");
+    const original = playwright.chromium.launch;
+    // @ts-expect-error — intentional monkey-patch for test isolation
+    playwright.chromium.launch = async () => browser;
+    try {
+      await fn();
+    } finally {
+      playwright.chromium.launch = original;
+    }
+  }
+
+  function buildOpts(tmpDataHome: string): RunAuthOptions {
+    return {
+      dataHome: tmpDataHome,
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+        // pino minimal shape
+        child: () => ({}) as never,
+      } as unknown as RunAuthOptions["logger"],
+    };
+  }
+
+  test("waitForLoadState('load') is called before context.cookies() on no-challenge path", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "scanldr-auth-order-"));
+    try {
+      const { browser, callLog } = buildMocks({});
+
+      // Stub fetch to simulate a successful verify.
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+
+      try {
+        await withMockBrowser(browser, () => runAuth(buildOpts(tmpDir)));
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      const waitIdx = callLog.indexOf("waitForLoadState");
+      const cookiesIdx = callLog.indexOf("cookies");
+      expect(waitIdx).toBeGreaterThanOrEqual(0);
+      expect(cookiesIdx).toBeGreaterThanOrEqual(0);
+      expect(waitIdx).toBeLessThan(cookiesIdx);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("load timeout falls through: warn fires, cookies still extracted, session saved", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "scanldr-auth-timeout-"));
+    const warnEvents: string[] = [];
+    try {
+      const { browser } = buildMocks({ loadRejects: true });
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+
+      let warnFired = false;
+      const opts: RunAuthOptions = {
+        ...buildOpts(tmpDir),
+        logger: {
+          info: () => {},
+          warn: (fields: Record<string, unknown>) => {
+            if (fields.event === "auth.load_timeout") warnFired = true;
+            warnEvents.push(String(fields.event));
+          },
+          error: () => {},
+          debug: () => {},
+          child: () => ({}) as never,
+        } as unknown as RunAuthOptions["logger"],
+      };
+
+      try {
+        await withMockBrowser(browser, () => runAuth(opts));
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      expect(warnFired).toBe(true);
+      // Session file should exist despite timeout.
+      const sessionPath = resolveAuthPath({ dataHome: tmpDir });
+      const raw = await readFile(sessionPath, "utf8");
+      const parsed = JSON.parse(raw) as { userAgent: string };
+      expect(parsed.userAgent).toBe("Mozilla/5.0 (mock)");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // On-disk perms — hand-write a session file the same way runAuth would,
 // to assert mkdir + writeFile mode flags actually take effect on this FS.
 // (We cannot exercise runAuth itself without launching Chromium.)

--- a/src/integrations/mangakakalot/browser/browser.test.ts
+++ b/src/integrations/mangakakalot/browser/browser.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveAuthPath } from "@plugins/auth-path/index.ts";
-import { AuthError, pageHasRealContent, pollForClearance } from "./index.ts";
+import { AuthError, buildVerifyHeaders, pageHasRealContent, pollForClearance } from "./index.ts";
 import type { CookieLike } from "./types.ts";
 
 // ---------------------------------------------------------------------------
@@ -193,6 +193,39 @@ describe("pollForClearance", () => {
         intervalMs: 10,
       }),
     ).rejects.toBe(browserClosedError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVerifyHeaders — verify-fetch header construction
+// ---------------------------------------------------------------------------
+
+describe("buildVerifyHeaders", () => {
+  test("omits Cookie header when cookies map is empty", () => {
+    const headers = buildVerifyHeaders({}, "Mozilla/5.0");
+    expect("cookie" in headers).toBe(false);
+    expect(headers["user-agent"]).toBe("Mozilla/5.0");
+  });
+
+  test("includes Cookie header when cookies map is non-empty", () => {
+    const headers = buildVerifyHeaders({ _ga: "GA1.1.123", cf_clearance: "abc" }, "Mozilla/5.0");
+    expect(headers.cookie).toBeDefined();
+    expect(headers.cookie).toContain("_ga=GA1.1.123");
+    expect(headers.cookie).toContain("cf_clearance=abc");
+    expect(headers["user-agent"]).toBe("Mozilla/5.0");
+  });
+
+  test("single cookie produces correct k=v format with no trailing separator", () => {
+    const headers = buildVerifyHeaders({ token: "xyz" }, "ua");
+    expect(headers.cookie).toBe("token=xyz");
+  });
+
+  test("multiple cookies are joined by '; '", () => {
+    const headers = buildVerifyHeaders({ a: "1", b: "2" }, "ua");
+    // Order depends on Object.entries — just verify both are present and separator exists
+    expect(headers.cookie).toMatch(/a=1/);
+    expect(headers.cookie).toMatch(/b=2/);
+    expect(headers.cookie).toContain("; ");
   });
 });
 

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -131,6 +131,21 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
         { event: "auth.no_challenge", context: "browser" },
         "Page loaded with real site content — skipping cf_clearance poll.",
       );
+
+      // GA / tracking cookies are set by JS that runs on "load", not on
+      // "domcontentloaded". Without them, Cloudflare's fingerprint check on
+      // protected endpoints (e.g. /search/…) returns 403 even when the
+      // homepage itself is public. Wait for the full load event so those
+      // cookies have time to land before we extract the session.
+      try {
+        await page.waitForLoadState("load", { timeout: 10_000 });
+      } catch {
+        // "load" may never fire if a tracking pixel hangs — proceed anyway.
+        logger.warn(
+          { event: "auth.load_timeout", context: "browser" },
+          "page load did not complete within 10s; proceeding with whatever cookies are set",
+        );
+      }
     } else {
       logger.info(
         { event: "auth.waiting", context: "browser" },

--- a/src/integrations/mangakakalot/browser/index.ts
+++ b/src/integrations/mangakakalot/browser/index.ts
@@ -55,6 +55,27 @@ export async function pollForClearance(opts: PollForClearanceOptions): Promise<v
 }
 
 /**
+ * Builds the headers object for the session-verify fetch.
+ * Omits the Cookie header when `cookies` is empty so the request is sent
+ * with no Cookie header at all — matching FallbackHttpClient behaviour (#21).
+ * Exported for unit tests.
+ */
+export function buildVerifyHeaders(
+  cookies: Record<string, string>,
+  userAgent: string,
+): Record<string, string> {
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ");
+
+  const headers: Record<string, string> = { "user-agent": userAgent };
+  if (cookieHeader.length > 0) {
+    headers.cookie = cookieHeader;
+  }
+  return headers;
+}
+
+/**
  * Runs the interactive auth flow:
  * 1. Opens headful Chromium.
  * 2. Navigates to SITE_ROOT.
@@ -144,22 +165,14 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
       cookies[c.name] = c.value;
     }
 
-    // Guard: if the no-challenge path produced no cookies, the session is invalid.
-    if (Object.keys(cookies).length === 0) {
-      throw new AuthError(
-        "No cookies captured after page load. Session cannot be saved — re-run scanldr auth.",
-      );
-    }
-
     logger.info(
       { event: "auth.challenge_resolved", context: "browser" },
       "Challenge resolved. Verifying session…",
     );
 
     // Verify: plain fetch with captured cookies + UA must return 200.
-    const cookieHeader = Object.entries(cookies)
-      .map(([k, v]) => `${k}=${v}`)
-      .join("; ");
+    // The verify step is the spec'd source of truth (ADR/issue #40); no second gate needed.
+    const verifyHeaders = buildVerifyHeaders(cookies, userAgent);
 
     const controller = new AbortController();
     const verifyTimer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
@@ -167,10 +180,7 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
     let verifyOk = false;
     try {
       const res = await fetch(SITE_ROOT, {
-        headers: {
-          cookie: cookieHeader,
-          "user-agent": userAgent,
-        },
+        headers: verifyHeaders,
         signal: controller.signal,
       });
       verifyOk = res.ok;
@@ -195,6 +205,13 @@ export async function runAuth(opts: RunAuthOptions): Promise<void> {
       encoding: "utf8",
       mode: 0o600,
     });
+
+    if (Object.keys(cookies).length === 0) {
+      logger.info(
+        { event: "auth.saved_no_cookies", context: "browser" },
+        "Session saved with no cookies — site is public; only User-Agent is being persisted.",
+      );
+    }
 
     logger.info(
       { event: "auth.saved", context: "browser", path: outPath },


### PR DESCRIPTION
## What this PR does

Fecha a trilha de fallback (`#21 → #22 → #23`). Quando o MangaDex não consegue servir um título — não está no catálogo, não tem chapters nas línguas preferidas, ou todos os chapters são externos (caso típico Dandadan/MangaPlus) — o `download` agora oferece o picker de fallback, captura a escolha do usuário, e roteia o download através do mangakakalot via cookie replay.

## Por que existe

Sem essa peça, séries populares ongoing publicadas via MangaPlus (Dandadan, JJK, One Piece, Spy x Family, MHA…) batiam no `CliError "Chapter X is hosted externally..."` e o usuário ficava sem alternativa dentro do scanldr. Com o fallback wired, o caminho `Pick mangakakalot → search → download` funciona ponta-a-ponta.

Ref: #23

## Como funciona por dentro

### Refactor do `runDownload`

A função monolítica foi decomposta em:

- **`tryMangaDexPipeline`** — tenta resolver via MangaDex (search + aggregate + feedChapters + soft language). Retorna `MangaDexResolveResult | null`. `null` apenas no caso "title not found" (agora detectado via `TitleNotFoundError` tipado, não via string match).
- **`isFallbackEligible`** — função pura. Decide com base no resultado se devemos cair no fallback. Três casos eleg脥veis: `title_not_found`, `no_chapters_in_lang`, `all_external`. Mistura de chapters externos + CDN não dispara fallback (MangaDex ainda é usável).
- **`runMangaDexDownload`** — corpo original, agora invocado apenas quando MangaDex serve.
- **`runFallbackDownload`** — novo orquestrador, em `src/commands/download/fallback.ts`.

### Fluxo do `runFallbackDownload`

1. Validação: se `--volume` foi pedido mas o MangaDex não tem aggregate → `CliError` instruindo `--chapter`. Volume metadata só é reutilizável quando o MangaDex sabe `vol N = chapters X-Y`.
2. **Site picker** (mesmo com 1 site) — ADR-002 decisão #4: nunca cair silenciosamente em fallback. TTY → prompt; non-TTY → `CliError` apontando pra `auth` + uso interativo.
3. Bootstrap: `createFallbackHttp({ logger })` (cookie replay do `auth.json` capturado em `scanldr auth`) + `createMangakakalotClient({ http, logger })`.
4. Search no mangakakalot (slug é diferente do MangaDex UUID). 0 results → `CliError`. Multi-candidate → mesmo padrão TTY/non-TTY do `resolveTitle`.
5. **`buildFallbackBundles`** — reuso de volume metadata: para cada volume pedido, lê `mdVolume.chapterIds → numeros` via `mangadexChapters`, depois encontra os chapters do mangakakalot que casam por número. Se algum chapter falta no mangakakalot, warn e segue com os disponíveis. Volume completamente ausente → skip.
6. **`processFallbackBundle`** — history check (skip se `isVolumeFullyDownloaded` e não `--force`), monta `ChapterInput[]` com fetcher per-chapter via `makeMangakakalotFetcher(http, logger)`, chama `downloadBundle`, grava history rows com `source: "mangakakalot"` e `language: "en"` (constante `MANGAKAKALOT_LANGUAGE` — site é EN-only por design conforme ADR-002).

### Erros tipados propagam

- `MissingAuthError` (do `createFallbackHttp`) e `CloudflareError` (do `mkClient`) **não** são wrapped como `CliError`. `src/index.ts` ganhou handlers tipados ao lado dos existentes (`CliError`, `AuthError`, `NotImplementedError`). Mensagem original chega ao usuário com a instrução acionável ("Run `scanldr auth` to capture one." / "Cloudflare rejected the request to ... Run `scanldr auth` to refresh.").

### Helper compartilhado de prompt

`promptNumericChoice` em `src/commands/download/prompt.ts` substitui as 3 funções quase-idênticas que existiam (`promptCandidatePick`, `pickCandidate`, `promptFallbackSite`). Cada call site mantém sua assinatura tipada externamente (retorna `MangaCandidate`, `FallbackSiteOption`, etc.), mas a parte de readline + parse + warn-before-throw vive num lugar só.

### Tipo `TitleNotFoundError`

Novo em `@integrations/mangadex/client`. Substitui o string match `err.message.startsWith("No manga found")` por `instanceof TitleNotFoundError`. Mensagem preservada — backward compat.

## O que não mudou

- Caminho MangaDex existente (`runMergeDexDownload`): single-chapter / multi-chapter / `--force` / `--no-track` / `--dry-run` / atomic-on-failure / external-chapter refuse (quando há chapters CDN no mesmo idioma) — todos passam.
- `FallbackHttpClient` API e seu retry / 1-req/s throttle / cookie replay (do #21).
- `MangakakalotClient` API e sua paginação / `MangakakalotParseError` / `mangakakalot.fetch` log (do #22).
- `downloadBundle` API e contratos atomicidade.
- `recordDownloadedChapters` API e schema da tabela `downloads`.

## ACs satisfeitos

- [x] Title não está no MangaDex → fallback prompt
- [x] Sem chapters nas línguas preferidas → fallback prompt
- [x] Todos chapters do MangaDex são externos → fallback prompt (caso Dandadan)
- [x] Non-TTY → `CliError` apontando pra TTY + `scanldr auth`
- [x] Volume metadata reuse: MangaDex vol 3 = ch.18-21 → mangakakalot baixa 18-21, agrupa como vol 3
- [x] Sem aggregate AND sem `--chapter` → `CliError` instruindo `--chapter`
- [x] History row com `source = "mangakakalot"`
- [x] Integration test: not-on-MangaDex + has-on-mangakakalot → `.cbz` produzido + history correto + bytes do archive batem com fetcher do mangakakalot (sentinel)

## Test checklist

- [x] `isFallbackEligible` 4 casos (3 elegíveis + 1 não)
- [x] `buildFallbackBundles`: volume happy path / parcial (warn + segue) / total-zero-match (skip + warn) / chapter mode com volume reuse / chapter mode com `volumeForHistory: "none"`
- [x] `runFallbackDownload`: search 0 results / search multi non-TTY / `MissingAuthError` propagation
- [x] `promptFallbackSite` non-TTY → CliError
- [x] `promptNumericChoice` (novo helper): valid input / out-of-range / non-numeric — todos com logger.warn antes do reject
- [x] Integration: 5 cenários cobertos em `download.test.ts` (incluindo Dandadan-style all-external)
- [x] CLI integration test (`cli-routing.test.ts`) intacto
- [x] `TitleNotFoundError` é o caminho único de detecção no `tryMangaDexPipeline`
- [x] `bun test` — 375 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- O picker de fallback está hardcoded para 1 site (mangakakalot). Quando `#22-equivalent` para outro site (Comikey, etc.) entrar, é só adicionar ao array — o prompt ja escala.
- `processFallbackBundle` usa o mangakakalot slug como `mangaId` na history (mangakakalot não tem UUIDs). Isso significa que um mesmo manga baixado via MangaDex e depois via mangakakalot terá `mangaId` diferentes — `update`/`sync` (#16/#17) precisam considerar isso quando forem implementados.
- Ainda é possível que MangaDex tenha um manga com chapters mistos (alguns externos, alguns CDN) — nesse caso, o caminho MangaDex ganha (eligibility é só "ALL external"). O usuário com sorte pega os CDN; quando bater num externo, o `CliError` per-chapter dispara como antes.

## Closes

Ref: #23