### PR TITLE
fix(fallback): clear error when requested volumes aren't mapped in MangaDex aggregate

### DIFF
--- a/src/commands/download/fallback.test.ts
+++ b/src/commands/download/fallback.test.ts
@@ -527,6 +527,203 @@ describe("promptFallbackSite — TTY readline mock", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runFallbackDownload — volume mode, all requested volumes missing from aggregate
+// ---------------------------------------------------------------------------
+
+describe("runFallbackDownload — volume mode with all requested volumes missing from aggregate", () => {
+  test("throws CliError with actionable message and fires warn event", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const fakeFallbackHttp: FallbackHttpClient = {
+      get: async () => new Response(new Uint8Array([]), { status: 200 }),
+    };
+
+    // aggregate has vols "1" and "none", user requests vol "13"
+    const mangadexResolve: MangaDexResolveResult = {
+      candidate: { id: "manga-dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      volumes: [makeVolumeRef("1", ["ch-1"]), makeVolumeRef("none", ["ch-0"])],
+      chaptersInLang: [
+        makeChapterRef({ id: "ch-1", chapter: "1", volume: "1" }),
+        makeChapterRef({ id: "ch-0", chapter: "0", volume: "none" }),
+      ],
+      language: "en",
+    };
+
+    const mkClientStub: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan-slug", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => [makeChapterRef({ id: "mk-ch1", chapter: "1", volume: null })],
+      getChapterImages: async () => [],
+    };
+
+    const warnPayloads: Array<Record<string, unknown>> = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null) {
+          warnPayloads.push(obj as Record<string, unknown>);
+        }
+      },
+      error: () => {},
+    };
+
+    const err = await runFallbackDownload({
+      args: baseArgs({ volume: "13" }),
+      ctx: {
+        logger: spyLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve,
+      createFallbackHttp: async () => fakeFallbackHttp,
+      createMangakakalotClient: () => mkClientStub,
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      promptSite: async (sites) => sites[0]!,
+    }).catch((e) => e);
+
+    db.close();
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("None of the requested volumes are mapped");
+    expect((err as CliError).message).toContain("Dandadan");
+    expect((err as CliError).message).toContain("Available mapped volumes:");
+    expect((err as CliError).message).toContain("1");
+    expect((err as CliError).message).toContain("none");
+    expect((err as CliError).message).toContain("--chapter");
+    expect((err as CliError).exitCode).toBe(2);
+
+    const noVolWarn = warnPayloads.find((p) => p.event === "download.fallback_no_volumes_matched");
+    expect(noVolWarn).toBeDefined();
+    expect(noVolWarn?.requested).toEqual(expect.arrayContaining(["13"]));
+    expect(noVolWarn?.available).toEqual(expect.arrayContaining(["1", "none"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runFallbackDownload — volume mode, mixed match (some found, some not)
+// ---------------------------------------------------------------------------
+
+describe("runFallbackDownload — volume mode with mixed match still proceeds with matched ones", () => {
+  test("processes matched volumes and warns on missing ones without throwing", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const imageUrl = "https://img-r1.2xstorage.com/test/1/0.webp";
+    const searchHtml = `<html><body>
+      <div class="panel_story_list">
+        <div class="story_item">
+          <div class="story_name"><a href="https://www.mangakakalot.gg/manga/test-slug">Test</a></div>
+        </div>
+      </div>
+    </body></html>`;
+    const chapterHtml = `<div class="container-chapter-reader"><img src="${imageUrl}" /></div>`;
+    const chaptersJson = JSON.stringify({
+      success: true,
+      data: {
+        chapters: [
+          {
+            chapter_name: "Chapter 1",
+            chapter_slug: "chapter-1",
+            chapter_num: 1,
+            updated_at: "2024-01-01T00:00:00.000000Z",
+            view: 0,
+          },
+        ],
+      },
+    });
+
+    const mockHttp: FallbackHttpClient = {
+      get: async (url: string) => {
+        if (url === imageUrl) {
+          return new Response(new Uint8Array([1, 2, 3]).buffer, { status: 200 });
+        }
+        if (url.includes("/api/manga/")) {
+          return new Response(chaptersJson, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.includes("/search/")) {
+          return new Response(searchHtml, {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          });
+        }
+        return new Response(chapterHtml, { status: 200, headers: { "content-type": "text/html" } });
+      },
+    };
+
+    // aggregate has vols "1" and "none", user requests "1,13"
+    const mangadexResolve: MangaDexResolveResult = {
+      candidate: { id: "manga-test", title: "Test", originalLanguage: "ja", year: 2021 },
+      volumes: [makeVolumeRef("1", ["ch-md-1"]), makeVolumeRef("none", ["ch-md-0"])],
+      chaptersInLang: [
+        makeChapterRef({ id: "ch-md-1", chapter: "1", volume: "1" }),
+        makeChapterRef({ id: "ch-md-0", chapter: "0", volume: "none" }),
+      ],
+      language: "en",
+    };
+
+    const warnPayloads: Array<Record<string, unknown>> = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null) {
+          warnPayloads.push(obj as Record<string, unknown>);
+        }
+      },
+      error: () => {},
+    };
+
+    // Should complete without throwing (vol "1" is available, vol "13" gets a per-volume warn)
+    await runFallbackDownload({
+      args: baseArgs({ volume: "1,13", noTrack: true }),
+      ctx: {
+        logger: spyLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve,
+      createFallbackHttp: async () => mockHttp,
+      createMangakakalotClient: (opts) => mkClient(opts),
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      promptSite: async (sites) => sites[0]!,
+    });
+
+    db.close();
+
+    // vol 13 should generate a per-volume warn (not the top-level "no volumes matched" error)
+    const perVolWarn = warnPayloads.find((p) => p.event === "download.fallback_volume_missing");
+    expect(perVolWarn).toBeDefined();
+    expect(perVolWarn?.volume).toBe("13");
+
+    // The top-level "no volumes matched" should NOT fire
+    const noMatchWarn = warnPayloads.find(
+      (p) => p.event === "download.fallback_no_volumes_matched",
+    );
+    expect(noMatchWarn).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // makeMangakakalotFetcher — Referer header
 // ---------------------------------------------------------------------------
 

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -333,6 +333,31 @@ export async function runFallbackDownload(opts: {
     logger,
   });
 
+  // Guard: volume mode + MangaDex has volumes, but none of the requested ones are in the mapping.
+  // This happens when the title is partner-published and MangaDex doesn't track certain volumes.
+  if (
+    args.volume !== undefined &&
+    bundles.length === 0 &&
+    mangadexResolve &&
+    mangadexResolve.volumes.length > 0
+  ) {
+    const requested = [...requestedTokens].sort();
+    const available = mangadexResolve.volumes.map((v) => v.volume).sort();
+    logger.warn(
+      {
+        event: "download.fallback_no_volumes_matched",
+        context: "download",
+        requested,
+        available,
+      },
+      "no requested volume tokens are mapped in MangaDex aggregate",
+    );
+    throw new CliError(
+      `None of the requested volumes are mapped in MangaDex's aggregate for "${mangadexResolve.candidate.title}".\nAvailable mapped volumes: ${available.join(", ")}.\nUse --chapter <range> instead — MangaDex doesn't track this volume for this title (likely partner-published series).`,
+      2,
+    );
+  }
+
   const slug = toSlug(mkChosen.title, logger);
 
   for (const bundle of bundles) {

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -144,6 +144,16 @@ function makeMangakakalotFetcher(
 // buildFallbackBundles
 // ---------------------------------------------------------------------------
 
+function compareVolumeTokens(a: string, b: string): number {
+  if (a === "none" && b === "none") return 0;
+  if (a === "none") return 1;
+  if (b === "none") return -1;
+  const an = Number(a);
+  const bn = Number(b);
+  if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn;
+  return a.localeCompare(b);
+}
+
 export function buildFallbackBundles(opts: {
   args: DownloadArgs;
   requestedTokens: Set<string>;
@@ -341,8 +351,8 @@ export async function runFallbackDownload(opts: {
     mangadexResolve &&
     mangadexResolve.volumes.length > 0
   ) {
-    const requested = [...requestedTokens].sort();
-    const available = mangadexResolve.volumes.map((v) => v.volume).sort();
+    const requested = [...requestedTokens].sort(compareVolumeTokens);
+    const available = mangadexResolve.volumes.map((v) => v.volume).sort(compareVolumeTokens);
     logger.warn(
       {
         event: "download.fallback_no_volumes_matched",
@@ -353,7 +363,7 @@ export async function runFallbackDownload(opts: {
       "no requested volume tokens are mapped in MangaDex aggregate",
     );
     throw new CliError(
-      `None of the requested volumes are mapped in MangaDex's aggregate for "${mangadexResolve.candidate.title}".\nAvailable mapped volumes: ${available.join(", ")}.\nUse --chapter <range> instead — MangaDex doesn't track this volume for this title (likely partner-published series).`,
+      `None of the requested volumes are mapped in MangaDex's aggregate for "${mangadexResolve.candidate.title}". Available mapped volumes: ${available.join(", ")}. Use --chapter <range> instead: MangaDex doesn't track this volume for this title (likely partner-published series).`,
       2,
     );
   }


### PR DESCRIPTION
## What this PR does

Adds a clear, actionable error when the user runs `scanldr download <title> --volume N` against a manga where MangaDex has partial aggregate metadata — some volumes mapped, but the specific requested volume not.

## Why it exists

Discovered while testing Dandadan vol 13 against the fallback trail merged in #59.

Scenario: Dandadan on MangaDex has `volumes: ["1", "none"]` in the EN aggregate (because it's served via MangaPlus, and MangaDex stopped mapping volumes past vol 1). Asking for `--volume 13`:

```
$ scanldr download "Dandadan" --volume 13
info: searching manga
info: manga resolved
info: MangaDex unavailable for "Dandadan" (reason: all_external); offering fallback
info: title resolved on fallback site
info: fetching page (chapter list from mangakakalot)
warn: volume 13 not found in MangaDex aggregate; skipping
[no .cbz produced, exit 0 silently]
```

No useful feedback. The user can't tell whether the request was a bug, downloaded somewhere else, or whether the title even exists.

## Why the gap existed

Two guards were already implemented in `runFallbackDownload`:

1. **MangaDex aggregate completely empty** (`volumes.length === 0`) → `CliError` "MangaDex doesn't know this title's volumes" + `--chapter` hint. ✅ Already shipped.
2. **Aggregate is partial** (some volumes mapped but not the one requested) → silent skip. ❌ This was the gap.

`buildFallbackBundles` iterates the requested tokens, logs a per-volume warn for each missing one, but never aborts. Result: empty bundles → empty processing loop → exit 0.

## How it works

Adds a third guard, **after** `buildFallbackBundles` returns and **before** the bundle processing loop:

```ts
if (args.volume !== undefined && bundles.length === 0 && mangadexResolve && mangadexResolve.volumes.length > 0) {
  // All requested volume tokens missed the MangaDex aggregate mapping
  logger.warn({ event: "download.fallback_no_volumes_matched", ..., requested, available }, ...);
  throw new CliError(
    `None of the requested volumes are mapped in MangaDex's aggregate for "${title}". Available mapped volumes: ${available.join(", ")}. Use --chapter <range> instead: MangaDex doesn't track this volume for this title (likely partner-published series).`,
    2,
  );
}
```

Predicate has 3 conditions, all required:
- `args.volume !== undefined` — only fires in volume mode (chapter mode doesn't involve volume mapping)
- `bundles.length === 0` — only when NO requested volume matched (mixed match still proceeds)
- `mangadexResolve.volumes.length > 0` — only when the aggregate has data (fully empty case is covered by the upstream guard)

`requested` and `available` are sorted numerically (with `"none"` always last) via the local `compareVolumeTokens` helper. Output reads `1, 2, 10, none` instead of lexicographic `1, 10, 2, none`.

## What did not change

- "MangaDex aggregate completely empty" case — pre-existing guard still fires first.
- Mixed-match (`--volume 1,13` where 1 is mapped and 13 is not) — keeps processing vol 1 with a per-volume `logger.warn` for 13. Does NOT trigger the new guard.
- `--chapter` mode — no volume mapping involved; untouched.
- MangaDex direct path (no fallback) — untouched.

## ACs satisfied

- [x] Volume mode + zero bundles after mapping + non-empty aggregate → `CliError` with title-specific message + `logger.warn` first
- [x] Mixed match (vol 1 mapped, vol 13 not) → vol 1 downloads, vol 13 only warns, exit 0 succeeds
- [x] Numeric-aware sort: vols `["1","2","10","none"]` render in that order
- [x] `CliError` message contains: title, mapped-volumes list, `--chapter` hint
- [x] Exit code 2 (consistent with other user-facing `CliError`s)

## Test checklist

- [x] Unit test: all-missing → `CliError` with expected message shape, `logger.warn` event matches
- [x] Unit test: mixed match → bundle processed, per-volume warn, no top-level error
- [x] `bun test` — 398 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Reviewer notes

- This is exactly the behavior the user described while testing: "if MangaDex has the volumes, look there for the mapping and then go to mangakakalot. If MangaDex doesn't have the mapping, warn the user so they can use a chapter range." This PR is the missing-mapping warning side of that flow.
- The error message points at `--chapter <range>` but does not auto-compute the range. Auto-computing would require an external source (AniList, Wikidata) or mangakakalot exposing volume info — neither is available in the current architecture. Worth a follow-up issue if/when valuable.
- `compareVolumeTokens` lives locally in `fallback.ts` for now. If volume-token sorting is needed elsewhere (e.g., the `list` command), it can be promoted to a shared helper. Currently single-use.

## Closes / Refs

No specific issue. Discovered during real-world testing of Dandadan vol 13 against PR #59. Can be linked from any future issue about fallback / volume-mapping UX.

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/` (not applicable — UX-only fix; doc updates tracked in #61)