### PR TITLE
chore(http): typed MangaDexHttpError to replace string-parsed status

### DIFF
--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { MangaDexHttpError } from "@integrations/mangadex/http/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { AtHomeError, getAtHomeServer, mangadexImageFetcher } from "./index.ts";
@@ -61,7 +62,10 @@ describe("getAtHomeServer", () => {
   it("throws AtHomeError with status 404 and external hint when http layer returns 404", async () => {
     const client = makeHttpClient({
       get: async () => {
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext",
+          404,
+        );
       },
     });
     const err = await getAtHomeServer(client, "ch-ext", "data").catch((e) => e);
@@ -74,7 +78,10 @@ describe("getAtHomeServer", () => {
   it("throws AtHomeError with correct status for non-404 HTTP errors", async () => {
     const client = makeHttpClient({
       get: async () => {
-        throw new Error("MangaDex HTTP 403: https://api.mangadex.org/at-home/server/ch-403");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 403: https://api.mangadex.org/at-home/server/ch-403",
+          403,
+        );
       },
     });
     const err = await getAtHomeServer(client, "ch-403", "data").catch((e) => e);
@@ -103,7 +110,10 @@ describe("getAtHomeServer", () => {
     };
     const client = makeHttpClient({
       get: async () => {
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext",
+          404,
+        );
       },
     });
     const err = await getAtHomeServer(client, "ch-ext", "data", spyLogger).catch((e) => e);
@@ -251,7 +261,10 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
             chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
           } as T;
         }
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del",
+          404,
+        );
       },
     });
 
@@ -323,7 +336,10 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
             chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
           } as T;
         }
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del",
+          404,
+        );
       },
     });
 

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -1,3 +1,4 @@
+import { MangaDexHttpError } from "@integrations/mangadex/http/index.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { AtHomeError } from "./types.ts";
@@ -36,13 +37,6 @@ function logRefreshFailed(logger: Logger, chapterId: string, attempt: number, er
   );
 }
 
-// Parse HTTP status from error messages like "MangaDex HTTP 404: <url>"
-function parseHttpStatus(err: unknown): number | null {
-  if (!(err instanceof Error)) return null;
-  const match = /^MangaDex HTTP (\d+):/.exec(err.message);
-  return match ? Number(match[1]) : null;
-}
-
 export async function getAtHomeServer(
   httpClient: AtHomeOptions["httpClient"],
   chapterId: string,
@@ -57,8 +51,8 @@ export async function getAtHomeServer(
       pages: quality === "data" ? res.chapter.data : res.chapter.dataSaver,
     };
   } catch (err) {
-    const status = parseHttpStatus(err);
-    if (status !== null) {
+    if (err instanceof MangaDexHttpError) {
+      const { status } = err;
       const msg =
         status === 404
           ? `at-home server returned 404 for chapter ${chapterId}. Likely an externally-hosted chapter (MangaPlus / Comikey / Cubari). Check chapter.externalUrl in the feed.`

--- a/src/integrations/mangadex/http/index.ts
+++ b/src/integrations/mangadex/http/index.ts
@@ -49,7 +49,7 @@ export function createMangaDexHttp(opts: MangaDexHttpOptions): MangaDexHttpClien
           "429 rate-limited, backing off",
         );
         await sleep(waitMs);
-        lastError = new Error(`HTTP 429 after ${attempt + 1} attempt(s)`);
+        lastError = new MangaDexHttpError(`HTTP 429 after ${attempt + 1} attempt(s)`, 429);
         continue;
       }
 
@@ -66,7 +66,10 @@ export function createMangaDexHttp(opts: MangaDexHttpOptions): MangaDexHttpClien
           "5xx error, retrying",
         );
         await sleep(waitMs);
-        lastError = new Error(`HTTP ${response.status} after ${attempt + 1} attempt(s)`);
+        lastError = new MangaDexHttpError(
+          `HTTP ${response.status} after ${attempt + 1} attempt(s)`,
+          response.status,
+        );
         continue;
       }
 

--- a/src/integrations/mangadex/http/index.ts
+++ b/src/integrations/mangadex/http/index.ts
@@ -1,7 +1,9 @@
 import { acquire, createBucket } from "./bucket.ts";
 import { backoffMs, buildUrl, retryAfterMs } from "./request.ts";
+import { MangaDexHttpError } from "./types.ts";
 import type { FetchFn, MangaDexHttpClient, MangaDexHttpOptions, QueryParams } from "./types.ts";
 
+export { MangaDexHttpError } from "./types.ts";
 export type { FetchFn, MangaDexHttpClient, MangaDexHttpOptions, QueryParams } from "./types.ts";
 
 const BASE_URL = "https://api.mangadex.org";
@@ -68,7 +70,7 @@ export function createMangaDexHttp(opts: MangaDexHttpOptions): MangaDexHttpClien
         continue;
       }
 
-      throw new Error(`MangaDex HTTP ${response.status}: ${url}`);
+      throw new MangaDexHttpError(`MangaDex HTTP ${response.status}: ${url}`, response.status);
     }
 
     throw lastError ?? new Error(`MangaDex request failed after ${MAX_RETRIES} attempts: ${url}`);

--- a/src/integrations/mangadex/http/mangadex-http.test.ts
+++ b/src/integrations/mangadex/http/mangadex-http.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
+import { MangaDexHttpError, createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
 import type { FetchFn } from "@integrations/mangadex/http/index.ts";
 import type { Config } from "@plugins/config/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
@@ -182,7 +182,10 @@ describe("MangaDexHttp.get", () => {
       fetch: statusFetch(503),
     });
 
-    await expect(client.get("/manga")).rejects.toThrow("HTTP 503");
+    const err = await client.get("/manga").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).status).toBe(503);
+    expect((err as MangaDexHttpError).message).toContain("HTTP 503");
     expect(sleep.calls.length).toBe(5);
   });
 
@@ -195,8 +198,41 @@ describe("MangaDexHttp.get", () => {
       fetch: statusFetch(404),
     });
 
-    await expect(client.get("/not-found")).rejects.toThrow("HTTP 404");
+    const err = await client.get("/not-found").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).status).toBe(404);
+    expect((err as MangaDexHttpError).message).toContain("HTTP 404");
     expect(sleep.calls.length).toBe(0);
+  });
+
+  test("throws MangaDexHttpError after 429 retries are exhausted", async () => {
+    const sleep = makeSleep();
+    const client = createMangaDexHttp({
+      logger: noopLogger,
+      config: baseConfig,
+      sleep: sleep.fn,
+      fetch: statusFetch(429),
+    });
+
+    const err = await client.get("/manga").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).status).toBe(429);
+    expect((err as MangaDexHttpError).message).toContain("HTTP 429");
+  });
+
+  test("throws MangaDexHttpError after 5xx retries are exhausted", async () => {
+    const sleep = makeSleep();
+    const client = createMangaDexHttp({
+      logger: noopLogger,
+      config: baseConfig,
+      sleep: sleep.fn,
+      fetch: statusFetch(503),
+    });
+
+    const err = await client.get("/manga").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).status).toBe(503);
+    expect((err as MangaDexHttpError).message).toContain("HTTP 503");
   });
 
   test("query params — appended to URL", async () => {

--- a/src/integrations/mangadex/http/request.test.ts
+++ b/src/integrations/mangadex/http/request.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { MangaDexHttpError, createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
+import type { Config } from "@plugins/config/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+
+const noop = (_f: Record<string, unknown>, _m: string) => {};
+const noopLogger: Logger = { error: noop, warn: noop, info: noop };
+const baseConfig: Config = {
+  preferred_languages: ["en"],
+  download_quality: "data",
+  default_format: "cbz",
+  default_out: "./download",
+  db_path: "./scanldr.db",
+  image_concurrency: 4,
+  chapter_delay_ms: 100,
+};
+
+describe("MangaDexHttpError", () => {
+  test("instanceof Error and instanceof MangaDexHttpError both true", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+  });
+
+  test("status field holds numeric status code", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err.status).toBe(404);
+  });
+
+  test("name is MangaDexHttpError", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err.name).toBe("MangaDexHttpError");
+  });
+
+  test("optional body field", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 422: /foo", 422, "validation failed");
+    expect(err.body).toBe("validation failed");
+  });
+
+  test("body is undefined when not provided", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err.body).toBeUndefined();
+  });
+});
+
+describe("createMangaDexHttp — MangaDexHttpError on 4xx", () => {
+  test("fetch returning 404 throws MangaDexHttpError with status 404", async () => {
+    const client = createMangaDexHttp({
+      logger: noopLogger,
+      config: baseConfig,
+      fetch: async () => new Response(null, { status: 404 }),
+    });
+
+    const err = await client.get("/not-found").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).status).toBe(404);
+  });
+
+  test("error message preserves MangaDex HTTP <status>: <url> format", async () => {
+    const client = createMangaDexHttp({
+      logger: noopLogger,
+      config: baseConfig,
+      fetch: async () => new Response(null, { status: 403 }),
+    });
+
+    const err = await client.get("/forbidden").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).message).toMatch(/^MangaDex HTTP 403:/);
+  });
+});

--- a/src/integrations/mangadex/http/types.ts
+++ b/src/integrations/mangadex/http/types.ts
@@ -1,6 +1,17 @@
 import type { Config } from "@plugins/config/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 
+export class MangaDexHttpError extends Error {
+  override readonly name = "MangaDexHttpError";
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body?: string,
+  ) {
+    super(message);
+  }
+}
+
 export type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 export interface MangaDexHttpOptions {


### PR DESCRIPTION
## What this PR does

Replaces the brittle string-parsed HTTP status detection (`parseHttpStatus` regex on `"MangaDex HTTP 404:"` messages) with a typed `MangaDexHttpError extends Error` carrying a numeric `.status` field. Consumers branch on `instanceof MangaDexHttpError` instead of regex parsing.

Throw sites converted in `src/integrations/mangadex/http/index.ts`:
- Immediate 4xx (line ~76)
- 429 retry-exhaustion (line ~52)
- 5xx retry-exhaustion (line ~69)

Consumer refactored: `src/integrations/mangadex/at-home/index.ts` no longer string-parses; uses `err instanceof MangaDexHttpError` + `.status`.

## Why it exists

`parseHttpStatus` did `String(err.message).match(/MangaDex HTTP (\d+)/)`. Any change to the error message format silently broke status detection — exactly the kind of fragility that bites only in production. With a typed class, the contract is enforced by the compiler.

Closes #51 (deferred follow-up from PR #50).

## How it works internally

- **`MangaDexHttpError`** lives in `src/integrations/mangadex/http/types.ts`. Convention exception: `Error` subclasses are explicitly allowed per `docs/conventions.md`. The class has `status: number`, optional `body?: string`, `override readonly name = "MangaDexHttpError"`, and trivial body — just `super(message)` and field assignment.
- **Re-exported** from `src/integrations/mangadex/http/index.ts` so callers import via `@integrations/mangadex/http`.
- **Network errors** (fetch reject, ECONNRESET, etc.) deliberately bubble unwrapped — they are not `MangaDexHttpError`. The retry loop captures them in `lastError` and re-throws unchanged when retries are exhausted.
- **Message format** preserved (`MangaDex HTTP <status>: <url>`) so existing log scrapers keep working — only the typed branch changes.

## What did not change

- Retry / backoff timing — untouched.
- HTTP client public surface — only adds the `MangaDexHttpError` export.
- `at-home` external behavior — same return values for 404/403, just sourced from the typed branch.
- Other consumers (`mangadex/client/`) — already used the message string in non-branching ways; no refactor needed.
- mangakakalot HTTP — separate stack, untouched.

## Test checklist

- [x] `bun test` — 451 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — biome clean
- [x] `MangaDexHttpError` invariants tested: `instanceof Error`, `instanceof MangaDexHttpError`, `.name === "MangaDexHttpError"`, `.status` is numeric
- [x] Status code parity: 404, 403, 429 (retry-exhausted), 5xx (retry-exhausted) all produce typed errors with the right `.status`
- [x] Network errors bubble unwrapped (NOT typed)
- [x] `grep -rn "parseHttpStatus" src/` returns zero matches
- [x] `grep -rn 'new Error("MangaDex HTTP' src/` returns zero matches outside test fixtures
- [x] Existing tests hardened to assert type, not just message string

## Reviewer notes

- The `at-home/index.ts:150` image fetcher (CDN) still throws plain `new Error("HTTP ...")`. That's a separate path (image bytes from at-home server, not the MangaDex API). Out of scope for this issue — open a follow-up if relevant.
- The fallback throw at `http/index.ts:79` (`new Error("MangaDex request failed after ${MAX_RETRIES} attempts")`) is unreachable today (every retry path assigns `lastError`). Could be tightened to `assert` but harmless as-is.
- Two error-message shapes coexist: `"MangaDex HTTP <status>: <url>"` (immediate) vs `"HTTP <status> after N attempt(s)"` (retry-exhausted). Consumers using `.message` may see both. Trivial unification skipped to keep this PR focused.

## Closes

Closes #51

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions (Error subclass exception per docs/conventions.md, type in `types.ts`, factory functions, logger signature)
- [x] No new dependencies