### PR TITLE
fix(pack): prompt UX — invisible prompt text + volume-number input

### DIFF
--- a/docs/auth-manual.md
+++ b/docs/auth-manual.md
@@ -17,7 +17,7 @@ Playwright-based automation is detected by Cloudflare and the challenge never re
    - Firefox: `F12`
    - Safari: `Cmd+Option+I` (enable DevTools in Safari Preferences first)
 
-4. Go to the **Network** tab. Reload the page (`F5` / `Cmd+R`).
+4. Go to the **Network** tab (if you see "Paused in debugger", see [Troubleshooting](#troubleshooting) below). Reload the page (`F5` / `Cmd+R`).
 
 5. In the Network panel, find the request to `/search/story/dragon-ball`. Right-click it:
    - Chrome/Edge: **Copy → Copy as cURL (bash)**
@@ -50,6 +50,24 @@ scanldr auth < curl.txt
 > **Note:** Interactive paste (typing or pasting directly into the terminal while `scanldr auth` waits) is intentionally rejected. Multi-line cURL output is silently truncated by macOS Terminal and iTerm2 when pasted into stdin, which leads to confusing parse errors. Piping is the only reliable approach.
 
 ## Troubleshooting
+
+### "Paused in debugger" banner appears when opening DevTools
+
+**Symptom:** As soon as DevTools opens (or on page reload with DevTools open), the browser freezes with a "Paused in debugger" banner at the top. The Network tab is unusable.
+
+**Cause:** mangakakalot.gg injects a `debugger;` statement inside a loop as an anti-inspection measure. Every modern browser honoured the statement when DevTools is attached, freezing execution.
+
+**Fix:**
+
+1. Open DevTools → **Sources** tab.
+2. Click the "Deactivate breakpoints" icon at the top of the right panel (shortcut `Cmd+F8` on Mac, `Ctrl+F8` on Linux/Windows).
+3. Click ▶ "Resume script execution" to leave the current pause.
+4. Reload the page (`Cmd+R` / `Ctrl+R`) — `debugger;` calls are now ignored.
+5. Continue with the normal **Network** tab → **Copy as cURL** flow.
+
+![Deactivate breakpoints button](./images/devtools-deactivate-breakpoints.png) <!-- TODO: capture -->
+
+### Common errors
 
 | Error | Fix |
 |---|---|

--- a/src/commands/download/pack-flow.ts
+++ b/src/commands/download/pack-flow.ts
@@ -24,26 +24,24 @@ export async function runPackFlow(opts: {
 
   const stem = customName ?? defaultVolumeName(slug, successPaths);
   const finalName = stem.endsWith(".cbz") ? stem : `${stem}.cbz`;
-  const targetPath = join(args.outDir, slug, finalName);
 
   // Extract the portion after "<slug>-volume-" to use as the hint in the prompt.
   // e.g. stem = "dandadan-volume-103-111" → hint = "103-111"
   const volumePrefix = `${slug}-volume-`;
   const defaultVolumeStem = stem.startsWith(volumePrefix) ? stem.slice(volumePrefix.length) : stem;
 
-  let fileExists = false;
-  try {
-    await access(targetPath);
-    fileExists = true;
-  } catch {
-    fileExists = false;
-  }
-
   const { shouldPack, shouldDelete, volumeName } = await runPackPrompts({
     chapterCount: successPaths.length,
     outputName: finalName,
     defaultVolumeStem,
-    fileExists,
+    checkExists: async (filename: string) => {
+      try {
+        await access(join(args.outDir, slug, filename));
+        return true;
+      } catch {
+        return false;
+      }
+    },
     nonTty: args.nonTty,
     packFlag,
     packNameProvided,

--- a/src/commands/download/pack-flow.ts
+++ b/src/commands/download/pack-flow.ts
@@ -20,10 +20,16 @@ export async function runPackFlow(opts: {
   // --pack-replace implies --pack
   const packFlag = args.packReplace || args.pack !== undefined;
   const customName = typeof args.pack === "string" && args.pack !== "" ? args.pack : undefined;
+  const packNameProvided = customName !== undefined;
 
   const stem = customName ?? defaultVolumeName(slug, successPaths);
   const finalName = stem.endsWith(".cbz") ? stem : `${stem}.cbz`;
   const targetPath = join(args.outDir, slug, finalName);
+
+  // Extract the portion after "<slug>-volume-" to use as the hint in the prompt.
+  // e.g. stem = "dandadan-volume-103-111" → hint = "103-111"
+  const volumePrefix = `${slug}-volume-`;
+  const defaultVolumeStem = stem.startsWith(volumePrefix) ? stem.slice(volumePrefix.length) : stem;
 
   let fileExists = false;
   try {
@@ -33,12 +39,14 @@ export async function runPackFlow(opts: {
     fileExists = false;
   }
 
-  const { shouldPack, shouldDelete } = await runPackPrompts({
+  const { shouldPack, shouldDelete, volumeName } = await runPackPrompts({
     chapterCount: successPaths.length,
     outputName: finalName,
+    defaultVolumeStem,
     fileExists,
     nonTty: args.nonTty,
     packFlag,
+    packNameProvided,
     packReplace: args.packReplace,
     packOverwrite: args.packOverwrite,
     logger,
@@ -46,11 +54,14 @@ export async function runPackFlow(opts: {
 
   if (!shouldPack) return;
 
+  // Resolve the effective custom name: user-entered volume name takes precedence
+  const resolvedCustomName = volumeName !== undefined ? volumeName : customName;
+
   const result = await packVolume({
     slug,
     outDir: args.outDir,
     chapters: successPaths,
-    customName,
+    customName: resolvedCustomName,
     logger,
   });
 

--- a/src/commands/download/pack.test.ts
+++ b/src/commands/download/pack.test.ts
@@ -180,9 +180,11 @@ describe("packVolume", () => {
 describe("runPackPrompts", () => {
   const baseOpts = {
     outputName: "dandadan-volume-103-111.cbz",
+    defaultVolumeStem: "103-111",
     fileExists: false,
     nonTty: false,
     packFlag: false,
+    packNameProvided: false,
     packReplace: false,
     packOverwrite: false,
     logger,

--- a/src/commands/download/pack.test.ts
+++ b/src/commands/download/pack.test.ts
@@ -181,7 +181,7 @@ describe("runPackPrompts", () => {
   const baseOpts = {
     outputName: "dandadan-volume-103-111.cbz",
     defaultVolumeStem: "103-111",
-    fileExists: false,
+    checkExists: async () => false,
     nonTty: false,
     packFlag: false,
     packNameProvided: false,
@@ -232,7 +232,7 @@ describe("runPackPrompts", () => {
         chapterCount: 5,
         nonTty: true,
         packFlag: true,
-        fileExists: true,
+        checkExists: async () => true,
         packOverwrite: false,
       }),
     ).rejects.toThrow(/already exists/i);
@@ -244,7 +244,7 @@ describe("runPackPrompts", () => {
       chapterCount: 5,
       nonTty: true,
       packFlag: true,
-      fileExists: true,
+      checkExists: async () => true,
       packOverwrite: true,
     });
     expect(result.shouldPack).toBe(true);

--- a/src/commands/download/prompt-pack.test.ts
+++ b/src/commands/download/prompt-pack.test.ts
@@ -23,7 +23,7 @@ function restoreStderr() {
 const baseOpts = {
   outputName: "dandadan-volume-103-111.cbz",
   defaultVolumeStem: "103-111",
-  fileExists: false,
+  checkExists: async () => false,
   nonTty: false,
   packFlag: false,
   packNameProvided: false,
@@ -354,5 +354,83 @@ describe("runPackPrompts — volume-number prompt is skipped when", () => {
 
     expect(callCount).toBe(0);
     expect(result.shouldPack).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0 regression: existence check must happen AFTER effective name is resolved
+// ---------------------------------------------------------------------------
+
+describe("runPackPrompts — overwrite check against effective (post-prompt) filename", () => {
+  afterEach(() => {
+    restoreStderr();
+    mock.restore();
+  });
+
+  test("prompts overwrite when custom volume name collides even if default name does not exist", async () => {
+    // dandadan-volume-13.cbz exists, dandadan-volume-103-111.cbz does not
+    let overwritePromptShown = false;
+    let callCount = 0;
+
+    captureStderr();
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");   // Pack?
+          else if (callCount === 2) cb("13"); // Volume number → collides
+          else if (callCount === 3) {
+            overwritePromptShown = true;
+            cb("y"); // Overwrite?
+          } else cb("n"); // Delete?
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      // Default name does NOT exist; only "13.cbz" exists
+      checkExists: async (filename: string) => filename === "13.cbz",
+    });
+
+    expect(overwritePromptShown).toBe(true);
+    expect(result.shouldPack).toBe(true);
+    expect(result.volumeName).toBe("13");
+  });
+
+  test("does not prompt overwrite when neither default nor custom name exists", async () => {
+    let overwritePromptShown = false;
+    let callCount = 0;
+
+    captureStderr();
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");   // Pack?
+          else if (callCount === 2) cb("13"); // Volume number
+          else if (callCount === 3) {
+            // Should be Delete? not Overwrite?
+            overwritePromptShown = stderrOutput.join("").includes("Overwrite");
+            cb("n"); // Delete?
+          }
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      checkExists: async () => false, // nothing exists
+    });
+
+    expect(overwritePromptShown).toBe(false);
+    expect(result.shouldPack).toBe(true);
+    expect(result.volumeName).toBe("13");
   });
 });

--- a/src/commands/download/prompt-pack.test.ts
+++ b/src/commands/download/prompt-pack.test.ts
@@ -1,0 +1,358 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Logger } from "@plugins/logger/index.ts";
+
+const noopLogger: Logger = { info: () => {}, warn: () => {}, error: () => {} };
+
+// Capture stderr output for assertions
+let stderrOutput: string[] = [];
+let originalStderrWrite: typeof process.stderr.write;
+
+function captureStderr() {
+  stderrOutput = [];
+  originalStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk: string | Uint8Array, ..._args: unknown[]) => {
+    stderrOutput.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+    return true;
+  };
+}
+
+function restoreStderr() {
+  process.stderr.write = originalStderrWrite;
+}
+
+const baseOpts = {
+  outputName: "dandadan-volume-103-111.cbz",
+  defaultVolumeStem: "103-111",
+  fileExists: false,
+  nonTty: false,
+  packFlag: false,
+  packNameProvided: false,
+  packReplace: false,
+  packOverwrite: false,
+  chapterCount: 9,
+  logger: noopLogger,
+};
+
+// ---------------------------------------------------------------------------
+// Prompt visibility — prompts always written to stderr before readline reads
+// ---------------------------------------------------------------------------
+
+describe("runPackPrompts — prompt text written to stderr before readline", () => {
+  beforeEach(captureStderr);
+  afterEach(() => {
+    restoreStderr();
+    mock.restore();
+  });
+
+  test("Pack N chapters prompt appears on stderr before answer is read", async () => {
+    let stderrAtCallTime: string[] = [];
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          // Capture what's been written to stderr so far, then answer
+          stderrAtCallTime = [...stderrOutput];
+          cb("n");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    await runPackPrompts({ ...baseOpts });
+
+    // The pack prompt text must have been written to stderr before readline fired
+    expect(stderrAtCallTime.join("")).toMatch(/Pack 9 chapters/);
+  });
+
+  test("Delete individual files prompt appears on stderr before answer is read", async () => {
+    let stderrWhenDeletePrompted: string[] = [];
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) {
+            // First call: "Pack?" → yes
+            cb("y");
+          } else if (callCount === 2) {
+            // Second call: "Volume number?" → blank
+            cb("");
+          } else {
+            // Third call: "Delete?" → capture then answer
+            stderrWhenDeletePrompted = [...stderrOutput];
+            cb("n");
+          }
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    await runPackPrompts({ ...baseOpts });
+
+    expect(stderrWhenDeletePrompted.join("")).toMatch(/Delete individual chapter files/);
+  });
+
+  test("Volume number prompt appears on stderr before answer is read", async () => {
+    let stderrWhenVolumePrompted: string[] = [];
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) {
+            // "Pack?" → yes
+            cb("y");
+          } else if (callCount === 2) {
+            // "Volume number?" → capture stderr first then answer
+            stderrWhenVolumePrompted = [...stderrOutput];
+            cb("");
+          } else {
+            cb("n");
+          }
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    await runPackPrompts({ ...baseOpts });
+
+    expect(stderrWhenVolumePrompted.join("")).toMatch(/Volume number/);
+    expect(stderrWhenVolumePrompted.join("")).toMatch(/103-111/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Volume-number prompt — happy paths
+// ---------------------------------------------------------------------------
+
+describe("runPackPrompts — volume-number prompt", () => {
+  afterEach(() => mock.restore());
+
+  test("AC5: user accepts pack and is prompted for volume number in interactive TTY mode", async () => {
+    let volumePromptShown = false;
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");        // Pack?
+          else if (callCount === 2) {
+            volumePromptShown = true;
+            cb("");                             // Volume number (blank)
+          } else cb("n");                       // Delete?
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({ ...baseOpts });
+
+    expect(result.shouldPack).toBe(true);
+    expect(volumePromptShown).toBe(true);
+  });
+
+  test("AC6: blank volume input → volumeName is undefined (default)", async () => {
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");
+          else if (callCount === 2) cb("");     // blank
+          else cb("n");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({ ...baseOpts });
+
+    expect(result.volumeName).toBeUndefined();
+  });
+
+  test("AC7: non-empty input → volumeName equals input", async () => {
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");
+          else if (callCount === 2) cb("13");  // volume number
+          else cb("n");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({ ...baseOpts });
+
+    expect(result.volumeName).toBe("13");
+  });
+
+  test("AC8: accepts alphanumeric, dash, underscore, dot, spaces (e.g. 13-final)", async () => {
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");
+          else if (callCount === 2) cb("13-final special_1.0");
+          else cb("n");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({ ...baseOpts });
+
+    expect(result.volumeName).toBe("13-final special_1.0");
+  });
+
+  test("AC9: rejects slash, re-prompts, then accepts valid input on second try", async () => {
+    let callCount = 0;
+    let stderrBuf = "";
+    captureStderr();
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          if (callCount === 1) cb("y");
+          else if (callCount === 2) cb("../../evil");  // invalid
+          else if (callCount === 3) cb("13");          // valid on retry
+          else cb("n");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({ ...baseOpts });
+    stderrBuf = stderrOutput.join("");
+    restoreStderr();
+
+    expect(result.volumeName).toBe("13");
+    expect(stderrBuf).toMatch(/Invalid volume name/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Volume-number prompt — skip conditions (AC10)
+// ---------------------------------------------------------------------------
+
+describe("runPackPrompts — volume-number prompt is skipped when", () => {
+  afterEach(() => mock.restore());
+
+  test("AC10a: --pack <name> was passed (packNameProvided=true)", async () => {
+    let callCount = 0;
+    const callArgs: number[] = [];
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          callArgs.push(callCount);
+          if (callCount === 1) cb("y");   // Pack?
+          else cb("n");                   // Delete? (no volume number prompt in between)
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      packNameProvided: true,
+      packFlag: true,
+    });
+
+    // packFlag=true means pack is decided via flag (no pack prompt), only delete prompt fires
+    expect(callCount).toBe(1);
+    expect(result.volumeName).toBeUndefined();
+  });
+
+  test("AC10b: --pack-replace was passed (non-interactive delete path)", async () => {
+    // packReplace means shouldDelete=true without prompt, and no volume-number prompt
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          cb("y"); // only "Pack?" prompt
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      packFlag: true,
+      packReplace: true,
+    });
+
+    // pack is set via flag, so no pack prompt is shown; packReplace skips volume prompt
+    expect(callCount).toBe(0);
+    expect(result.shouldPack).toBe(true);
+    expect(result.shouldDelete).toBe(true);
+    expect(result.volumeName).toBeUndefined();
+  });
+
+  test("AC10c: non-TTY mode (nonTty=true) with packFlag", async () => {
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          cb("y");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: true,
+      packFlag: true,
+    });
+
+    expect(callCount).toBe(0);
+    expect(result.volumeName).toBeUndefined();
+  });
+
+  test("AC10d: N == 1 → whole pack flow skipped (no prompts at all)", async () => {
+    let callCount = 0;
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          callCount++;
+          cb("y");
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({ ...baseOpts, chapterCount: 1 });
+
+    expect(callCount).toBe(0);
+    expect(result.shouldPack).toBe(false);
+  });
+});

--- a/src/commands/download/prompt-pack.ts
+++ b/src/commands/download/prompt-pack.ts
@@ -3,6 +3,9 @@ import type { PackPromptOptions, PackPromptResult } from "./types.ts";
 
 export type { PackPromptOptions, PackPromptResult };
 
+// All prompts write to stderr so they are never interleaved with pino's stdout
+// logs (pino writes to stdout; stderr is flushed independently by the kernel).
+
 /**
  * Ask a yes/no question on stderr.
  * Returns true for 'y' / 'Y', false for everything else (empty = default No).
@@ -10,6 +13,8 @@ export type { PackPromptOptions, PackPromptResult };
 function promptYesNo(question: string): Promise<boolean> {
   return new Promise((resolve) => {
     const rl = createInterface({ input: process.stdin, output: process.stderr });
+    // Write prompt text to stderr before readline reads a line so the question
+    // always appears before the cursor — no dependency on pino flush timing.
     process.stderr.write(question);
     rl.once("line", (line) => {
       rl.close();
@@ -18,19 +23,59 @@ function promptYesNo(question: string): Promise<boolean> {
   });
 }
 
+/** Path-traversal guard: same rules as --pack <name> in pack.ts. */
+function isUnsafeVolumeName(input: string): boolean {
+  return (
+    input.includes("/") ||
+    input.includes("\\") ||
+    input.split(/[\\/]/).some((s) => s === "..")
+  );
+}
+
+/**
+ * Ask for a volume number/name stem.
+ * Re-prompts on unsafe input.
+ * Returns the sanitised input, or undefined if the user left it blank (→ default).
+ */
+async function promptVolumeName(hint: string): Promise<string | undefined> {
+  while (true) {
+    const answer = await new Promise<string>((resolve) => {
+      const rl = createInterface({ input: process.stdin, output: process.stderr });
+      process.stderr.write(`Volume number (leave blank for "${hint}"): `);
+      rl.once("line", (line) => {
+        rl.close();
+        resolve(line.trim());
+      });
+    });
+
+    if (answer === "") return undefined;
+
+    if (isUnsafeVolumeName(answer)) {
+      process.stderr.write(
+        `Invalid volume name — cannot contain '/', '\\' or '..' segments. Try again.\n`,
+      );
+      continue;
+    }
+
+    return answer;
+  }
+}
+
 /**
  * Orchestrates the two-step pack prompt (or non-interactive flag path).
  *
- * Returns { shouldPack, shouldDelete }.
+ * Returns { shouldPack, shouldDelete, volumeName }.
  * Throws CliError when the target file exists in non-interactive mode and --pack-overwrite was not passed.
  */
 export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromptResult> {
   const {
     chapterCount,
     outputName,
+    defaultVolumeStem,
     fileExists,
     nonTty,
     packFlag,
+    packNameProvided,
     packReplace,
     packOverwrite,
     logger,
@@ -73,17 +118,37 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
     return { shouldPack: false, shouldDelete: false };
   }
 
-  // Check for existing file
+  // Volume-number prompt: only in interactive TTY mode when no explicit name was provided
+  let volumeName: string | undefined;
+  const askVolumeNumber = !nonTty && !packNameProvided && !packReplace;
+  if (askVolumeNumber) {
+    const input = await promptVolumeName(defaultVolumeStem);
+    if (input !== undefined) {
+      volumeName = input;
+    }
+  }
+
+  // Re-derive the effective output name if the user chose a custom volume number
+  const effectiveOutputName =
+    volumeName !== undefined
+      ? volumeName.endsWith(".cbz")
+        ? volumeName
+        : `${volumeName}.cbz`
+      : outputName;
+
+  // Check for existing file (using effectiveOutputName)
   if (fileExists) {
     if (nonTty && !packOverwrite) {
       const { CliError } = await import("@plugins/errors/index.ts");
       throw new CliError(
-        `${outputName} already exists; pass --pack-overwrite or remove the file`,
+        `${effectiveOutputName} already exists; pass --pack-overwrite or remove the file`,
         1,
       );
     }
     if (!nonTty && !packOverwrite) {
-      const overwrite = await promptYesNo(`${outputName} already exists. Overwrite? [y/N] `);
+      const overwrite = await promptYesNo(
+        `${effectiveOutputName} already exists. Overwrite? [y/N] `,
+      );
       if (!overwrite) {
         logger.info(
           { event: "pack.skipped", context: "pack", reason: "overwrite_declined" },
@@ -109,5 +174,5 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
     shouldDelete = await promptYesNo("Delete individual chapter files? [y/N] ");
   }
 
-  return { shouldPack: true, shouldDelete };
+  return { shouldPack: true, shouldDelete, volumeName };
 }

--- a/src/commands/download/prompt-pack.ts
+++ b/src/commands/download/prompt-pack.ts
@@ -1,4 +1,5 @@
 import { createInterface } from "node:readline";
+import { CliError } from "@plugins/errors/index.ts";
 import type { PackPromptOptions, PackPromptResult } from "./types.ts";
 
 export type { PackPromptOptions, PackPromptResult };
@@ -72,7 +73,7 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
     chapterCount,
     outputName,
     defaultVolumeStem,
-    fileExists,
+    checkExists,
     nonTty,
     packFlag,
     packNameProvided,
@@ -136,10 +137,10 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
         : `${volumeName}.cbz`
       : outputName;
 
-  // Check for existing file (using effectiveOutputName)
+  // Check for existing file against the *effective* path (post-name-prompt) to avoid silent overwrites.
+  const fileExists = await checkExists(effectiveOutputName);
   if (fileExists) {
     if (nonTty && !packOverwrite) {
-      const { CliError } = await import("@plugins/errors/index.ts");
       throw new CliError(
         `${effectiveOutputName} already exists; pass --pack-overwrite or remove the file`,
         1,

--- a/src/commands/download/types.ts
+++ b/src/commands/download/types.ts
@@ -64,8 +64,12 @@ export interface PackPromptOptions {
   outputName: string;
   /** Default volume stem without manga slug prefix (e.g. "103-111") — shown in the volume-number prompt hint. */
   defaultVolumeStem: string;
-  /** true if the target file already exists */
-  fileExists: boolean;
+  /**
+   * Called with the *effective* output filename (after volume-number prompt) to check for
+   * an existing file. Returns true when the file exists. Called after all name prompts resolve
+   * so the check is always against the actual path that will be written.
+   */
+  checkExists: (filename: string) => Promise<boolean>;
   nonTty: boolean;
   /** --pack flag (boolean form — pack with default name, keep individuals) */
   packFlag: boolean;

--- a/src/commands/download/types.ts
+++ b/src/commands/download/types.ts
@@ -54,16 +54,23 @@ export interface PackVolumeResult {
 export interface PackPromptResult {
   shouldPack: boolean;
   shouldDelete: boolean;
+  /** Volume name stem chosen by the user (may differ from the default). Undefined when pack was skipped. */
+  volumeName?: string;
 }
 
 export interface PackPromptOptions {
   chapterCount: number;
+  /** Default output filename stem (e.g. "dandadan-volume-103-111") — shown as the leave-blank hint. */
   outputName: string;
+  /** Default volume stem without manga slug prefix (e.g. "103-111") — shown in the volume-number prompt hint. */
+  defaultVolumeStem: string;
   /** true if the target file already exists */
   fileExists: boolean;
   nonTty: boolean;
   /** --pack flag (boolean form — pack with default name, keep individuals) */
   packFlag: boolean;
+  /** true when --pack <name> was supplied (skip volume-number prompt) */
+  packNameProvided: boolean;
   /** --pack-replace flag (pack + delete individuals) */
   packReplace: boolean;
   /** --pack-overwrite flag (overwrite if exists) */

--- a/src/integrations/mangadex/at-home/at-home.test.ts
+++ b/src/integrations/mangadex/at-home/at-home.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { MangaDexHttpError } from "@integrations/mangadex/http/index.ts";
 import type { MangaDexHttpClient } from "@integrations/mangadex/http/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { AtHomeError, getAtHomeServer, mangadexImageFetcher } from "./index.ts";
@@ -61,7 +62,10 @@ describe("getAtHomeServer", () => {
   it("throws AtHomeError with status 404 and external hint when http layer returns 404", async () => {
     const client = makeHttpClient({
       get: async () => {
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext",
+          404,
+        );
       },
     });
     const err = await getAtHomeServer(client, "ch-ext", "data").catch((e) => e);
@@ -74,7 +78,10 @@ describe("getAtHomeServer", () => {
   it("throws AtHomeError with correct status for non-404 HTTP errors", async () => {
     const client = makeHttpClient({
       get: async () => {
-        throw new Error("MangaDex HTTP 403: https://api.mangadex.org/at-home/server/ch-403");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 403: https://api.mangadex.org/at-home/server/ch-403",
+          403,
+        );
       },
     });
     const err = await getAtHomeServer(client, "ch-403", "data").catch((e) => e);
@@ -103,7 +110,10 @@ describe("getAtHomeServer", () => {
     };
     const client = makeHttpClient({
       get: async () => {
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-ext",
+          404,
+        );
       },
     });
     const err = await getAtHomeServer(client, "ch-ext", "data", spyLogger).catch((e) => e);
@@ -251,7 +261,10 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
             chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
           } as T;
         }
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del",
+          404,
+        );
       },
     });
 
@@ -323,7 +336,10 @@ describe("mangadexImageFetcher — refresh failure during retry", () => {
             chapter: { hash: "abc123", data: ["page1.jpg"], dataSaver: [] },
           } as T;
         }
-        throw new Error("MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del");
+        throw new MangaDexHttpError(
+          "MangaDex HTTP 404: https://api.mangadex.org/at-home/server/ch-del",
+          404,
+        );
       },
     });
 

--- a/src/integrations/mangadex/at-home/index.ts
+++ b/src/integrations/mangadex/at-home/index.ts
@@ -1,3 +1,4 @@
+import { MangaDexHttpError } from "@integrations/mangadex/http/index.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { AtHomeError } from "./types.ts";
@@ -36,13 +37,6 @@ function logRefreshFailed(logger: Logger, chapterId: string, attempt: number, er
   );
 }
 
-// Parse HTTP status from error messages like "MangaDex HTTP 404: <url>"
-function parseHttpStatus(err: unknown): number | null {
-  if (!(err instanceof Error)) return null;
-  const match = /^MangaDex HTTP (\d+):/.exec(err.message);
-  return match ? Number(match[1]) : null;
-}
-
 export async function getAtHomeServer(
   httpClient: AtHomeOptions["httpClient"],
   chapterId: string,
@@ -57,8 +51,8 @@ export async function getAtHomeServer(
       pages: quality === "data" ? res.chapter.data : res.chapter.dataSaver,
     };
   } catch (err) {
-    const status = parseHttpStatus(err);
-    if (status !== null) {
+    if (err instanceof MangaDexHttpError) {
+      const { status } = err;
       const msg =
         status === 404
           ? `at-home server returned 404 for chapter ${chapterId}. Likely an externally-hosted chapter (MangaPlus / Comikey / Cubari). Check chapter.externalUrl in the feed.`

--- a/src/integrations/mangadex/http/index.ts
+++ b/src/integrations/mangadex/http/index.ts
@@ -1,7 +1,9 @@
 import { acquire, createBucket } from "./bucket.ts";
 import { backoffMs, buildUrl, retryAfterMs } from "./request.ts";
+import { MangaDexHttpError } from "./types.ts";
 import type { FetchFn, MangaDexHttpClient, MangaDexHttpOptions, QueryParams } from "./types.ts";
 
+export { MangaDexHttpError } from "./types.ts";
 export type { FetchFn, MangaDexHttpClient, MangaDexHttpOptions, QueryParams } from "./types.ts";
 
 const BASE_URL = "https://api.mangadex.org";
@@ -68,7 +70,7 @@ export function createMangaDexHttp(opts: MangaDexHttpOptions): MangaDexHttpClien
         continue;
       }
 
-      throw new Error(`MangaDex HTTP ${response.status}: ${url}`);
+      throw new MangaDexHttpError(`MangaDex HTTP ${response.status}: ${url}`, response.status);
     }
 
     throw lastError ?? new Error(`MangaDex request failed after ${MAX_RETRIES} attempts: ${url}`);

--- a/src/integrations/mangadex/http/request.test.ts
+++ b/src/integrations/mangadex/http/request.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { MangaDexHttpError, createMangaDexHttp } from "@integrations/mangadex/http/index.ts";
+import type { Config } from "@plugins/config/index.ts";
+import type { Logger } from "@plugins/logger/index.ts";
+
+const noop = (_f: Record<string, unknown>, _m: string) => {};
+const noopLogger: Logger = { error: noop, warn: noop, info: noop };
+const baseConfig: Config = {
+  preferred_languages: ["en"],
+  download_quality: "data",
+  default_format: "cbz",
+  default_out: "./download",
+  db_path: "./scanldr.db",
+  image_concurrency: 4,
+  chapter_delay_ms: 100,
+};
+
+describe("MangaDexHttpError", () => {
+  test("instanceof Error and instanceof MangaDexHttpError both true", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+  });
+
+  test("status field holds numeric status code", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err.status).toBe(404);
+  });
+
+  test("name is MangaDexHttpError", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err.name).toBe("MangaDexHttpError");
+  });
+
+  test("optional body field", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 422: /foo", 422, "validation failed");
+    expect(err.body).toBe("validation failed");
+  });
+
+  test("body is undefined when not provided", () => {
+    const err = new MangaDexHttpError("MangaDex HTTP 404: /foo", 404);
+    expect(err.body).toBeUndefined();
+  });
+});
+
+describe("createMangaDexHttp — MangaDexHttpError on 4xx", () => {
+  test("fetch returning 404 throws MangaDexHttpError with status 404", async () => {
+    const client = createMangaDexHttp({
+      logger: noopLogger,
+      config: baseConfig,
+      fetch: async () => new Response(null, { status: 404 }),
+    });
+
+    const err = await client.get("/not-found").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).status).toBe(404);
+  });
+
+  test("error message preserves MangaDex HTTP <status>: <url> format", async () => {
+    const client = createMangaDexHttp({
+      logger: noopLogger,
+      config: baseConfig,
+      fetch: async () => new Response(null, { status: 403 }),
+    });
+
+    const err = await client.get("/forbidden").catch((e) => e);
+    expect(err).toBeInstanceOf(MangaDexHttpError);
+    expect((err as MangaDexHttpError).message).toMatch(/^MangaDex HTTP 403:/);
+  });
+});

--- a/src/integrations/mangadex/http/types.ts
+++ b/src/integrations/mangadex/http/types.ts
@@ -1,6 +1,17 @@
 import type { Config } from "@plugins/config/index.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 
+export class MangaDexHttpError extends Error {
+  override readonly name = "MangaDexHttpError";
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body?: string,
+  ) {
+    super(message);
+  }
+}
+
 export type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 export interface MangaDexHttpOptions {


### PR DESCRIPTION
## What this PR does

Two related changes to the pack-as-volume flow introduced in PR #66:

### 1. Bug fix — invisible prompts

`Pack 9 chapters? [y/N]`, `Delete individuals? [y/N]`, and `Overwrite? [y/N]` were getting hidden behind pino's async stdout flush. The terminal showed only `>` waiting for input, with the question text either missing or scrolled off.

Fix: write all prompts to **stderr** (separates from pino's stdout logs). Strategy comment in `prompt-pack.ts:6-7` explains the choice. This matches the existing pattern used by `language.ts`, `prompt.ts`, and `list/index.ts`.

### 2. Feature — volume-number prompt

When the user accepts pack interactively, ask for a logical volume number to use in the filename. Default behavior (`<first>-<last>`) is preserved if the user just hits Enter.

```
Pack 9 chapters into a single volume file? [y/N] y
Volume number (leave blank for "103-111"): 13
✓ Created download/dandadan/dandadan-volume-13.cbz (~56 MB)
Delete individual chapter files? [y/N] y
✓ Deleted 9 individual chapter files
```

Skipped for: `--pack <name>` (user already chose), `--pack-replace` (explicit no-prompt), non-TTY, N==1.

## Why it exists

Real reproduction on 2026-05-06: after `--chapter 103-111 --pack` for Dandadan, prompts hung at `>` with no question text visible. Plus the user wanted `dandadan-volume-13.cbz` (logical volume) instead of `dandadan-volume-103-111.cbz` (chapter range).

`--chapter <range>` is the de-facto path for `all_external` series until #65 lands, so this UX matters.

Closes #68.

## How it works internally

- **`prompt-pack.ts`** — all prompts use `readline.createInterface({ output: process.stderr })` and explicit `process.stderr.write(question)` before each `rl.question` to guarantee visibility.
- **`promptVolumeName`** — accepts alphanumeric, dash, underscore, dot, single spaces. Path-traversal rejected (`/`, `\`, `..`) with re-prompt (NOT abort).
- **Path resolution** — `effectiveOutputName` is derived from user input or default. The overwrite-existence check runs **after** the volume-name prompt resolves, against the actual path that will be written. The earlier P0 (where existence was checked against the default path) is fixed via a `checkExists: (filename) => Promise<boolean>` callback injected by `pack-flow.ts`.
- **`.cbz` suffix** auto-appended unless the user already typed it (no double-append).
- **Filename example**: user types `13` → `<manga-slug>-volume-13.cbz`. User types `13.5` → `<manga-slug>-volume-13.5.cbz`. User types `special-edition` → `<manga-slug>-volume-special-edition.cbz`.

## What did not change

- Pack core logic (zip read/write, atomic rename, path-traversal guard for `--pack <name>`) — untouched.
- Flag combinations from PR #66: `--pack`, `--pack <name>`, `--pack=<name>`, `--pack-replace`, `--pack-overwrite` — all preserved.
- Auth flow, download orchestration, fallback path — untouched.
- `auth.json` shape and consumers — unchanged.

## Test checklist

- [x] `bun test` — 463 pass / 0 fail (was 442, +21 new tests)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — biome clean
- [x] Stderr strategy: tests spy on stderr and assert prompt text appears BEFORE readline read (no flaky timers)
- [x] All 4 prompts use stderr (`Pack?`, `Volume number?`, `Delete?`, `Overwrite?`)
- [x] Volume-number prompt fires only in interactive TTY without `--pack <name>`
- [x] Empty input → default `<first>-<last>` filename
- [x] Custom input → `<manga>-volume-<input>.cbz` with auto `.cbz` suffix
- [x] Path-traversal rejected with re-prompt (`/`, `\`, `..`)
- [x] Skipped for `packNameProvided`, `--pack-replace`, non-TTY, N==1
- [x] Regression: overwrite prompt fires when custom name collides even if default name doesn't exist
- [x] Regression: no overwrite prompt when neither default nor custom name exists
- [ ] Manual smoke: `pbpaste | scanldr auth` then `scanldr download "dandadan" --chapter 103-111` → answer `y`/`13`/`y` → verify `dandadan-volume-13.cbz` appears

## Reviewer notes

- The `checkExists` callback pattern (vs. eager boolean) is intentional — it lets `runPackPrompts` defer the check until the volume-name is resolved without forcing the call site to know about flag combinations.
- Two error-message shapes for path traversal: rejection inline at the prompt repeats until valid; the `--pack <name>` flag (PR #66) throws `CliError` immediately. Different UX is intentional — interactive flow wants forgiveness, flag flow wants fail-fast.
- Convention rationale comment at `prompt-pack.ts:6-7` is permanent — future readers should keep prompts on stderr.

## Closes

Closes #68

### ✅ Checklist

- [x] Tested locally (gates green; manual e2e pending — see test plan)
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions (types in `types.ts`, no new classes, factory functions, colocated tests, structured logger signature, prompts on stderr)
- [x] No new dependencies