### PR TITLE
feat(fallback): source volume mapping from fallback site when MangaDex has all_external

### DIFF
--- a/docs/flows/download_flow.md
+++ b/docs/flows/download_flow.md
@@ -54,9 +54,19 @@ sequenceDiagram
     alt title not found on MangaDex OR user rejects all languages
         CLI-->>User: "Not available on MangaDex with an acceptable language.\nFallback sites:\n  [1] mangakakalot.gg\nPick one or cancel:"
         User->>CLI: 1
-        CLI->>Fallback: fetch manga page → parse chapter list
-        Fallback-->>CLI: ChapterRef[]
-        Note over CLI: volume range from MangaDex used if available,<br/>otherwise user must pass --chapter manually
+        CLI->>Fallback: search title → resolve slug
+
+        alt reason == all_external (Shueisha/MangaPlus partner titles, e.g. Dandadan, JJK, OPM)
+            Note over CLI,Fallback: MangaDex aggregate is empty for these titles.<br/>Source volume→chapter mapping from fallback site manga page.
+            CLI->>Fallback: GET /manga/<slug> (manga detail page)
+            Fallback-->>CLI: HTML with "Vol.X Ch.Y" chapter list
+            CLI->>CLI: parseVolumeMapping(html) → VolumeMap [{ volume, chapters[] }]
+            Note over CLI: if VolumeMap is empty → CliError "use --chapter instead"<br/>if requested volume not in map → CliError with available volumes list
+        else reason == title_not_found OR no_chapters_in_lang
+            Note over CLI,Fallback: volume range sourced from MangaDex aggregate if available,<br/>otherwise user must pass --chapter manually
+            CLI->>Fallback: GET /api/manga/<slug>/chapters → ChapterRef[]
+        end
+
         loop for each chapter in volume range
             CLI->>Fallback: download chapter images
             Fallback-->>CLI: image bytes
@@ -64,7 +74,7 @@ sequenceDiagram
         CLI->>Out: write "witch-hat-atelier-volume-003.cbz" (rename .temp → final)
         CLI->>History: BEGIN TRANSACTION
         loop for each chapter packaged into the volume
-            CLI->>History: INSERT { mangaId, volume, chapterId, chapterNum, source, language, downloadedAt }
+            CLI->>History: INSERT { mangaId, volume, chapterId, chapterNum, source: "mangakakalot", language: "en", downloadedAt }
         end
         CLI->>History: COMMIT
         CLI-->>User: done
@@ -89,7 +99,7 @@ All chapters belonging to a volume are merged into a single `.cbz` archive, sort
 2. **History writes are atomic per volume** — chapters are accumulated in memory while downloading; once the `.cbz` is renamed from `.temp` to its final path, all chapter rows are inserted in a single SQLite transaction. Either every chapter of the volume lands in history or none does — no orphan rows pointing at a volume archive that was never produced.
 3. **Preferred languages from config** — CLI only prompts for language selection when none of the user's `preferred_languages` (from `scanldr.json`) are available. If a preferred language is found, it is used silently.
 4. **User always picks fallback** — CLI never silently falls back to another site. Always warns and prompts.
-5. **Volume metadata from MangaDex is reused on fallback** — if MangaDex knows volume 3 = chapters 18-21, that range is used even when downloading from mangakakalot.
+5. **Volume metadata source depends on fallback reason** — for `all_external` series (Shueisha/MangaPlus titles like Dandadan, JJK, OPM, Spy x Family), the MangaDex aggregate is empty. The CLI fetches the fallback site's manga detail page and parses the `Vol.X Ch.Y` chapter list as the authoritative volume→chapter mapping (`volumeMappingSource: 'fallback'`). For all other reasons (`title_not_found`, `no_chapters_in_lang`), MangaDex aggregate data is used when available (`volumeMappingSource: 'mangadex'`).
 6. **`--chapter` as escape hatch** — when volume metadata is unavailable, the user can pass `--chapter 18-21` manually.
 7. **One `.cbz` per volume** — all chapters in the volume are merged into a single archive.
 8. **Zero-padded image filenames** — pages saved as `0001.png`, `0002.png`, etc. to guarantee correct sort order in all CBZ readers.

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -1019,6 +1019,7 @@ function makeMkClient(overrides?: Partial<MangakakalotClient>): MangakakalotClie
     getChapterImages: async (_id: string): Promise<ImageRef[]> => [
       { url: "https://cdn.mangakakalot.gg/img/1.png", page: 1 },
     ],
+    getVolumeMap: async () => [],
     ...overrides,
   };
 }
@@ -1038,6 +1039,7 @@ describe("fallback — title not on MangaDex, mangakakalot has it", () => {
       getChapterImages: async (_id: string): Promise<ImageRef[]> => [
         { url: "https://cdn.mk.gg/img/1.png", page: 1 },
       ],
+      getVolumeMap: async () => [],
     };
 
     const fallbackHttp = makeFallbackHttp();
@@ -1110,6 +1112,7 @@ describe("fallback — MangaDex aggregate reused for volume mode", () => {
       getChapterImages: async (_id: string): Promise<ImageRef[]> => [
         { url: "https://cdn.mk.gg/img/1.png", page: 1 },
       ],
+      getVolumeMap: async () => [],
     };
 
     const fallbackHttp = makeFallbackHttp();

--- a/src/commands/download/fallback.test.ts
+++ b/src/commands/download/fallback.test.ts
@@ -15,10 +15,12 @@ import { unzipSync } from "fflate";
 import type { FallbackSiteOption, MangaDexResolveResult } from "./fallback-types.ts";
 import {
   buildFallbackBundles,
+  buildFallbackBundlesFromVolumeMap,
   isFallbackEligible,
   promptFallbackSite,
   runFallbackDownload,
 } from "./fallback.ts";
+import type { VolumeMap } from "@integrations/mangakakalot/client/index.ts";
 import type { DownloadArgs } from "./types.ts";
 
 const noopLogger: Logger = {
@@ -430,6 +432,7 @@ describe("runFallbackDownload — searchManga returns empty", () => {
       searchManga: async () => [],
       getChapterList: async () => [],
       getChapterImages: async () => [],
+      getVolumeMap: async () => [],
     };
 
     const warnEvents: string[] = [];
@@ -567,6 +570,7 @@ describe("runFallbackDownload — volume mode with all requested volumes missing
       ],
       getChapterList: async () => [makeChapterRef({ id: "mk-ch1", chapter: "1", volume: null })],
       getChapterImages: async () => [],
+      getVolumeMap: async () => [],
     };
 
     const warnPayloads: Array<Record<string, unknown>> = [];
@@ -855,6 +859,7 @@ function makeFallbackPackMkClient(
     getChapterImages: async (_id: string): Promise<ImageRef[]> => [
       { url: "https://cdn.mk.gg/img/1.png", page: 1 },
     ],
+    getVolumeMap: async () => [],
   };
 }
 
@@ -949,6 +954,7 @@ describe("runFallbackDownload calls pack flow when --pack is set and N>1", () =>
         }
         return [{ url: "https://cdn.mk.gg/img/1.png", page: 1 }];
       },
+      getVolumeMap: async () => [],
     };
 
     const warnEvents: string[] = [];
@@ -1007,5 +1013,326 @@ describe("runFallbackDownload calls pack flow when --pack is set and N>1", () =>
 
     db.close();
     await rm(tmpDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFallbackBundlesFromVolumeMap — volume mode
+// ---------------------------------------------------------------------------
+
+describe("buildFallbackBundlesFromVolumeMap — volume mode", () => {
+  const volumeMap: VolumeMap = [
+    {
+      volume: "13",
+      chapters: [
+        { id: "dandadan/chapter-128", chapter: "128" },
+        { id: "dandadan/chapter-129", chapter: "129" },
+        { id: "dandadan/chapter-130", chapter: "130" },
+      ],
+    },
+    {
+      volume: "12",
+      chapters: [
+        { id: "dandadan/chapter-119", chapter: "119" },
+        { id: "dandadan/chapter-120", chapter: "120" },
+      ],
+    },
+  ];
+
+  test("returns volume bundle with chapters from volumeMap", () => {
+    const bundles = buildFallbackBundlesFromVolumeMap({
+      args: baseArgs({ volume: "13" }),
+      requestedTokens: new Set(["13"]),
+      volumeMap,
+      logger: noopLogger,
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]?.kind).toBe("volume");
+    expect(bundles[0]?.bundleNumber).toBe("13");
+    expect(bundles[0]?.chapters.map((c) => c.id)).toEqual([
+      "dandadan/chapter-128",
+      "dandadan/chapter-129",
+      "dandadan/chapter-130",
+    ]);
+  });
+
+  test("warns and skips volume not in map", () => {
+    const warnEvents: string[] = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvents.push((obj as Record<string, unknown>).event as string);
+        }
+      },
+      error: () => {},
+    };
+
+    const bundles = buildFallbackBundlesFromVolumeMap({
+      args: baseArgs({ volume: "99" }),
+      requestedTokens: new Set(["99"]),
+      volumeMap,
+      logger: spyLogger,
+    });
+
+    expect(bundles).toHaveLength(0);
+    expect(warnEvents).toContain("download.fallback_volume_missing");
+  });
+
+  test("multi-volume request — only matched volumes returned", () => {
+    const bundles = buildFallbackBundlesFromVolumeMap({
+      args: baseArgs({ volume: "12,13,99" }),
+      requestedTokens: new Set(["12", "13", "99"]),
+      volumeMap,
+      logger: noopLogger,
+    });
+
+    expect(bundles).toHaveLength(2);
+    expect(bundles.map((b) => b.bundleNumber).sort()).toEqual(["12", "13"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFallbackBundlesFromVolumeMap — chapter mode
+// ---------------------------------------------------------------------------
+
+describe("buildFallbackBundlesFromVolumeMap — chapter mode", () => {
+  const volumeMap: VolumeMap = [
+    {
+      volume: "13",
+      chapters: [
+        { id: "dandadan/chapter-128", chapter: "128" },
+        { id: "dandadan/chapter-129", chapter: "129" },
+      ],
+    },
+    {
+      volume: "unknown",
+      chapters: [{ id: "dandadan/chapter-999", chapter: "999" }],
+    },
+  ];
+
+  test("finds chapter across all volume buckets", () => {
+    const bundles = buildFallbackBundlesFromVolumeMap({
+      args: baseArgs({ volume: undefined, chapter: "128" }),
+      requestedTokens: new Set(["128"]),
+      volumeMap,
+      logger: noopLogger,
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]?.kind).toBe("chapter");
+    expect(bundles[0]?.chapters[0]?.id).toBe("dandadan/chapter-128");
+    expect(bundles[0]?.volumeForHistory).toBe("13");
+  });
+
+  test("chapter in 'unknown' bucket → volumeForHistory is 'none'", () => {
+    const bundles = buildFallbackBundlesFromVolumeMap({
+      args: baseArgs({ volume: undefined, chapter: "999" }),
+      requestedTokens: new Set(["999"]),
+      volumeMap,
+      logger: noopLogger,
+    });
+
+    expect(bundles[0]?.volumeForHistory).toBe("none");
+  });
+
+  test("warns when chapter is not found in any bucket", () => {
+    const warnEvents: string[] = [];
+    const spyLogger: Logger = {
+      info: () => {},
+      warn: (obj: unknown) => {
+        if (typeof obj === "object" && obj !== null && "event" in obj) {
+          warnEvents.push((obj as Record<string, unknown>).event as string);
+        }
+      },
+      error: () => {},
+    };
+
+    const bundles = buildFallbackBundlesFromVolumeMap({
+      args: baseArgs({ volume: undefined, chapter: "1" }),
+      requestedTokens: new Set(["1"]),
+      volumeMap,
+      logger: spyLogger,
+    });
+
+    expect(bundles).toHaveLength(0);
+    expect(warnEvents).toContain("download.fallback_chapter_missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runFallbackDownload — volumeMappingSource: 'fallback' end-to-end
+// ---------------------------------------------------------------------------
+
+describe("runFallbackDownload — volumeMappingSource: fallback, --volume 13 on all_external series", () => {
+  test("uses getVolumeMap and downloads chapters from volume 13 without querying MangaDex aggregate", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "scanldr-fallback-vmap-"));
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const imageUrl = "https://img-r1.2xstorage.com/dandadan/128/0.webp";
+
+    const mkClientWithVolumeMap: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => {
+        throw new Error("getChapterList should NOT be called when volumeMappingSource=fallback");
+      },
+      getVolumeMap: async () => [
+        {
+          volume: "13",
+          chapters: [{ id: "dandadan/chapter-128", chapter: "128" }],
+        },
+      ],
+      getChapterImages: async (_id: string): Promise<ImageRef[]> => [{ url: imageUrl, page: 1 }],
+    };
+
+    const mockHttp: FallbackHttpClient = {
+      get: async (url: string) => {
+        if (url === imageUrl) {
+          return new Response(new Uint8Array([1, 2, 3]).buffer, { status: 200 });
+        }
+        throw new Error(`unexpected http.get call: ${url}`);
+      },
+    };
+
+    // mangadexResolve simulates all_external: volumes is empty (aggregate returned nothing)
+    const mangadexResolve: MangaDexResolveResult = {
+      candidate: { id: "manga-dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      volumes: [],
+      chaptersInLang: [
+        makeChapterRef({
+          id: "ch-ext-1",
+          externalUrl: "https://mangaplus.shueisha.co.jp/viewer/1001",
+        }),
+      ],
+      language: "en",
+    };
+
+    await runFallbackDownload({
+      args: baseArgs({ volume: "13", outDir: tmpDir, noTrack: true }),
+      ctx: {
+        logger: noopLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: tmpDir,
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve,
+      createFallbackHttp: async () => mockHttp,
+      createMangakakalotClient: () => mkClientWithVolumeMap,
+      volumeMappingSource: "fallback",
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      promptSite: async (sites) => sites[0]!,
+    });
+
+    db.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("throws CliError when volumeMap is empty and --volume is requested", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const mkClientEmptyMap: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => [],
+      getVolumeMap: async () => [],
+      getChapterImages: async () => [],
+    };
+
+    const fakeFallbackHttp: FallbackHttpClient = {
+      get: async () => new Response("", { status: 200 }),
+    };
+
+    const err = await runFallbackDownload({
+      args: baseArgs({ volume: "13" }),
+      ctx: {
+        logger: noopLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve: null,
+      createFallbackHttp: async () => fakeFallbackHttp,
+      createMangakakalotClient: () => mkClientEmptyMap,
+      volumeMappingSource: "fallback",
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      promptSite: async (sites) => sites[0]!,
+    }).catch((e) => e);
+
+    db.close();
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("Volume mapping not available");
+    expect((err as CliError).message).toContain("--chapter");
+  });
+
+  test("throws CliError when requested volume not found in map", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const mkClientMissingVol: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => [],
+      getVolumeMap: async () => [
+        { volume: "1", chapters: [{ id: "dandadan/chapter-1", chapter: "1" }] },
+        { volume: "2", chapters: [{ id: "dandadan/chapter-9", chapter: "9" }] },
+      ],
+      getChapterImages: async () => [],
+    };
+
+    const fakeFallbackHttp: FallbackHttpClient = {
+      get: async () => new Response("", { status: 200 }),
+    };
+
+    const err = await runFallbackDownload({
+      args: baseArgs({ volume: "13" }),
+      ctx: {
+        logger: noopLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve: null,
+      createFallbackHttp: async () => fakeFallbackHttp,
+      createMangakakalotClient: () => mkClientMissingVol,
+      volumeMappingSource: "fallback",
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      promptSite: async (sites) => sites[0]!,
+    }).catch((e) => e);
+
+    db.close();
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("Volume 13 not found");
+    expect((err as CliError).message).toContain("Available volumes: 1, 2");
+    expect((err as CliError).message).toContain("--chapter");
   });
 });

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -5,6 +5,7 @@
 import type { ChapterRef, VolumeRef } from "@integrations/_shared/manga.ts";
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import type { createMangakakalotClient } from "@integrations/mangakakalot/client/index.ts";
+import type { VolumeMap } from "@integrations/mangakakalot/client/types.ts";
 import { downloadBundle } from "@modules/downloader/index.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
 import type { ChapterInput } from "@modules/downloader/types.ts";
@@ -241,6 +242,94 @@ export function buildFallbackBundles(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// buildFallbackBundlesFromVolumeMap
+// Used when volumeMappingSource === 'fallback' (all_external series).
+// ---------------------------------------------------------------------------
+
+export function buildFallbackBundlesFromVolumeMap(opts: {
+  args: DownloadArgs;
+  requestedTokens: Set<string>;
+  volumeMap: VolumeMap;
+  logger: Logger;
+}): FallbackBundle[] {
+  const { args, requestedTokens, volumeMap, logger } = opts;
+
+  if (args.volume === undefined) {
+    // --chapter mode: find chapter directly from all buckets (flat lookup).
+    const bundles: FallbackBundle[] = [];
+    for (const chToken of requestedTokens) {
+      let found = false;
+      for (const bucket of volumeMap) {
+        const match = bucket.chapters.find((c) => c.chapter === chToken);
+        if (match) {
+          const volumeForHistory = bucket.volume === "unknown" ? "none" : bucket.volume;
+          bundles.push({
+            kind: "chapter",
+            bundleNumber: chToken,
+            volumeForHistory,
+            chapters: [
+              {
+                id: match.id,
+                volume: volumeForHistory,
+                chapter: chToken,
+                title: null,
+                translatedLanguage: "en",
+                scanlationGroup: null,
+                readableAt: "",
+                externalUrl: null,
+              },
+            ],
+          });
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        logger.warn(
+          { event: "download.fallback_chapter_missing", context: "download", chapter: chToken },
+          `chapter ${chToken} not found on fallback site; skipping`,
+        );
+      }
+    }
+    return bundles;
+  }
+
+  // --volume mode: use volumeMap buckets as authoritative source.
+  const bundles: FallbackBundle[] = [];
+
+  for (const volToken of requestedTokens) {
+    const bucket = volumeMap.find((b) => b.volume === volToken);
+    if (!bucket || bucket.chapters.length === 0) {
+      logger.warn(
+        { event: "download.fallback_volume_missing", context: "download", volume: volToken },
+        `volume ${volToken} not found in fallback site mapping; skipping`,
+      );
+      continue;
+    }
+
+    const chapters: ChapterRef[] = bucket.chapters.map((c) => ({
+      id: c.id,
+      volume: volToken,
+      chapter: c.chapter,
+      title: null,
+      translatedLanguage: "en",
+      scanlationGroup: null,
+      readableAt: "",
+      externalUrl: null,
+    }));
+
+    bundles.push({
+      kind: "volume",
+      bundleNumber: volToken,
+      volumeForHistory: volToken,
+      chapters,
+    });
+  }
+
+  return bundles;
+}
+
+// ---------------------------------------------------------------------------
 // runFallbackDownload
 // ---------------------------------------------------------------------------
 
@@ -255,6 +344,12 @@ export async function runFallbackDownload(opts: {
     http: import("@integrations/fallback-http/types.ts").FallbackHttpClient;
     logger: Logger;
   }) => import("@integrations/mangakakalot/client/types.ts").MangakakalotClient;
+  /**
+   * Controls where volume→chapter mapping is sourced from.
+   * 'fallback' — parse from the fallback site manga page (required for all_external series).
+   * 'mangadex' — use MangaDex aggregate (default, preserves existing behaviour).
+   */
+  volumeMappingSource?: "mangadex" | "fallback";
   /** Override for tests — bypasses stdin prompt. When provided, nonTty check is skipped. */
   promptSite?: (sites: FallbackSiteOption[]) => Promise<FallbackSiteOption>;
 }): Promise<void> {
@@ -264,12 +359,18 @@ export async function runFallbackDownload(opts: {
     mangadexResolve,
     createFallbackHttp: mkFallbackHttp,
     createMangakakalotClient: mkClientFactory,
+    volumeMappingSource = "mangadex",
     promptSite,
   } = opts;
   const { logger } = ctx;
 
-  // Volume mode requires MangaDex aggregate to map volumes → chapter numbers
-  if (args.volume !== undefined && (!mangadexResolve || mangadexResolve.volumes.length === 0)) {
+  // Volume mode with mangadex source requires MangaDex aggregate to map volumes → chapter numbers.
+  // When volumeMappingSource === 'fallback', we skip this guard and source from the manga page.
+  if (
+    args.volume !== undefined &&
+    volumeMappingSource === "mangadex" &&
+    (!mangadexResolve || mangadexResolve.volumes.length === 0)
+  ) {
     logger.warn(
       { event: "download.fallback_no_volume_metadata", context: "download" },
       "MangaDex has no volume data; --chapter is required for fallback",
@@ -329,45 +430,97 @@ export async function runFallbackDownload(opts: {
     "title resolved on fallback site",
   );
 
-  const mkChapters = await mkClient.getChapterList(mkChosen.id);
-
   const requestedTokens =
     args.volume !== undefined
       ? parseRangeSet(args.volume).values
       : parseRangeSet(args.chapter as string).values;
 
-  const bundles = buildFallbackBundles({
-    args,
-    requestedTokens,
-    mangadexVolumes: mangadexResolve?.volumes ?? [],
-    mangadexChapters: mangadexResolve?.chaptersInLang ?? [],
-    mkChapters,
-    logger,
-  });
+  let bundles: FallbackBundle[];
 
-  // Guard: volume mode + MangaDex has volumes, but none of the requested ones are in the mapping.
-  // This happens when the title is partner-published and MangaDex doesn't track certain volumes.
-  if (
-    args.volume !== undefined &&
-    bundles.length === 0 &&
-    mangadexResolve &&
-    mangadexResolve.volumes.length > 0
-  ) {
-    const requested = [...requestedTokens].sort(compareVolumeTokens);
-    const available = mangadexResolve.volumes.map((v) => v.volume).sort(compareVolumeTokens);
-    logger.warn(
-      {
-        event: "download.fallback_no_volumes_matched",
-        context: "download",
-        requested,
-        available,
-      },
-      "no requested volume tokens are mapped in MangaDex aggregate",
+  if (volumeMappingSource === "fallback") {
+    // Source volume→chapter mapping from the fallback site manga page.
+    logger.info(
+      { event: "download.fallback_volume_map_fetch", context: "download", slug: mkChosen.id },
+      "fetching volume mapping from fallback site",
     );
-    throw new CliError(
-      `None of the requested volumes are mapped in MangaDex's aggregate for "${mangadexResolve.candidate.title}". Available mapped volumes: ${available.join(", ")}. Use --chapter <range> instead: MangaDex doesn't track this volume for this title (likely partner-published series).`,
-      2,
-    );
+    const volumeMap = await mkClient.getVolumeMap(mkChosen.id);
+
+    if (args.volume !== undefined && volumeMap.length === 0) {
+      logger.warn(
+        { event: "download.fallback_volume_map_empty", context: "download", slug: mkChosen.id },
+        "fallback site manga page returned no volume mapping",
+      );
+      throw new CliError(
+        "Volume mapping not available on the fallback site. Use --chapter <range> instead.",
+        2,
+      );
+    }
+
+    bundles = buildFallbackBundlesFromVolumeMap({
+      args,
+      requestedTokens,
+      volumeMap,
+      logger,
+    });
+
+    // Volume mode: all requested tokens missing → specific error with available volumes.
+    if (args.volume !== undefined && bundles.length === 0) {
+      const requested = [...requestedTokens].sort(compareVolumeTokens);
+      const available = volumeMap
+        .map((b) => b.volume)
+        .filter((v) => v !== "unknown")
+        .sort(compareVolumeTokens);
+      logger.warn(
+        {
+          event: "download.fallback_no_volumes_matched",
+          context: "download",
+          requested,
+          available,
+          source: "fallback",
+        },
+        "no requested volume tokens found in fallback site mapping",
+      );
+      throw new CliError(
+        `Volume ${requested.join(", ")} not found in fallback site mapping for "${mkChosen.title}". Available volumes: ${available.join(", ")}. Use --chapter <range> if you need partial.`,
+        2,
+      );
+    }
+  } else {
+    // Default: source from MangaDex aggregate (original path).
+    const mkChapters = await mkClient.getChapterList(mkChosen.id);
+
+    bundles = buildFallbackBundles({
+      args,
+      requestedTokens,
+      mangadexVolumes: mangadexResolve?.volumes ?? [],
+      mangadexChapters: mangadexResolve?.chaptersInLang ?? [],
+      mkChapters,
+      logger,
+    });
+
+    // Guard: volume mode + MangaDex has volumes, but none of the requested ones are in the mapping.
+    if (
+      args.volume !== undefined &&
+      bundles.length === 0 &&
+      mangadexResolve &&
+      mangadexResolve.volumes.length > 0
+    ) {
+      const requested = [...requestedTokens].sort(compareVolumeTokens);
+      const available = mangadexResolve.volumes.map((v) => v.volume).sort(compareVolumeTokens);
+      logger.warn(
+        {
+          event: "download.fallback_no_volumes_matched",
+          context: "download",
+          requested,
+          available,
+        },
+        "no requested volume tokens are mapped in MangaDex aggregate",
+      );
+      throw new CliError(
+        `None of the requested volumes are mapped in MangaDex's aggregate for "${mangadexResolve.candidate.title}". Available mapped volumes: ${available.join(", ")}. Use --chapter <range> instead: MangaDex doesn't track this volume for this title (likely partner-published series).`,
+        2,
+      );
+    }
   }
 
   const slug = toSlug(mkChosen.title, logger);

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -522,6 +522,9 @@ export async function runDownload(
       mangadexResolve,
       createFallbackHttp,
       createMangakakalotClient,
+      // For all_external series (Shueisha/MangaPlus titles), the MangaDex aggregate is empty.
+      // Source volume→chapter mapping from the fallback site manga page instead.
+      volumeMappingSource: eligibility.reason === "all_external" ? "fallback" : "mangadex",
     });
   }
 

--- a/src/integrations/mangakakalot/client/index.ts
+++ b/src/integrations/mangakakalot/client/index.ts
@@ -7,12 +7,13 @@ import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
 import { parseChapterImages, parseChapterListFromApi, parseSearchResults } from "./parser.ts";
-import type { MangakakalotClient } from "./types.ts";
+import type { MangakakalotClient, VolumeMap } from "./types.ts";
 import { MangakakalotParseError } from "./types.ts";
+import { parseVolumeMapping } from "./volume-parser.ts";
 
 export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 export type { ImageRef } from "@modules/downloader/types.ts";
-export type { MangakakalotClient } from "./types.ts";
+export type { FallbackChapterRef, MangakakalotClient, VolumeBucket, VolumeMap } from "./types.ts";
 export { MangakakalotParseError } from "./types.ts";
 
 const SITE_ROOT = "https://www.mangakakalot.gg";
@@ -124,6 +125,12 @@ export function createMangakakalotClient(opts: {
     return allChapters;
   }
 
+  async function getVolumeMap(slug: string): Promise<VolumeMap> {
+    const url = `${SITE_ROOT}/manga/${encodeURIComponent(slug)}`;
+    const html = await fetchHtml(url);
+    return runParser(url, () => parseVolumeMapping(html));
+  }
+
   async function getChapterImages(chapterIdOrUrl: string): Promise<ImageRef[]> {
     // Accept a full URL, a composite id "mangaSlug/chapter-slug" (from parseChapterListFromApi),
     // or the legacy path-style id "chapter/manga-slug/chapter-1".
@@ -142,5 +149,5 @@ export function createMangakakalotClient(opts: {
     return runParser(url, () => parseChapterImages(html, url));
   }
 
-  return { searchManga, getChapterList, getChapterImages };
+  return { searchManga, getChapterList, getChapterImages, getVolumeMap };
 }

--- a/src/integrations/mangakakalot/client/types.ts
+++ b/src/integrations/mangakakalot/client/types.ts
@@ -5,6 +5,31 @@ import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts"
 import type { ImageRef } from "@modules/downloader/types.ts";
 
 // ---------------------------------------------------------------------------
+// Volume mapping (manga page HTML)
+// ---------------------------------------------------------------------------
+
+/** A chapter reference on the fallback site with enough info for volume-based selection. */
+export interface FallbackChapterRef {
+  /** Chapter number string (e.g. "128", "1.5"). Null when not parseable. */
+  chapter: string | null;
+  /** Composite id "<mangaSlug>/<chapter-slug>" matching getChapterImages() convention. */
+  id: string;
+}
+
+/** One volume bucket extracted from the manga page. */
+export interface VolumeBucket {
+  /** Volume number as a string (e.g. "13"). "unknown" for flat/unlabelled chapters. */
+  volume: string;
+  chapters: FallbackChapterRef[];
+}
+
+/**
+ * Volume-to-chapter mapping parsed from the fallback site manga page.
+ * Empty array means the page had no chapter list at all (DOM drift).
+ */
+export type VolumeMap = VolumeBucket[];
+
+// ---------------------------------------------------------------------------
 // JSON API shapes (chapter list endpoint)
 // ---------------------------------------------------------------------------
 
@@ -47,4 +72,6 @@ export interface MangakakalotClient {
   searchManga(title: string): Promise<MangaCandidate[]>;
   getChapterList(slug: string): Promise<ChapterRef[]>;
   getChapterImages(chapterIdOrUrl: string): Promise<ImageRef[]>;
+  /** Fetch the manga detail page and parse volume→chapter mapping from the HTML. */
+  getVolumeMap(slug: string): Promise<VolumeMap>;
 }

--- a/src/integrations/mangakakalot/client/volume-parser.test.ts
+++ b/src/integrations/mangakakalot/client/volume-parser.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseVolumeMapping } from "./volume-parser.ts";
+
+const fixturesDir = join(import.meta.dir, "../../../../tests/fixtures/mangakakalot");
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixturesDir, name), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// parseVolumeMapping — Dandadan fixture (all_external series with volume labels)
+// ---------------------------------------------------------------------------
+
+describe("parseVolumeMapping — Dandadan fixture", () => {
+  it("returns volume buckets sorted numerically ascending", () => {
+    const html = readFixture("manga-page-dandadan.html");
+    const map = parseVolumeMapping(html);
+
+    const volumes = map.map((b) => b.volume);
+    expect(volumes).toEqual(["1", "11", "12", "13"]);
+  });
+
+  it("volume 13 has 3 chapters sorted ascending", () => {
+    const html = readFixture("manga-page-dandadan.html");
+    const map = parseVolumeMapping(html);
+
+    const vol13 = map.find((b) => b.volume === "13");
+    expect(vol13).toBeDefined();
+    expect(vol13?.chapters.map((c) => c.chapter)).toEqual(["128", "129", "130"]);
+  });
+
+  it("composite id follows <slug>/<chapter-slug> convention", () => {
+    const html = readFixture("manga-page-dandadan.html");
+    const map = parseVolumeMapping(html);
+
+    const vol13 = map.find((b) => b.volume === "13");
+    expect(vol13?.chapters[0]?.id).toBe("dandadan/chapter-128");
+    expect(vol13?.chapters[1]?.id).toBe("dandadan/chapter-129");
+    expect(vol13?.chapters[2]?.id).toBe("dandadan/chapter-130");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVolumeMapping — JJK fixture
+// ---------------------------------------------------------------------------
+
+describe("parseVolumeMapping — JJK fixture", () => {
+  it("returns expected volumes", () => {
+    const html = readFixture("manga-page-jjk.html");
+    const map = parseVolumeMapping(html);
+
+    const volumes = map.map((b) => b.volume);
+    expect(volumes).toEqual(["1", "26", "27"]);
+  });
+
+  it("volume 27 has 2 chapters", () => {
+    const html = readFixture("manga-page-jjk.html");
+    const map = parseVolumeMapping(html);
+
+    const vol27 = map.find((b) => b.volume === "27");
+    expect(vol27?.chapters).toHaveLength(2);
+    expect(vol27?.chapters.map((c) => c.chapter)).toEqual(["270", "271"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVolumeMapping — flat list (no volume labels)
+// ---------------------------------------------------------------------------
+
+describe("parseVolumeMapping — flat list (no volume labels)", () => {
+  it("returns a single 'unknown' bucket with all chapters", () => {
+    const html = readFixture("manga-page-flat.html");
+    const map = parseVolumeMapping(html);
+
+    expect(map).toHaveLength(1);
+    expect(map[0]?.volume).toBe("unknown");
+    expect(map[0]?.chapters.map((c) => c.chapter)).toEqual(["1", "5", "10"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVolumeMapping — edge cases
+// ---------------------------------------------------------------------------
+
+describe("parseVolumeMapping — edge cases", () => {
+  it("returns [] when .row-content-chapter is absent", () => {
+    const html = "<html><body><h1>Some page</h1></body></html>";
+    expect(parseVolumeMapping(html)).toEqual([]);
+  });
+
+  it("returns [] for empty HTML string", () => {
+    expect(parseVolumeMapping("")).toEqual([]);
+  });
+
+  it("normalises leading-zero volume numbers (Vol.01 → '1')", () => {
+    const html = `<html><body>
+      <ul class="row-content-chapter">
+        <li class="a-h"><a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/test/chapter-1">Vol.01 Ch.001</a></li>
+      </ul>
+    </body></html>`;
+    const map = parseVolumeMapping(html);
+    expect(map[0]?.volume).toBe("1");
+    expect(map[0]?.chapters[0]?.chapter).toBe("1");
+  });
+
+  it("chapters within a volume are sorted by chapter number ascending", () => {
+    // Fixture provides chapters newest-first (130, 129, 128)
+    const html = readFixture("manga-page-dandadan.html");
+    const map = parseVolumeMapping(html);
+    const vol13 = map.find((b) => b.volume === "13");
+    const nums = vol13?.chapters.map((c) => Number(c.chapter)) ?? [];
+    expect(nums).toEqual([...nums].sort((a, b) => a - b));
+  });
+});

--- a/src/integrations/mangakakalot/client/volume-parser.ts
+++ b/src/integrations/mangakakalot/client/volume-parser.ts
@@ -1,0 +1,108 @@
+// Parses the volume→chapter mapping from a mangakakalot manga detail page.
+// Chapter names on the manga page follow the pattern "Vol.X Ch.Y [- Optional Title]"
+// or just "Chapter N [- Optional Title]" (flat list, no volume labels).
+
+import * as cheerio from "cheerio";
+import type { FallbackChapterRef, VolumeMap } from "./types.ts";
+
+// Confirmed selector against real mangakakalot.gg manga pages (2026-05-06).
+// Each <li> inside .row-content-chapter has an <a class="chapter-name"> with the chapter label.
+const CHAPTER_LIST_SELECTOR = ".row-content-chapter li";
+const CHAPTER_LINK_SELECTOR = "a.chapter-name";
+
+// Matches "Vol.13 Ch.128 ..." or "Vol.1 Ch.1" — captures volume and chapter numbers.
+const VOL_CH_PATTERN = /Vol\.(\d+(?:\.\d+)?)\s+Ch\.(\d+(?:\.\d+)?)/i;
+
+// Matches "Ch.N" or "Chapter N" without a volume prefix.
+const CH_ONLY_PATTERN = /(?:Ch\.|Chapter\s+)(\d+(?:\.\d+)?)/i;
+
+/**
+ * Extract chapter slug from a mangakakalot chapter URL.
+ * URL form: https://www.mangakakalot.gg/manga/<manga-slug>/<chapter-slug>
+ * Returns "<manga-slug>/<chapter-slug>" composite id (matches getChapterImages convention).
+ */
+function compositeIdFromUrl(href: string): string | null {
+  try {
+    const parsed = new URL(href);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    // Expected: ["manga", "<manga-slug>", "<chapter-slug>"]
+    const mangaIdx = parts.indexOf("manga");
+    if (mangaIdx >= 0 && parts[mangaIdx + 1] && parts[mangaIdx + 2]) {
+      return `${parts[mangaIdx + 1]}/${parts[mangaIdx + 2]}`;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse the manga detail page HTML and extract volume→chapter mapping.
+ *
+ * Returns a VolumeMap (array of VolumeBucket).
+ * - Chapters with "Vol.X Ch.Y" labels are grouped under volume X.
+ * - Chapters without volume labels are grouped under the "unknown" bucket.
+ * - Empty array when the chapter list container is absent (DOM drift).
+ *
+ * Buckets are sorted by volume number ascending; "unknown" is always last.
+ * Chapters within each bucket are sorted by chapter number ascending.
+ */
+export function parseVolumeMapping(html: string): VolumeMap {
+  const $ = cheerio.load(html);
+  const items = $(CHAPTER_LIST_SELECTOR);
+
+  if (items.length === 0) {
+    return [];
+  }
+
+  // volume string → chapters list
+  const buckets = new Map<string, FallbackChapterRef[]>();
+
+  items.each((_, el) => {
+    const anchor = $(el).find(CHAPTER_LINK_SELECTOR).first();
+    const label = anchor.text().trim();
+    const href = anchor.attr("href") ?? "";
+
+    const id = compositeIdFromUrl(href);
+    if (!id) return;
+
+    const volChMatch = label.match(VOL_CH_PATTERN);
+    if (volChMatch) {
+      const volume = String(Number(volChMatch[1])); // normalise "01" → "1"
+      const chapter = String(Number(volChMatch[2]));
+      const existing = buckets.get(volume) ?? [];
+      existing.push({ id, chapter });
+      buckets.set(volume, existing);
+      return;
+    }
+
+    // Flat chapter without volume label — put in "unknown" bucket.
+    const chOnlyMatch = label.match(CH_ONLY_PATTERN);
+    const chapter = chOnlyMatch ? String(Number(chOnlyMatch[1])) : null;
+    const existing = buckets.get("unknown") ?? [];
+    existing.push({ id, chapter });
+    buckets.set("unknown", existing);
+  });
+
+  // Sort buckets: numeric volumes ascending, "unknown" last.
+  const sorted: VolumeMap = [];
+  const numericKeys = [...buckets.keys()]
+    .filter((k) => k !== "unknown")
+    .sort((a, b) => Number(a) - Number(b));
+
+  for (const vol of numericKeys) {
+    const chapters = (buckets.get(vol) ?? []).sort(
+      (a, b) => Number(a.chapter ?? 0) - Number(b.chapter ?? 0),
+    );
+    sorted.push({ volume: vol, chapters });
+  }
+
+  if (buckets.has("unknown")) {
+    const chapters = (buckets.get("unknown") ?? []).sort(
+      (a, b) => Number(a.chapter ?? 0) - Number(b.chapter ?? 0),
+    );
+    sorted.push({ volume: "unknown", chapters });
+  }
+
+  return sorted;
+}

--- a/tests/fixtures/mangakakalot/manga-page-dandadan.html
+++ b/tests/fixtures/mangakakalot/manga-page-dandadan.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics mangakakalot.gg manga detail page for Dandadan (all_external series).
+     Volume headers are present as .volume-header elements inside .chapter-list.
+     Structural HTML only — no tracking pixels, no session tokens, no ad scripts. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Dandadan - Manga</title></head>
+<body>
+<div class="story-info-right">
+  <h1 itemprop="name">Dandadan</h1>
+</div>
+<ul class="row-content-chapter">
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-130">Vol.13 Ch.130 - Goodbye, Turbo Granny</a>
+    <span class="chapter-time text-nowrap">May 01,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-129">Vol.13 Ch.129 - A Pinch</a>
+    <span class="chapter-time text-nowrap">Apr 24,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-128">Vol.13 Ch.128 - The Beginning of the End</a>
+    <span class="chapter-time text-nowrap">Apr 17,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-120">Vol.12 Ch.120</a>
+    <span class="chapter-time text-nowrap">Feb 01,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-119">Vol.12 Ch.119</a>
+    <span class="chapter-time text-nowrap">Jan 25,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-110">Vol.11 Ch.110</a>
+    <span class="chapter-time text-nowrap">Dec 01,2025</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-109">Vol.11 Ch.109</a>
+    <span class="chapter-time text-nowrap">Nov 25,2025</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/dandadan/chapter-1">Vol.1 Ch.1</a>
+    <span class="chapter-time text-nowrap">Jan 01,2022</span>
+  </li>
+</ul>
+</body>
+</html>

--- a/tests/fixtures/mangakakalot/manga-page-flat.html
+++ b/tests/fixtures/mangakakalot/manga-page-flat.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics mangakakalot.gg manga detail page for a series
+     that has NO volume labels in chapter names (flat chapter list only).
+     Parser should return a single bucket { volume: 'unknown', chapters: [...] }. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Some Series - Manga</title></head>
+<body>
+<div class="story-info-right">
+  <h1 itemprop="name">Some Series</h1>
+</div>
+<ul class="row-content-chapter">
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/some-series/chapter-10">Chapter 10</a>
+    <span class="chapter-time text-nowrap">May 01,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/some-series/chapter-5">Chapter 5</a>
+    <span class="chapter-time text-nowrap">Apr 01,2026</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/some-series/chapter-1">Chapter 1</a>
+    <span class="chapter-time text-nowrap">Mar 01,2026</span>
+  </li>
+</ul>
+</body>
+</html>

--- a/tests/fixtures/mangakakalot/manga-page-jjk.html
+++ b/tests/fixtures/mangakakalot/manga-page-jjk.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mimics mangakakalot.gg manga detail page for Jujutsu Kaisen.
+     Volume headers in chapter names follow the same Vol.X Ch.Y pattern.
+     Structural HTML only — no tracking pixels, no session tokens, no ad scripts. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Jujutsu Kaisen - Manga</title></head>
+<body>
+<div class="story-info-right">
+  <h1 itemprop="name">Jujutsu Kaisen</h1>
+</div>
+<ul class="row-content-chapter">
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/jujutsu-kaisen/chapter-271">Vol.27 Ch.271</a>
+    <span class="chapter-time text-nowrap">Sep 01,2024</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/jujutsu-kaisen/chapter-270">Vol.27 Ch.270</a>
+    <span class="chapter-time text-nowrap">Aug 25,2024</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/jujutsu-kaisen/chapter-256">Vol.26 Ch.256</a>
+    <span class="chapter-time text-nowrap">May 01,2024</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/jujutsu-kaisen/chapter-255">Vol.26 Ch.255</a>
+    <span class="chapter-time text-nowrap">Apr 24,2024</span>
+  </li>
+  <li class="a-h">
+    <a class="chapter-name text-nowrap" href="https://www.mangakakalot.gg/manga/jujutsu-kaisen/chapter-1">Vol.1 Ch.1 - Ryomen Sukuna</a>
+    <span class="chapter-time text-nowrap">Jan 01,2019</span>
+  </li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## What this PR does

Makes `--volume <n>` work for `all_external` series (Dandadan, JJK, OPM, Spy x Family — Shueisha titles published officially on MangaPlus). When MangaDex returns `reason: 'all_external'`, the orchestrator now sources the volume→chapter map from the **fallback site** (mangakakalot's manga page) instead of MangaDex's empty aggregate.

Two surfaces:

1. **New parser** `parseVolumeMapping(html): VolumeMap` in `src/integrations/mangakakalot/client/volume-parser.ts` — extracts `Vol.X Ch.Y` chapter labels from the manga detail page using existing `cheerio`.
2. **Branching** in `runFallbackDownload` via a new `volumeMappingSource: 'mangadex' | 'fallback'` option. `runDownload` sets it to `'fallback'` when the MangaDex pipeline reports `all_external`; default stays `'mangadex'` so other paths are untouched.

## Why it exists

Real reproduction logged on 2026-05-06:

```
info auth session loaded
info searching on fallback site
info fetching page
info title resolved on fallback site
info fetching chapter list from API   ← still queries MangaDex aggregate
warn volume 13 not found in MangaDex aggregate
warn no requested volume tokens are mapped in MangaDex aggregate
```

Even after PR #62 (manual auth) and PR #66 (pack volume) destravaram o caminho de download, `--volume 13` ainda falhava porque o aggregate do MangaDex está vazio para séries `all_external`. Workaround atual: `--chapter <range> --pack` — funciona mas perde a UX de "baixar volume X".

Closes #65.

## How it works internally

- **Parser** uses cheerio to walk `.row-content-chapter li` and extract `(volume, chapter, id)` triples. Returns `VolumeMap = VolumeBucket[]` where each bucket carries `{ volume: string, chapters: FallbackChapterRef[] }`. Unparseable labels (no `Vol.X`) fall into a single `unknown` bucket — preserves total count.
- **Wire-up**: `src/commands/download/index.ts:527` sets `volumeMappingSource: 'fallback'` when `tryMangaDexPipeline` returns `{ reason: 'all_external' }`.
- **`runFallbackDownload`** branches: if `volumeMappingSource === 'fallback'`, it calls `client.getVolumeMap(slug)` and routes through `buildFallbackBundlesFromVolumeMap` instead of `buildFallbackBundles` (the existing MangaDex aggregate path).
- **Errors**: empty `VolumeMap` → `CliError("Volume mapping not available on the fallback site. Use --chapter <range> instead.")`. Volume not in map → `CliError("Volume <n> not found in fallback site mapping for <title>. Available volumes: 1, 2, 3, ...")` with enumeration.
- **History** preserved: every chapter recorded with `source: 'mangakakalot'`.

## What did not change

- MangaDex pipeline when MangaDex has data — completely untouched (`volumeMappingSource: 'mangadex'` default).
- `--chapter <range>` flow — works on all sources, no behavior change.
- Auth flow, pack flow, download orchestration outside the new branching.
- Existing fallback paths for non-`all_external` reasons (e.g. user-prompted choice) — unchanged.
- `auth.json` shape, fallback HTTP client, mangakakalot client public surface (only adds `getVolumeMap`).

## Test checklist

- [x] `bun test` — 461 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — biome clean
- [x] Parser tests with 3 fixtures (Dandadan, JJK, flat list) covering label variations
- [x] Edge cases: malformed HTML, empty body, missing chapter list
- [x] E2E happy path: `runFallbackDownload` with `volumeMappingSource: 'fallback'` + `--volume 13` resolves correctly without calling `getChapterList`
- [x] Error UX: empty `VolumeMap` and "volume not in map" both produce typed `CliError` with useful messages
- [x] Backward compat: `volumeMappingSource: 'mangadex'` (default) keeps existing flow untouched
- [ ] Manual smoke: `scanldr download "dandadan" --volume 13` against live mangakakalot.gg

## Reviewer notes

- Parser silently returns `[]` on DOM drift (selector miss). Convention from commit `15d8b88` is to throw `MangakakalotParseError` instead. Follow-up issue tracked separately — non-blocking for this PR but worth fixing for telemetry consistency.
- Fixtures are synthetic (banner comment in each file). Real captured HTML would harden against future site refactors. Worth replacing on a follow-up.
- For `all_external` + `--chapter <range>`, the new code path always fetches the manga page (extra round-trip vs. MangaDex aggregate). Acceptable trade-off — these series have empty aggregate anyway.

## Closes

Closes #65

### ✅ Checklist

- [x] Tested locally (gates green; manual e2e pending — see test plan)
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions (no classes, types in `types.ts`, factory functions, colocated tests, structured logger signature)
- [x] Docs updated in `docs/` (`docs/flows/download_flow.md`)