### PR TITLE
fix(fallback): restrict fallback volume mapping to --volume mode only (regression from #73)

### DIFF
--- a/docs/flows/download_flow.md
+++ b/docs/flows/download_flow.md
@@ -56,14 +56,17 @@ sequenceDiagram
         User->>CLI: 1
         CLI->>Fallback: search title → resolve slug
 
-        alt reason == all_external (Shueisha/MangaPlus partner titles, e.g. Dandadan, JJK, OPM)
-            Note over CLI,Fallback: MangaDex aggregate is empty for these titles.<br/>Source volume→chapter mapping from fallback site manga page.
+        alt reason == all_external AND --volume mode (Shueisha/MangaPlus partner titles)
+            Note over CLI,Fallback: MangaDex aggregate is empty for these titles.<br/>Source volume→chapter mapping from fallback site manga page (volumeMappingSource='fallback').
             CLI->>Fallback: GET /manga/<slug> (manga detail page)
             Fallback-->>CLI: HTML with "Vol.X Ch.Y" chapter list
             CLI->>CLI: parseVolumeMapping(html) → VolumeMap [{ volume, chapters[] }]
             Note over CLI: if VolumeMap is empty → CliError "use --chapter instead"<br/>if requested volume not in map → CliError with available volumes list
+        else reason == all_external AND --chapter mode
+            Note over CLI,Fallback: volumeMappingSource='mangadex' (uses JSON API, not HTML parser).<br/>getChapterList() is reliable for chapter lookups; getVolumeMap() (HTML) returns<br/>0 buckets for real Shueisha titles (selector drift / DMCA redirect).
+            CLI->>Fallback: GET /api/manga/<slug>/chapters → ChapterRef[]
         else reason == title_not_found OR no_chapters_in_lang
-            Note over CLI,Fallback: volume range sourced from MangaDex aggregate if available,<br/>otherwise user must pass --chapter manually
+            Note over CLI,Fallback: volume range sourced from MangaDex aggregate if available,<br/>otherwise user must pass --chapter manually (volumeMappingSource='mangadex')
             CLI->>Fallback: GET /api/manga/<slug>/chapters → ChapterRef[]
         end
 
@@ -99,7 +102,10 @@ All chapters belonging to a volume are merged into a single `.cbz` archive, sort
 2. **History writes are atomic per volume** — chapters are accumulated in memory while downloading; once the `.cbz` is renamed from `.temp` to its final path, all chapter rows are inserted in a single SQLite transaction. Either every chapter of the volume lands in history or none does — no orphan rows pointing at a volume archive that was never produced.
 3. **Preferred languages from config** — CLI only prompts for language selection when none of the user's `preferred_languages` (from `scanldr.json`) are available. If a preferred language is found, it is used silently.
 4. **User always picks fallback** — CLI never silently falls back to another site. Always warns and prompts.
-5. **Volume metadata source depends on fallback reason** — for `all_external` series (Shueisha/MangaPlus titles like Dandadan, JJK, OPM, Spy x Family), the MangaDex aggregate is empty. The CLI fetches the fallback site's manga detail page and parses the `Vol.X Ch.Y` chapter list as the authoritative volume→chapter mapping (`volumeMappingSource: 'fallback'`). For all other reasons (`title_not_found`, `no_chapters_in_lang`), MangaDex aggregate data is used when available (`volumeMappingSource: 'mangadex'`).
+5. **Volume metadata source depends on fallback reason AND mode** — `volumeMappingSource` is set as follows:
+   - `'fallback'` (HTML parser, `getVolumeMap`): only when reason is `all_external` **AND** `--volume` flag is set. The MangaDex aggregate is empty for these titles, so the CLI parses the fallback site manga page to map volumes → chapters.
+   - `'mangadex'` (JSON API, `getChapterList`): all other cases — including `--chapter` with `all_external`. `getVolumeMap` (HTML parser) returns 0 buckets for real Shueisha titles (Dandadan, JJK, Spy x Family) due to selector drift or DMCA redirects; `getChapterList` (JSON API) is stable and sufficient for chapter-mode lookups.
+   - **Invariant**: `volumeMappingSource='fallback'` with `--chapter` mode is explicitly forbidden and throws `CliError("Internal: chapter-mode with volumeMappingSource='fallback' is not supported...")`.
 6. **`--chapter` as escape hatch** — when volume metadata is unavailable, the user can pass `--chapter 18-21` manually.
 7. **One `.cbz` per volume** — all chapters in the volume are merged into a single archive.
 8. **Zero-padded image filenames** — pages saved as `0001.png`, `0002.png`, etc. to guarantee correct sort order in all CBZ readers.

--- a/src/commands/download/download.test.ts
+++ b/src/commands/download/download.test.ts
@@ -1175,6 +1175,122 @@ describe("fallback — all MangaDex chapters external (Dandadan/MangaPlus scenar
   });
 });
 
+// ---------------------------------------------------------------------------
+// AC#1 + AC#2: volumeMappingSource wiring for all_external
+// ---------------------------------------------------------------------------
+
+describe("runDownload — all_external + --chapter uses mangadex source (not fallback)", () => {
+  test("getVolumeMap NOT called, getChapterList IS called when --chapter + all_external", async () => {
+    const extCh = makeChapterRef({
+      id: "ch-ext",
+      volume: "1",
+      chapter: "112",
+      externalUrl: "https://mangaplus.shueisha.co.jp/viewer/1",
+    });
+
+    const clientAllExternal = makeClient({ feedChapters: async () => [extCh] });
+
+    let getVolumeMapCalled = false;
+    let getChapterListCalled = false;
+
+    const mkClientSpy: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => {
+        getChapterListCalled = true;
+        return [makeMkChapterRef({ id: "mk-112", chapter: "112" })];
+      },
+      getChapterImages: async (_id: string): Promise<ImageRef[]> => [
+        { url: "https://cdn.mk.gg/img/1.png", page: 1 },
+      ],
+      getVolumeMap: async () => {
+        getVolumeMapCalled = true;
+        return [];
+      },
+    };
+
+    try {
+      // Will throw CliError from non-TTY fallback site prompt — that's fine,
+      // we only care about which MK client methods were called before that.
+      await runDownload(
+        baseArgs({ volume: undefined, chapter: "112", nonTty: true }),
+        baseCtx(),
+        clientAllExternal,
+        makeFullHttpClient(),
+      );
+    } catch {
+      // expected: non-TTY fallback prompt throws CliError
+    }
+
+    // The call above hits non-TTY guard before reaching mkClient methods.
+    // We need to inject the mkClient — use runFallbackDownload directly to assert wiring.
+    // Reset and call runFallbackDownload with chapter mode + mangadex source.
+    getVolumeMapCalled = false;
+    getChapterListCalled = false;
+
+    try {
+      await runFallbackDownload({
+        args: baseArgs({ volume: undefined, chapter: "112", nonTty: true }),
+        ctx: baseCtx(),
+        mangadexResolve: null,
+        createFallbackHttp: async () => makeFallbackHttp(),
+        createMangakakalotClient: () => mkClientSpy,
+        volumeMappingSource: "mangadex", // the source set by runDownload for chapter mode
+        // biome-ignore lint/style/noNonNullAssertion: test stub
+        promptSite: async (sites) => sites[0]!,
+      });
+    } catch {
+      // may throw because mkChapters doesn't match — that's ok
+    }
+
+    expect(getVolumeMapCalled).toBe(false);
+    expect(getChapterListCalled).toBe(true);
+  });
+
+  test("getVolumeMap IS called when --volume + all_external", async () => {
+    let getVolumeMapCalled = false;
+    let getChapterListCalled = false;
+
+    const mkClientSpy: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => {
+        getChapterListCalled = true;
+        return [];
+      },
+      getChapterImages: async (_id: string): Promise<ImageRef[]> => [
+        { url: "https://cdn.mk.gg/img/1.png", page: 1 },
+      ],
+      getVolumeMap: async () => {
+        getVolumeMapCalled = true;
+        return [
+          { volume: "13", chapters: [{ id: "dandadan/chapter-128", chapter: "128" }] },
+        ];
+      },
+    };
+
+    try {
+      await runFallbackDownload({
+        args: baseArgs({ volume: "13", nonTty: true }),
+        ctx: baseCtx(),
+        mangadexResolve: null,
+        createFallbackHttp: async () => makeFallbackHttp(),
+        createMangakakalotClient: () => mkClientSpy,
+        volumeMappingSource: "fallback", // the source set by runDownload for --volume + all_external
+        // biome-ignore lint/style/noNonNullAssertion: test stub
+        promptSite: async (sites) => sites[0]!,
+      });
+    } catch {
+      // may throw because image fetch stub — that's ok
+    }
+
+    expect(getVolumeMapCalled).toBe(true);
+    expect(getChapterListCalled).toBe(false);
+  });
+});
+
 describe("fallback — non-TTY with title_not_found → CliError", () => {
   test("throws CliError pointing at auth and interactive use (--chapter mode)", async () => {
     const clientNoResults = makeClient({

--- a/src/commands/download/fallback.test.ts
+++ b/src/commands/download/fallback.test.ts
@@ -1017,6 +1017,60 @@ describe("runFallbackDownload calls pack flow when --pack is set and N>1", () =>
 });
 
 // ---------------------------------------------------------------------------
+// runFallbackDownload — chapter-mode + volumeMappingSource='fallback' is an invariant violation
+// ---------------------------------------------------------------------------
+
+describe("runFallbackDownload — chapter mode + volumeMappingSource='fallback' throws CliError", () => {
+  test("throws CliError with internal invariant message", async () => {
+    const db = openDb(":memory:");
+    runMigrations(db);
+
+    const fakeFallbackHttp: FallbackHttpClient = {
+      get: async () => new Response("", { status: 200 }),
+    };
+
+    const mkClientStub: MangakakalotClient = {
+      searchManga: async () => [
+        { id: "dandadan", title: "Dandadan", originalLanguage: "ja", year: 2021 },
+      ],
+      getChapterList: async () => [],
+      getVolumeMap: async () => [],
+      getChapterImages: async () => [],
+    };
+
+    const err = await runFallbackDownload({
+      args: baseArgs({ volume: undefined, chapter: "128" }),
+      ctx: {
+        logger: noopLogger,
+        config: {
+          preferred_languages: ["en"],
+          download_quality: "data",
+          default_format: "cbz",
+          default_out: "/tmp",
+          image_concurrency: 1,
+          chapter_delay_ms: 0,
+          db_path: ":memory:",
+        },
+        db,
+      },
+      mangadexResolve: null,
+      createFallbackHttp: async () => fakeFallbackHttp,
+      createMangakakalotClient: () => mkClientStub,
+      volumeMappingSource: "fallback",
+      // biome-ignore lint/style/noNonNullAssertion: test stub
+      promptSite: async (sites) => sites[0]!,
+    }).catch((e) => e);
+
+    db.close();
+
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).message).toContain("Internal");
+    expect((err as CliError).message).toContain("chapter-mode");
+    expect((err as CliError).message).toContain("volumeMappingSource='fallback'");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildFallbackBundlesFromVolumeMap — volume mode
 // ---------------------------------------------------------------------------
 

--- a/src/commands/download/fallback.ts
+++ b/src/commands/download/fallback.ts
@@ -437,6 +437,16 @@ export async function runFallbackDownload(opts: {
 
   let bundles: FallbackBundle[];
 
+  // Invariant: volumeMappingSource='fallback' is only valid when --volume is set.
+  // --chapter + 'fallback' is an internal caller error: getVolumeMap (HTML parser) is unreliable
+  // for real titles; getChapterList (JSON API) must be used for chapter mode.
+  if (volumeMappingSource === "fallback" && args.volume === undefined) {
+    throw new CliError(
+      "Internal: chapter-mode with volumeMappingSource='fallback' is not supported. Use volumeMappingSource='mangadex' for chapter mode.",
+      2,
+    );
+  }
+
   if (volumeMappingSource === "fallback") {
     // Source volume→chapter mapping from the fallback site manga page.
     logger.info(

--- a/src/commands/download/index.ts
+++ b/src/commands/download/index.ts
@@ -522,9 +522,12 @@ export async function runDownload(
       mangadexResolve,
       createFallbackHttp,
       createMangakakalotClient,
-      // For all_external series (Shueisha/MangaPlus titles), the MangaDex aggregate is empty.
-      // Source volume→chapter mapping from the fallback site manga page instead.
-      volumeMappingSource: eligibility.reason === "all_external" ? "fallback" : "mangadex",
+      // For all_external series (Shueisha/MangaPlus titles) in --volume mode, the MangaDex
+      // aggregate is empty so we source volume→chapter mapping from the fallback site manga page.
+      // In --chapter mode, keep the old path (getChapterList JSON API) which works correctly —
+      // getVolumeMap parses the HTML detail page which returns 0 buckets for real titles.
+      volumeMappingSource:
+        eligibility.reason === "all_external" && args.volume !== undefined ? "fallback" : "mangadex",
     });
   }
 


### PR DESCRIPTION
## What this PR does

**Hot fix for production regression introduced by PR #73.**

Restricts the new `volumeMappingSource: 'fallback'` path (HTML parser of mangakakalot's manga detail page) to `--volume <n>` mode only. For `--chapter <range>` on `all_external` series, restores the previously-working `mangadex` source path which falls through to mangakakalot's JSON API for chapter resolution.

Truth table after this PR:

| reason | mode | source |
|---|---|---|
| `all_external` | `--volume <n>` | `'fallback'` (parser) |
| `all_external` | `--chapter <range>` | `'mangadex'` (JSON API) ← restored |
| any other | any | `'mangadex'` (default) |

Plus a typed `CliError` guard in `runFallbackDownload` against the impossible combo (`volumeMappingSource: 'fallback'` + chapter mode) so callers fail fast if they accidentally rewire the contract.

## Why it exists

User repro on 2026-05-06 right after PR #73 merged:

```
$ scanldr download "dandadan" --chapter 112-120 --pack
... title resolved on fallback site ...
... fetching volume mapping from fallback site ...
warn chapter 112 not found on fallback site; skipping
warn chapter 113 not found on fallback site; skipping
... (all 9 missing — zero downloads)
```

Live diagnostic against real `mangakakalot.gg/manga/dandadan` showed: `200 OK`, 132KB HTML, **0 buckets parsed** by `parseVolumeMapping`. The selector `.row-content-chapter li` matches nothing on the real page (synthetic fixtures in PR #73 didn't reflect production HTML).

The same input (`dandadan --chapter 103-111`) worked an hour earlier — before #73 — because the OLD path called `mkClient.getChapterList(slug)` (JSON API) which returned the chapter list correctly. PR #73 rerouted chapter mode through the new HTML parser path, breaking it.

## How it works internally

- **`src/commands/download/index.ts:530`** — condition tightened from `reason === 'all_external'` to `reason === 'all_external' && args.volume !== undefined`. Chapter mode never gets `'fallback'`.
- **`src/commands/download/fallback.ts:443-448`** — guard placed BEFORE `getVolumeMap` call. Throws `CliError("Internal: chapter-mode with volumeMappingSource='fallback' is not supported. Use volumeMappingSource='mangadex' for chapter mode.")` if the impossible combo is ever wired again. Costs nothing on the happy paths.
- **Tests** in `download.test.ts`: `--volume + all_external` exercises the new path (asserts `getVolumeMap` called, `getChapterList` not); `--chapter + all_external` exercises the restored path (asserts the inverse).
- **`docs/flows/download_flow.md`** updated with the 4-cell branching truth table and an explicit invariant note.

## What did not change

- `parseVolumeMapping` itself — separate parser-drift issue (#75) tracks the real-HTML-vs-fixture mismatch
- `getChapterList` JSON API path — already worked, untouched
- Auth flow, pack flow, MangaDex pipeline — all unaffected
- `--volume <n>` for non-`all_external` series — same default `'mangadex'` source as before

## Test checklist

- [x] `bun test` — 487 pass / 0 fail (was 484, +3 new tests)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — biome clean
- [x] `--chapter + all_external` integration test asserts JSON API path
- [x] `--volume + all_external` integration test asserts new parser path (preserved from #73)
- [x] CliError invariant test for the impossible combo
- [x] All 484 pre-existing tests still pass
- [ ] Manual smoke: `pbpaste | scanldr auth` then `scanldr download "dandadan" --chapter 112-120 --pack` — should download 9 chapters + pack (assuming chapters exist on mangakakalot.gg)

## Reviewer notes

- The remaining `--volume <n>` path for `all_external` is **also broken** in production today because of the parser-drift (issue #75). Fixing that is non-trivial — needs real captured HTML and a new selector strategy. This PR doesn't try to fix it; it just stops `--chapter` mode from being collateral damage.
- Inspector flagged P2: the integration test for `--chapter + all_external` doesn't directly exercise the conditional in `runDownload` — it asserts the downstream behavior of `runFallbackDownload`. Acceptable since the conditional itself is one ternary, but a more direct test could be added in a follow-up.

## Closes

Refs #73 (introduced regression), #75 (follow-up parser-drift fix)

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions (typed `CliError`, no new classes, factory functions, logger signature, colocated tests)
- [x] Docs updated in `docs/` (`docs/flows/download_flow.md`)