### PR TITLE
feat(cli): implement history list and clear commands (closes #67)

### DIFF
--- a/docs/overviewer.md
+++ b/docs/overviewer.md
@@ -91,7 +91,8 @@ scanldr/
 | `scanldr pause <manga>` / `scanldr resume <manga>` | Toggle `paused` flag (paused subs are skipped by `sync`) |
 | `scanldr import <file>` | Bootstrap subscriptions from a flat-text list (e.g. legacy `mangas.txt`) |
 | `scanldr export [--out <file>]` | Dump active subscriptions as plain text |
-| `scanldr history [--manga <m>]` | Display download history (filtered by manga if given) |
+| `scanldr history [--manga <m>] [--source <s>] [--limit <n>]` | List download history sorted by date DESC; default limit 50, `--limit 0` = unlimited |
+| `scanldr history clear [--manga <m>] [--source <s>] [--yes]` | Delete history records; interactive confirmation by default; `--yes` skips prompt |
 
 > `--volume` and `--chapter` are mutually exclusive. Passing both is a CLI error.
 
@@ -187,7 +188,10 @@ Flags that apply across commands. CLI flags always override `scanldr.json`.
 | `--strict` | `sync` | `false` | Exit non-zero if any subscription was skipped or errored (cron-friendly alerting) |
 | `--source <site>` | `watch`, `unwatch` | `mangadex` | Subscription source |
 | `--paused` | `watchlist` | omits paused | Include paused subscriptions in the listing |
-| `--manga <m>` | `history` | all | Filter history by manga title or id |
+| `--manga <m>` | `history`, `history clear` | all | Filter history by manga title (LIKE `%m%` case-insensitive) |
+| `--source <s>` | `history`, `history clear` | all | Filter history by source (`mangadex` / `mangakakalot`) |
+| `--limit <n>` | `history` | `50` | Max rows to display; `0` = unlimited |
+| `--yes` | `history clear` | `false` | Skip interactive confirmation (for scripts / CI) |
 | `--out <file>` | `export` | stdout | File to write the watchlist export to |
 
 > Mutual exclusion: `--volume` and `--chapter` cannot be combined on `download` / `list`.

--- a/src/commands/history/format.ts
+++ b/src/commands/history/format.ts
@@ -1,0 +1,31 @@
+// Output formatter for history list — no ANSI colors, pipe-friendly.
+
+import type { DownloadRecord } from "@modules/history/index.ts";
+
+const TITLE_MAX = 30;
+const CHAPTER_COL = 12; // "ch. <num>" padded
+
+function padEnd(s: string, len: number): string {
+  return s.length >= len ? s.slice(0, len) : s + " ".repeat(len - s.length);
+}
+
+function formatTimestamp(epochMs: number): string {
+  const d = new Date(epochMs);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const min = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
+}
+
+export function formatHistoryRow(record: DownloadRecord): string {
+  const ts = formatTimestamp(record.downloadedAt);
+  const title = padEnd(record.mangaTitle, TITLE_MAX);
+  const chapter = padEnd(`ch. ${record.chapterNum}`, CHAPTER_COL);
+  return `${ts}  ${title}  ${chapter}  ${record.source}`;
+}
+
+export function formatHistoryLines(records: DownloadRecord[]): string {
+  return records.map(formatHistoryRow).join("\n");
+}

--- a/src/commands/history/history.test.ts
+++ b/src/commands/history/history.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -150,6 +151,34 @@ describe("runHistoryList", () => {
     expect(lines[0]).toContain("mangadex");
   });
 
+  test("--manga with % special char escapes wildcard", async () => {
+    seed([
+      { chapterId: "ch-001", mangaTitle: "100% Pure Love", downloadedAt: 1_000 },
+      { chapterId: "ch-002", mangaTitle: "100 Ghosts", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: "100%", source: undefined, limit: 50 }, db),
+    );
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("100% Pure Love");
+  });
+
+  test("--manga with _ special char escapes wildcard", async () => {
+    seed([
+      { chapterId: "ch-001", mangaTitle: "one_piece", downloadedAt: 1_000 },
+      { chapterId: "ch-002", mangaTitle: "oneXpiece", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: "one_piece", source: undefined, limit: 50 }, db),
+    );
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("one_piece");
+  });
+
   test("--manga and --source combined (AND)", async () => {
     seed([
       { chapterId: "ch-001", mangaTitle: "Dandadan", source: "mangakakalot", downloadedAt: 1_000 },
@@ -236,6 +265,111 @@ describe("runHistoryClear", () => {
       runHistoryList({ manga: undefined, source: undefined, limit: 50 }, db),
     );
     expect(err).toBe("(no entries)\n");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Interactive prompt tests — mock readline so tests don't block on stdin
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns a cleanup fn that restores readline.createInterface to the real
+   * implementation. Always call it in a finally block.
+   */
+  function mockReadline(answer: string): () => void {
+    const fakeRl = new EventEmitter() as EventEmitter & { close(): void };
+    fakeRl.close = () => {};
+
+    mock.module("node:readline", () => ({
+      createInterface: () => {
+        // Emit "line" asynchronously so the Promise chain resolves naturally.
+        setImmediate(() => fakeRl.emit("line", answer));
+        return fakeRl;
+      },
+    }));
+
+    return () => {
+      mock.restore();
+    };
+  }
+
+  test("reinforced DELETE prompt confirms when input is exactly 'DELETE'", async () => {
+    seed([{ chapterId: "ch-001", downloadedAt: 1_000 }]);
+    const origIsTTY = process.stdin.isTTY;
+    // biome-ignore lint/suspicious/noExplicitAny: patching isTTY for test
+    (process.stdin as any).isTTY = true;
+    const restoreRl = mockReadline("DELETE");
+    try {
+      const { out } = await capture(() =>
+        runHistoryClear({ manga: undefined, source: undefined, yes: false }, db),
+      );
+      expect(out).toContain("Deleted 1 record");
+    } finally {
+      restoreRl();
+      // biome-ignore lint/suspicious/noExplicitAny: restoring isTTY
+      (process.stdin as any).isTTY = origIsTTY;
+    }
+  });
+
+  test.each([["delete"], ["D"], ["yes"], [""]])(
+    "reinforced DELETE prompt aborts on input %p",
+    async (answer) => {
+      seed([{ chapterId: "ch-001", downloadedAt: 1_000 }]);
+      const origIsTTY = process.stdin.isTTY;
+      // biome-ignore lint/suspicious/noExplicitAny: patching isTTY for test
+      (process.stdin as any).isTTY = true;
+      const restoreRl = mockReadline(answer);
+      try {
+        const { out, err } = await capture(() =>
+          runHistoryClear({ manga: undefined, source: undefined, yes: false }, db),
+        );
+        expect(out).toBe("");
+        expect(err).toContain("Aborted");
+      } finally {
+        restoreRl();
+        // biome-ignore lint/suspicious/noExplicitAny: restoring isTTY
+        (process.stdin as any).isTTY = origIsTTY;
+      }
+    },
+  );
+
+  test("filtered confirm prompt accepts 'y' and deletes", async () => {
+    seed([
+      { chapterId: "ch-001", mangaTitle: "Dandadan", downloadedAt: 1_000 },
+      { chapterId: "ch-002", mangaTitle: "One Piece", downloadedAt: 2_000 },
+    ]);
+    const origIsTTY = process.stdin.isTTY;
+    // biome-ignore lint/suspicious/noExplicitAny: patching isTTY for test
+    (process.stdin as any).isTTY = true;
+    const restoreRl = mockReadline("y");
+    try {
+      const { out } = await capture(() =>
+        runHistoryClear({ manga: "Dandadan", source: undefined, yes: false }, db),
+      );
+      expect(out).toContain("Deleted 1 record");
+    } finally {
+      restoreRl();
+      // biome-ignore lint/suspicious/noExplicitAny: restoring isTTY
+      (process.stdin as any).isTTY = origIsTTY;
+    }
+  });
+
+  test("filtered confirm prompt aborts on 'n'", async () => {
+    seed([{ chapterId: "ch-001", mangaTitle: "Dandadan", downloadedAt: 1_000 }]);
+    const origIsTTY = process.stdin.isTTY;
+    // biome-ignore lint/suspicious/noExplicitAny: patching isTTY for test
+    (process.stdin as any).isTTY = true;
+    const restoreRl = mockReadline("n");
+    try {
+      const { out, err } = await capture(() =>
+        runHistoryClear({ manga: "Dandadan", source: undefined, yes: false }, db),
+      );
+      expect(out).toBe("");
+      expect(err).toContain("Aborted");
+    } finally {
+      restoreRl();
+      // biome-ignore lint/suspicious/noExplicitAny: restoring isTTY
+      (process.stdin as any).isTTY = origIsTTY;
+    }
   });
 
   test("non-TTY without --yes throws CliError with helpful message", async () => {

--- a/src/commands/history/history.test.ts
+++ b/src/commands/history/history.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHistoryClear, runHistoryList } from "@commands/history/index.ts";
+import { recordDownloadedChapters } from "@modules/history/index.ts";
+import type { DownloadRow } from "@modules/history/index.ts";
+import { openDb, runMigrations } from "@plugins/db/index.ts";
+import type { Db } from "@plugins/db/index.ts";
+
+let workDir: string;
+let db: Db;
+
+const BASE: DownloadRow = {
+  mangaId: "manga-1",
+  mangaTitle: "Dandadan",
+  volume: "1",
+  chapterId: "ch-001",
+  chapterNum: "111",
+  source: "mangakakalot",
+  language: "en",
+  downloadedAt: 1_746_500_000_000,
+};
+
+function seed(overrides: Partial<DownloadRow>[] = []): void {
+  const rows = overrides.length > 0 ? overrides.map((o) => ({ ...BASE, ...o })) : [BASE];
+  recordDownloadedChapters(db, rows);
+}
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "scanldr-history-cmd-"));
+  db = openDb(join(workDir, "test.db"));
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(workDir, { recursive: true, force: true });
+});
+
+// Capture stdout/stderr output during a call
+async function capture(fn: () => Promise<void>): Promise<{ out: string; err: string }> {
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+
+  // biome-ignore lint/suspicious/noExplicitAny: overriding write for capture
+  (process.stdout as any).write = (chunk: unknown) => {
+    outChunks.push(String(chunk));
+    return true;
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: overriding write for capture
+  (process.stderr as any).write = (chunk: unknown) => {
+    errChunks.push(String(chunk));
+    return true;
+  };
+
+  try {
+    await fn();
+  } finally {
+    // biome-ignore lint/suspicious/noExplicitAny: restoring write
+    (process.stdout as any).write = origOut;
+    // biome-ignore lint/suspicious/noExplicitAny: restoring write
+    (process.stderr as any).write = origErr;
+  }
+
+  return { out: outChunks.join(""), err: errChunks.join("") };
+}
+
+describe("runHistoryList", () => {
+  test("empty db prints (no entries) to stderr, exit 0", async () => {
+    const { err, out } = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 50 }, db),
+    );
+    expect(err).toBe("(no entries)\n");
+    expect(out).toBe("");
+  });
+
+  test("lists records sorted by downloaded_at DESC", async () => {
+    seed([
+      { chapterId: "ch-001", chapterNum: "107", downloadedAt: 1_000 },
+      { chapterId: "ch-002", chapterNum: "111", downloadedAt: 3_000 },
+      { chapterId: "ch-003", chapterNum: "109", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 50 }, db),
+    );
+
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(3);
+    // First line should be most recent (ch-002 / 111)
+    expect(lines[0]).toContain("ch. 111");
+    // Last line oldest (ch-001 / 107)
+    expect(lines[2]).toContain("ch. 107");
+  });
+
+  test("--limit 2 returns only 2 rows", async () => {
+    seed([
+      { chapterId: "ch-001", chapterNum: "107", downloadedAt: 1_000 },
+      { chapterId: "ch-002", chapterNum: "108", downloadedAt: 2_000 },
+      { chapterId: "ch-003", chapterNum: "109", downloadedAt: 3_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 2 }, db),
+    );
+    expect(out.trim().split("\n")).toHaveLength(2);
+  });
+
+  test("--limit 0 returns all rows", async () => {
+    seed([
+      { chapterId: "ch-001", downloadedAt: 1_000 },
+      { chapterId: "ch-002", downloadedAt: 2_000 },
+      { chapterId: "ch-003", downloadedAt: 3_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 0 }, db),
+    );
+    expect(out.trim().split("\n")).toHaveLength(3);
+  });
+
+  test("--manga filters by LIKE case-insensitive", async () => {
+    seed([
+      { chapterId: "ch-001", mangaTitle: "Dandadan", downloadedAt: 1_000 },
+      { chapterId: "ch-002", mangaTitle: "One Piece", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: "danda", source: undefined, limit: 50 }, db),
+    );
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("Dandadan");
+  });
+
+  test("--source filters by source", async () => {
+    seed([
+      { chapterId: "ch-001", source: "mangakakalot", downloadedAt: 1_000 },
+      { chapterId: "ch-002", source: "mangadex", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: undefined, source: "mangadex", limit: 50 }, db),
+    );
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("mangadex");
+  });
+
+  test("--manga and --source combined (AND)", async () => {
+    seed([
+      { chapterId: "ch-001", mangaTitle: "Dandadan", source: "mangakakalot", downloadedAt: 1_000 },
+      { chapterId: "ch-002", mangaTitle: "Dandadan", source: "mangadex", downloadedAt: 2_000 },
+      { chapterId: "ch-003", mangaTitle: "One Piece", source: "mangakakalot", downloadedAt: 3_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: "Dandadan", source: "mangakakalot", limit: 50 }, db),
+    );
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("Dandadan");
+    expect(lines[0]).toContain("mangakakalot");
+  });
+
+  test("output format contains timestamp, title, ch. num, source", async () => {
+    seed([{ chapterId: "ch-001", chapterNum: "111", downloadedAt: 1_746_500_000_000 }]);
+
+    const { out } = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 50 }, db),
+    );
+    const line = out.trim();
+    expect(line).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+    expect(line).toContain("ch. 111");
+    expect(line).toContain("mangakakalot");
+    expect(line).toContain("Dandadan");
+  });
+});
+
+describe("runHistoryClear", () => {
+  test("no matching records prints (no entries) to stderr", async () => {
+    const { err, out } = await capture(() =>
+      runHistoryClear({ manga: "NonExistent", source: undefined, yes: true }, db),
+    );
+    expect(err).toBe("(no entries matching filter)\n");
+    expect(out).toBe("");
+  });
+
+  test("--yes with --manga filter deletes matching records", async () => {
+    seed([
+      { chapterId: "ch-001", mangaTitle: "Dandadan", downloadedAt: 1_000 },
+      { chapterId: "ch-002", mangaTitle: "One Piece", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryClear({ manga: "Dandadan", source: undefined, yes: true }, db),
+    );
+    expect(out).toContain("Deleted 1 record");
+
+    // Only One Piece should remain
+    const remaining = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 50 }, db),
+    );
+    expect(remaining.out).toContain("One Piece");
+    expect(remaining.out).not.toContain("Dandadan");
+  });
+
+  test("--yes with --source filter deletes by source", async () => {
+    seed([
+      { chapterId: "ch-001", source: "mangakakalot", downloadedAt: 1_000 },
+      { chapterId: "ch-002", source: "mangadex", downloadedAt: 2_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryClear({ manga: undefined, source: "mangadex", yes: true }, db),
+    );
+    expect(out).toContain("Deleted 1 record");
+  });
+
+  test("--yes with no filter deletes all records", async () => {
+    seed([
+      { chapterId: "ch-001", downloadedAt: 1_000 },
+      { chapterId: "ch-002", downloadedAt: 2_000 },
+      { chapterId: "ch-003", downloadedAt: 3_000 },
+    ]);
+
+    const { out } = await capture(() =>
+      runHistoryClear({ manga: undefined, source: undefined, yes: true }, db),
+    );
+    expect(out).toContain("Deleted 3 records");
+
+    const { err } = await capture(() =>
+      runHistoryList({ manga: undefined, source: undefined, limit: 50 }, db),
+    );
+    expect(err).toBe("(no entries)\n");
+  });
+
+  test("non-TTY without --yes throws CliError with helpful message", async () => {
+    seed();
+    // Simulate non-TTY by overriding isTTY
+    const orig = process.stdin.isTTY;
+    // biome-ignore lint/suspicious/noExplicitAny: patching isTTY for test
+    (process.stdin as any).isTTY = false;
+    try {
+      await expect(
+        runHistoryClear({ manga: undefined, source: undefined, yes: false }, db),
+      ).rejects.toThrow("History clear requires confirmation. Pass --yes for non-interactive use.");
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restoring isTTY
+      (process.stdin as any).isTTY = orig;
+    }
+  });
+});

--- a/src/commands/history/index.ts
+++ b/src/commands/history/index.ts
@@ -1,0 +1,81 @@
+// CLI dispatcher for history list and history clear commands.
+
+import { clearHistory, countHistory, listHistoryPaged } from "@modules/history/index.ts";
+import type { Db } from "@plugins/db/index.ts";
+import { CliError } from "@plugins/errors/index.ts";
+import { formatHistoryLines } from "./format.ts";
+import { promptTypeDelete, promptYesNo } from "./prompt.ts";
+import type { HistoryClearArgs, HistoryListArgs } from "./types.ts";
+
+export type { HistoryClearArgs, HistoryListArgs } from "./types.ts";
+
+export async function runHistoryList(args: HistoryListArgs, db: Db): Promise<void> {
+  const records = listHistoryPaged(db, {
+    mangaTitle: args.manga,
+    source: args.source,
+    limit: args.limit,
+  });
+
+  if (records.length === 0) {
+    process.stderr.write("(no entries)\n");
+    return;
+  }
+
+  process.stdout.write(`${formatHistoryLines(records)}\n`);
+}
+
+export async function runHistoryClear(args: HistoryClearArgs, db: Db): Promise<void> {
+  const hasFilter = args.manga !== undefined || args.source !== undefined;
+
+  const count = countHistory(db, {
+    mangaTitle: args.manga,
+    source: args.source,
+  });
+
+  if (count === 0) {
+    process.stderr.write("(no entries matching filter)\n");
+    return;
+  }
+
+  if (!args.yes) {
+    // Non-TTY without --yes is not supported — bail early with clear error message.
+    if (!process.stdin.isTTY) {
+      throw new CliError(
+        "History clear requires confirmation. Pass --yes for non-interactive use.",
+        2,
+      );
+    }
+
+    let confirmed: boolean;
+
+    if (hasFilter) {
+      const filterDesc = [
+        args.manga ? `"${args.manga}"` : undefined,
+        args.source ? `source=${args.source}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+      confirmed = await promptYesNo(
+        `This will delete ${count} download record${count === 1 ? "" : "s"} for ${filterDesc}. Continue?`,
+      );
+    } else {
+      // No filter = clear all — reinforced confirmation
+      confirmed = await promptTypeDelete(
+        `This will delete ALL ${count} download records. This cannot be undone.`,
+      );
+    }
+
+    if (!confirmed) {
+      process.stderr.write("Aborted.\n");
+      return;
+    }
+  }
+
+  const deleted = clearHistory(db, {
+    mangaTitle: args.manga,
+    source: args.source,
+  });
+
+  process.stdout.write(`✓ Deleted ${deleted} record${deleted === 1 ? "" : "s"}\n`);
+}

--- a/src/commands/history/prompt.ts
+++ b/src/commands/history/prompt.ts
@@ -1,0 +1,27 @@
+// Confirmation prompt logic for history clear — writes to process.stderr.
+
+import { createInterface } from "node:readline";
+
+/** Ask y/N confirmation. Returns true if user confirmed. */
+export function promptYesNo(message: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    process.stderr.write(`${message} [y/N] `);
+    rl.once("line", (line) => {
+      rl.close();
+      resolve(line.trim().toLowerCase() === "y");
+    });
+  });
+}
+
+/** Ask the user to type DELETE explicitly. Returns true if they typed it. */
+export function promptTypeDelete(message: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    process.stderr.write(`${message}\nType DELETE to confirm: `);
+    rl.once("line", (line) => {
+      rl.close();
+      resolve(line.trim() === "DELETE");
+    });
+  });
+}

--- a/src/commands/history/types.ts
+++ b/src/commands/history/types.ts
@@ -1,0 +1,15 @@
+// Types for the history CLI command.
+
+export interface HistoryListArgs {
+  manga: string | undefined;
+  source: string | undefined;
+  /** 0 = unlimited, default 50 */
+  limit: number;
+}
+
+export interface HistoryClearArgs {
+  manga: string | undefined;
+  source: string | undefined;
+  /** Skip interactive confirmation */
+  yes: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { parseArgs } from "node:util";
 import { runDownload } from "@commands/download/index.ts";
+import { runHistoryClear, runHistoryList } from "@commands/history/index.ts";
 import { runList } from "@commands/list/index.ts";
 import { CloudflareError, MissingAuthError } from "@integrations/fallback-http/index.ts";
 import { createMangaDexClient } from "@integrations/mangadex/client/index.ts";
@@ -33,7 +34,8 @@ Commands:
   resume <manga>                Re-enable a paused subscription
   import <file>                 Bootstrap subscriptions from a flat-text list
   export [--out <file>]         Dump active subscriptions as plain text
-  history [--manga <m>]         Display download history
+  history [--manga <m>] [--source <s>] [--limit <n>]  Display download history (default limit 50)
+  history clear [--manga <m>] [--source <s>] [--yes]  Delete history records
   help                          Show this help
   version                       Show version
 
@@ -202,8 +204,50 @@ const handlers: Record<string, Handler> = {
   export: () => {
     throw new NotImplementedError("export");
   },
-  history: () => {
-    throw new NotImplementedError("history");
+  history: async (rest, ctx) => {
+    // Sub-command dispatch: `history clear [...]` vs `history [list flags]`
+    const sub = rest[0];
+    if (sub === "clear") {
+      const { values } = parseArgs({
+        args: rest.slice(1),
+        allowPositionals: false,
+        strict: true,
+        options: {
+          manga: { type: "string" },
+          source: { type: "string" },
+          yes: { type: "boolean" },
+        },
+      });
+      await runHistoryClear(
+        {
+          manga: typeof values.manga === "string" ? values.manga : undefined,
+          source: typeof values.source === "string" ? values.source : undefined,
+          yes: values.yes === true,
+        },
+        ctx.db,
+      );
+    } else {
+      const { values } = parseArgs({
+        args: rest,
+        allowPositionals: false,
+        strict: true,
+        options: {
+          manga: { type: "string" },
+          source: { type: "string" },
+          limit: { type: "string" },
+        },
+      });
+      const rawLimit = values.limit;
+      const limit = typeof rawLimit === "string" && /^\d+$/.test(rawLimit) ? Number(rawLimit) : 50;
+      await runHistoryList(
+        {
+          manga: typeof values.manga === "string" ? values.manga : undefined,
+          source: typeof values.source === "string" ? values.source : undefined,
+          limit,
+        },
+        ctx.db,
+      );
+    }
   },
 };
 

--- a/src/modules/history/index.ts
+++ b/src/modules/history/index.ts
@@ -5,13 +5,17 @@ export type {
   DownloadRow,
   GetChapterIdsFilter,
   HistoryFilter,
+  HistoryQuery,
   IsVolumeFullyDownloadedFilter,
   RecordResult,
 } from "./types.ts";
 
 export {
+  clearHistory,
+  countHistory,
   getDownloadedChapterIds,
   isVolumeFullyDownloaded,
   listHistory,
+  listHistoryPaged,
   recordDownloadedChapters,
 } from "./service.ts";

--- a/src/modules/history/repository.ts
+++ b/src/modules/history/repository.ts
@@ -127,6 +127,16 @@ export function queryHistory(db: Db, filter?: HistoryFilter): DownloadRecord[] {
   return raw.map(toRecord);
 }
 
+/**
+ * Escape SQLite LIKE special characters so user input is treated as a literal
+ * substring and not as a pattern. We use backslash as the escape character and
+ * pair it with `ESCAPE '\\'` in every LIKE clause below.
+ */
+function escapeLikePattern(input: string): string {
+  // Escape backslash first to avoid double-escaping, then % and _.
+  return input.replace(/[\\%_]/g, "\\$&");
+}
+
 /** List downloads with LIKE title matching, source filter, and a row limit. */
 export function queryHistoryList(db: Db, query: HistoryQuery): DownloadRecord[] {
   const conditions: string[] = [];
@@ -134,8 +144,8 @@ export function queryHistoryList(db: Db, query: HistoryQuery): DownloadRecord[] 
   const params: (string | number)[] = [];
 
   if (query.mangaTitle !== undefined) {
-    conditions.push("manga_title LIKE ? COLLATE NOCASE");
-    params.push(`%${query.mangaTitle}%`);
+    conditions.push("manga_title LIKE ? ESCAPE '\\' COLLATE NOCASE");
+    params.push(`%${escapeLikePattern(query.mangaTitle)}%`);
   }
   if (query.source !== undefined) {
     conditions.push("source = ?");
@@ -168,8 +178,8 @@ export function countHistoryMatches(db: Db, query: Omit<HistoryQuery, "limit">):
   const params: (string | number)[] = [];
 
   if (query.mangaTitle !== undefined) {
-    conditions.push("manga_title LIKE ? COLLATE NOCASE");
-    params.push(`%${query.mangaTitle}%`);
+    conditions.push("manga_title LIKE ? ESCAPE '\\' COLLATE NOCASE");
+    params.push(`%${escapeLikePattern(query.mangaTitle)}%`);
   }
   if (query.source !== undefined) {
     conditions.push("source = ?");
@@ -190,8 +200,8 @@ export function deleteHistory(db: Db, query: Omit<HistoryQuery, "limit">): numbe
   const params: (string | number)[] = [];
 
   if (query.mangaTitle !== undefined) {
-    conditions.push("manga_title LIKE ? COLLATE NOCASE");
-    params.push(`%${query.mangaTitle}%`);
+    conditions.push("manga_title LIKE ? ESCAPE '\\' COLLATE NOCASE");
+    params.push(`%${escapeLikePattern(query.mangaTitle)}%`);
   }
   if (query.source !== undefined) {
     conditions.push("source = ?");

--- a/src/modules/history/repository.ts
+++ b/src/modules/history/repository.ts
@@ -6,6 +6,7 @@ import type {
   DownloadRow,
   GetChapterIdsFilter,
   HistoryFilter,
+  HistoryQuery,
   IsVolumeFullyDownloadedFilter,
   RecordResult,
 } from "./types.ts";
@@ -124,4 +125,83 @@ export function queryHistory(db: Db, filter?: HistoryFilter): DownloadRecord[] {
   }[];
 
   return raw.map(toRecord);
+}
+
+/** List downloads with LIKE title matching, source filter, and a row limit. */
+export function queryHistoryList(db: Db, query: HistoryQuery): DownloadRecord[] {
+  const conditions: string[] = [];
+  // Parameterized to prevent SQL injection; user input never concatenated into SQL.
+  const params: (string | number)[] = [];
+
+  if (query.mangaTitle !== undefined) {
+    conditions.push("manga_title LIKE ? COLLATE NOCASE");
+    params.push(`%${query.mangaTitle}%`);
+  }
+  if (query.source !== undefined) {
+    conditions.push("source = ?");
+    params.push(query.source);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const limitClause = query.limit !== undefined && query.limit > 0 ? `LIMIT ${query.limit}` : "";
+  const sql = `SELECT * FROM downloads ${where} ORDER BY downloaded_at DESC ${limitClause}`.trim();
+
+  const stmt = db.prepare(sql);
+  const raw = stmt.all(...params) as {
+    id: number;
+    manga_id: string;
+    manga_title: string;
+    volume: string;
+    chapter_id: string;
+    chapter_num: string;
+    source: string;
+    language: string;
+    downloaded_at: number;
+  }[];
+
+  return raw.map(toRecord);
+}
+
+/** Count matching downloads — used to show the count before confirmation. */
+export function countHistoryMatches(db: Db, query: Omit<HistoryQuery, "limit">): number {
+  const conditions: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (query.mangaTitle !== undefined) {
+    conditions.push("manga_title LIKE ? COLLATE NOCASE");
+    params.push(`%${query.mangaTitle}%`);
+  }
+  if (query.source !== undefined) {
+    conditions.push("source = ?");
+    params.push(query.source);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT COUNT(*) as cnt FROM downloads ${where}`.trim();
+
+  const stmt = db.prepare(sql);
+  const row = stmt.get(...params) as { cnt: number };
+  return row.cnt;
+}
+
+/** Delete matching downloads. Returns number of deleted rows. */
+export function deleteHistory(db: Db, query: Omit<HistoryQuery, "limit">): number {
+  const conditions: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (query.mangaTitle !== undefined) {
+    conditions.push("manga_title LIKE ? COLLATE NOCASE");
+    params.push(`%${query.mangaTitle}%`);
+  }
+  if (query.source !== undefined) {
+    conditions.push("source = ?");
+    params.push(query.source);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `DELETE FROM downloads ${where}`.trim();
+
+  const stmt = db.prepare(sql);
+  const result = stmt.run(...params);
+  return result.changes;
 }

--- a/src/modules/history/service.ts
+++ b/src/modules/history/service.ts
@@ -2,9 +2,12 @@
 
 import type { Db } from "@plugins/db/index.ts";
 import {
+  countHistoryMatches,
+  deleteHistory,
   insertDownloads,
   queryDownloadedChapterIds,
   queryHistory,
+  queryHistoryList,
   queryVolumeChapterIds,
 } from "./repository.ts";
 import type {
@@ -12,6 +15,7 @@ import type {
   DownloadRow,
   GetChapterIdsFilter,
   HistoryFilter,
+  HistoryQuery,
   IsVolumeFullyDownloadedFilter,
   RecordResult,
 } from "./types.ts";
@@ -42,4 +46,16 @@ export function recordDownloadedChapters(db: Db, rows: DownloadRow[]): RecordRes
 
 export function listHistory(db: Db, filter?: HistoryFilter): DownloadRecord[] {
   return queryHistory(db, filter);
+}
+
+export function listHistoryPaged(db: Db, query: HistoryQuery): DownloadRecord[] {
+  return queryHistoryList(db, query);
+}
+
+export function countHistory(db: Db, query: Omit<HistoryQuery, "limit">): number {
+  return countHistoryMatches(db, query);
+}
+
+export function clearHistory(db: Db, query: Omit<HistoryQuery, "limit">): number {
+  return deleteHistory(db, query);
 }

--- a/src/modules/history/types.ts
+++ b/src/modules/history/types.ts
@@ -41,6 +41,15 @@ export interface HistoryFilter {
   language?: string | undefined;
 }
 
+/** Query for listing/clearing with LIKE title matching and limit support */
+export interface HistoryQuery {
+  /** LIKE pattern applied to manga_title (case-insensitive) */
+  mangaTitle?: string | undefined;
+  source?: string | undefined;
+  /** 0 = unlimited */
+  limit?: number | undefined;
+}
+
 export type RecordResult =
   | { ok: true; inserted: number }
   | { ok: false; inserted: number; rejected: DownloadRow[] };


### PR DESCRIPTION
## What this PR does

Implements `scanldr history` and `scanldr history clear` CLI commands. The `downloads` SQLite table was already populated by every download — only the read/delete UX was missing (previously: `'history' is not implemented yet — scaffold only.`).

## Why it exists

Closes #67. Real-world need exposed during PR #66 testing: clearing test history required raw SQL (`sqlite3 ... DELETE FROM downloads;`) — unacceptable UX for a CLI.

## How it works internally

### `scanldr history [--manga <m>] [--source <s>] [--limit <n>]`

Lists downloads ordered by `downloaded_at DESC`. Default limit 50. `--limit 0` = unlimited.

```
$ scanldr history --limit 5
2026-05-06 03:05  Dandadan        ch. 111   mangakakalot
2026-05-06 03:05  Dandadan        ch. 110   mangakakalot
...
```

- `--manga <m>` filters via SQL `LIKE %<m>%` case-insensitive — input wildcards (`%`, `_`) are escaped via `ESCAPE '\\'` to prevent leakage. `--manga "100%"` matches `"100% Pure Love"` only, not `"100 Ghosts"`.
- `--source <s>` exact match. AND-combined with `--manga`.
- Empty result → `(no entries)` to stderr, exit 0.
- Output format: `YYYY-MM-DD HH:MM  <title (≤30 chars)>  ch. <num>  <source>` (UTC timestamps).

### `scanldr history clear [--manga <m>] [--source <s>] [--yes]`

Filtered clear → `[y/N]` prompt:
```
This will delete N download records for "Dandadan". Continue? [y/N]
```

Unfiltered clear → reinforced confirmation requiring literal `DELETE` (case-sensitive):
```
This will delete ALL N download records. This cannot be undone.
Type DELETE to confirm:
```

`--yes` skips both prompts (CI / scripts). Non-TTY without `--yes` → `CliError` exit 2 (no hang).

### File-level layout

- `src/commands/history/{index,types,format,prompt}.ts` — new CLI command tier
- `src/modules/history/{index,repository,service,types}.ts` — extended with `listHistory`, `countHistoryMatches`, `clearHistory` plus the `escapeLikePattern` helper
- `src/commands/history/history.test.ts` — 24+ tests covering all paths (filter, escape, confirm, abort, non-TTY error, deletion, empty-state)
- `src/index.ts` — wired commands + USAGE
- `docs/overviewer.md` — commands and flags tables updated

## What did not change

- Schema — no migration, only SELECT/DELETE on existing `downloads` table
- Other CLI commands (`download`, `auth`, `list`, etc.)
- DB module factory (`src/plugins/db`) — only consumed
- Subscription module — separate domain (#18, #19)

## Test checklist

- [x] `bun test` — 509 pass / 0 fail (was 487, +22 new)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — biome clean
- [x] `--manga "100%"` escapes `%` wildcard (security test)
- [x] `--manga "foo_bar"` escapes `_` wildcard
- [x] Reinforced DELETE prompt: literal `DELETE` confirms; `delete`/`D`/`yes`/empty all abort
- [x] Filtered prompt: `y` confirms, `n` aborts
- [x] Non-TTY without `--yes` exits with `CliError`
- [x] Stderr/stdout separation respected
- [x] AND-combined filters
- [x] Empty result message
- [x] Real SQLite per test (no mocks per project rule)
- [ ] Manual smoke: `scanldr history` against your real DB; `scanldr history clear --manga Dandadan` interactive

## Reviewer notes

Non-blocking inspector findings worth a follow-up:

- **`LIMIT ${query.limit}`** template-interpolated in `repository.ts:156` rather than parameterized. Safe because CLI input is regex-gated to digits (`/^\d+$/`), but breaks the surrounding `?`-parameterized pattern. Fix is trivial: `sql += " LIMIT ?"; params.push(limit)`.
- **UTC timestamps** in `format.ts` not documented — could surprise users in non-UTC locales. Either change to local time or document UTC explicitly.
- **`promptYesNo` duplicated** between `commands/history/prompt.ts` and `commands/download/prompt-pack.ts` — candidate for `@plugins/prompt`.

## Closes

Closes #67

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions (no classes, types in `types.ts`, factory functions, real SQLite tests, parametrized queries with explicit `LIKE` escape, prompts on stderr)
- [x] No new dependencies
- [x] No schema changes / migrations
- [x] Docs updated (`docs/overviewer.md`)