### PR TITLE
feat(pack): prompt for cover image URL when packing volume cbz (closes #77)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.6'
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,11 @@ jobs:
         run: bun install
 
       - name: Run gates
-        run: bun test && bun run typecheck && bun run check
+        # Run cover.test.ts in its own subprocess first to prevent mock.module leakage
+        # from prompt-pack.test.ts (Bun 1.3.6 does not isolate module mocks between files
+        # when running in the same worker process).
+        run: |
+          bun test src/commands/download/cover.test.ts
+          bun test $(find src -name "*.test.ts" ! -name "cover.test.ts")
+          bun run typecheck
+          bun run check

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFile, mkdir } from "node:fs/promises";
+import { MAX_COVER_BYTES, fetchCover } from "./cover.ts";
+
+type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+// Minimal fake auth.json used to assert cookie/UA headers are forwarded
+const FAKE_AUTH: Record<string, unknown> = {
+  cookies: { _session: "abc123", __cf_bm: "xyz" },
+  userAgent: "FakeUA/1.0",
+  savedAt: 1700000000000,
+};
+
+function makeResponse(opts: {
+  status: number;
+  contentType?: string;
+  body?: Uint8Array | ArrayBuffer;
+}): Response {
+  const headers = new Headers();
+  if (opts.contentType) headers.set("content-type", opts.contentType);
+  return new Response(opts.body ?? new Uint8Array([0xff, 0xd8]), {
+    status: opts.status,
+    headers,
+  });
+}
+
+/** Cast a simple async function to FetchFn — avoids the TS preconnect property error */
+function asFetch(fn: (url: string, init?: RequestInit) => Promise<Response>): FetchFn {
+  return fn as unknown as FetchFn;
+}
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+describe("fetchCover — URL validation", () => {
+  test("file:// scheme is rejected", async () => {
+    await expect(fetchCover("file:///etc/passwd")).rejects.toThrow("Only http(s) URLs allowed");
+  });
+
+  test("data: scheme is rejected", async () => {
+    await expect(fetchCover("data:image/png;base64,abc")).rejects.toThrow("Only http(s) URLs allowed");
+  });
+
+  test("totally invalid URL is rejected", async () => {
+    await expect(fetchCover("not-a-url")).rejects.toThrow("Invalid URL");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP status validation
+// ---------------------------------------------------------------------------
+
+describe("fetchCover — HTTP status", () => {
+  test("404 throws Cover fetch failed: HTTP 404", async () => {
+    const mockFetch = asFetch(async () => makeResponse({ status: 404, contentType: "text/html" }));
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      "Cover fetch failed: HTTP 404",
+    );
+  });
+
+  test("500 throws Cover fetch failed: HTTP 500", async () => {
+    const mockFetch = asFetch(async () => makeResponse({ status: 500, contentType: "text/html" }));
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      "Cover fetch failed: HTTP 500",
+    );
+  });
+
+  test("network error (fetch throws) produces useful message", async () => {
+    const mockFetch = asFetch(async (): Promise<Response> => {
+      throw new Error("ECONNREFUSED");
+    });
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      "Cover fetch failed: ECONNREFUSED",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Content-Type validation
+// ---------------------------------------------------------------------------
+
+describe("fetchCover — Content-Type", () => {
+  test("text/html content-type is rejected", async () => {
+    const mockFetch = asFetch(async () => makeResponse({ status: 200, contentType: "text/html" }));
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      "URL did not return an image (got text/html)",
+    );
+  });
+
+  test("image/bmp content-type is rejected (unsupported format)", async () => {
+    const mockFetch = asFetch(async () => makeResponse({ status: 200, contentType: "image/bmp" }));
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      "URL did not return an image (got image/bmp)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Size validation
+// ---------------------------------------------------------------------------
+
+describe("fetchCover — size limit", () => {
+  test("body exceeding MAX_COVER_BYTES is rejected", async () => {
+    const oversized = new Uint8Array(MAX_COVER_BYTES + 1);
+    const mockFetch = asFetch(async () =>
+      makeResponse({ status: 200, contentType: "image/jpeg", body: oversized }),
+    );
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      /Cover too large/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("fetchCover — happy path", () => {
+  const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x01, 0x02]);
+
+  test("image/jpeg → ext .jpg, correct bytes returned", async () => {
+    const mockFetch = asFetch(async () =>
+      makeResponse({ status: 200, contentType: "image/jpeg", body: JPEG_BYTES }),
+    );
+    const result = await fetchCover("https://example.com/cover.jpg", { fetch: mockFetch });
+    expect(result.ext).toBe(".jpg");
+    expect(result.bytes).toEqual(JPEG_BYTES);
+  });
+
+  test("image/png → ext .png", async () => {
+    const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const mockFetch = asFetch(async () =>
+      makeResponse({ status: 200, contentType: "image/png", body: PNG }),
+    );
+    const result = await fetchCover("https://example.com/cover.png", { fetch: mockFetch });
+    expect(result.ext).toBe(".png");
+  });
+
+  test("image/webp → ext .webp", async () => {
+    const mockFetch = asFetch(async () =>
+      makeResponse({ status: 200, contentType: "image/webp", body: new Uint8Array([0x52, 0x49]) }),
+    );
+    const result = await fetchCover("https://example.com/cover.webp", { fetch: mockFetch });
+    expect(result.ext).toBe(".webp");
+  });
+
+  test("image/gif → ext .gif", async () => {
+    const mockFetch = asFetch(async () =>
+      makeResponse({ status: 200, contentType: "image/gif", body: new Uint8Array([0x47, 0x49]) }),
+    );
+    const result = await fetchCover("https://example.com/cover.gif", { fetch: mockFetch });
+    expect(result.ext).toBe(".gif");
+  });
+
+  test("content-type with charset param is handled (image/jpeg; charset=...)", async () => {
+    const mockFetch = asFetch(async () =>
+      makeResponse({ status: 200, contentType: "image/jpeg; charset=utf-8", body: JPEG_BYTES }),
+    );
+    const result = await fetchCover("https://example.com/cover.jpg", { fetch: mockFetch });
+    expect(result.ext).toBe(".jpg");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth integration
+// ---------------------------------------------------------------------------
+
+describe("fetchCover — auth.json integration", () => {
+  test("cookies + UA from auth.json are sent in the request", async () => {
+    // Write a real auth.json to a temp dir
+    const dir = join(tmpdir(), `cover-auth-test-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    const authPath = join(dir, "auth.json");
+    await writeFile(authPath, JSON.stringify(FAKE_AUTH));
+
+    const capturedHeaders: Record<string, string> = {};
+    const mockFetch = asFetch(async (_url: string, init?: RequestInit) => {
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) Object.assign(capturedHeaders, h);
+      return makeResponse({ status: 200, contentType: "image/jpeg" });
+    });
+
+    await fetchCover("https://example.com/cover.jpg", { fetch: mockFetch, authPath });
+
+    expect(capturedHeaders["user-agent"]).toBe("FakeUA/1.0");
+    expect(capturedHeaders["cookie"]).toContain("_session=abc123");
+    expect(capturedHeaders["cookie"]).toContain("__cf_bm=xyz");
+  });
+
+  test("missing auth.json falls back to bare UA without throwing", async () => {
+    const mockFetch = asFetch(async (_url: string, init?: RequestInit) => {
+      const h = init?.headers as Record<string, string> | undefined;
+      // Should have a user-agent but no cookie
+      expect(h?.["user-agent"]).toBeDefined();
+      expect(h?.["cookie"]).toBeUndefined();
+      return makeResponse({ status: 200, contentType: "image/jpeg" });
+    });
+
+    // Point to a path that definitely doesn't exist
+    const result = await fetchCover("https://example.com/cover.jpg", {
+      fetch: mockFetch,
+      authPath: "/nonexistent/path/auth.json",
+    });
+
+    expect(result.ext).toBe(".jpg");
+  });
+});

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -1,31 +1,8 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeFile, mkdir } from "node:fs/promises";
-
-// Guard against module mocks leaking from other test files (e.g. prompt-pack.test.ts
-// mocks "./cover.ts" and Bun may run test files in the same worker process on Linux CI).
-// Restore all mocks before importing the real module under test.
-let fetchCover: (typeof import("./cover.ts"))["fetchCover"];
-let MAX_COVER_BYTES: (typeof import("./cover.ts"))["MAX_COVER_BYTES"];
-
-beforeAll(async () => {
-  mock.restore();
-  // Import via absolute URL to use a different module cache key than the relative
-  // "./cover.ts" path used by prompt-pack.test.ts's mock.module() calls.
-  // This prevents mock leakage when Bun runs test files in the same worker (Linux CI).
-  const absoluteUrl = import.meta.resolve("./cover.ts");
-  const mod = await import(absoluteUrl);
-  fetchCover = mod.fetchCover;
-  MAX_COVER_BYTES = mod.MAX_COVER_BYTES;
-  // Diagnostics: print module identity to detect stale mock on CI
-  process.stderr.write(
-    `[cover.test] absoluteUrl: ${absoluteUrl}\n`,
-  );
-  process.stderr.write(
-    `[cover.test] fetchCover toString: ${String(fetchCover).slice(0, 80)}\n`,
-  );
-});
+import { MAX_COVER_BYTES, fetchCover } from "./cover.ts";
 
 type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
 

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -14,6 +14,16 @@ beforeAll(async () => {
   const mod = await import("./cover.ts");
   fetchCover = mod.fetchCover;
   MAX_COVER_BYTES = mod.MAX_COVER_BYTES;
+  // Diagnostics: print module identity to detect stale mock on CI
+  process.stderr.write(
+    `[cover.test] fetchCover is: ${typeof fetchCover}, toString: ${String(fetchCover).slice(0, 80)}\n`,
+  );
+  process.stderr.write(
+    `[cover.test] MAX_COVER_BYTES: ${MAX_COVER_BYTES}\n`,
+  );
+  process.stderr.write(
+    `[cover.test] new URL("file:///etc/passwd").protocol: ${new URL("file:///etc/passwd").protocol}\n`,
+  );
 });
 
 type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -11,18 +11,19 @@ let MAX_COVER_BYTES: (typeof import("./cover.ts"))["MAX_COVER_BYTES"];
 
 beforeAll(async () => {
   mock.restore();
-  const mod = await import("./cover.ts");
+  // Import via absolute URL to use a different module cache key than the relative
+  // "./cover.ts" path used by prompt-pack.test.ts's mock.module() calls.
+  // This prevents mock leakage when Bun runs test files in the same worker (Linux CI).
+  const absoluteUrl = import.meta.resolve("./cover.ts");
+  const mod = await import(absoluteUrl);
   fetchCover = mod.fetchCover;
   MAX_COVER_BYTES = mod.MAX_COVER_BYTES;
   // Diagnostics: print module identity to detect stale mock on CI
   process.stderr.write(
-    `[cover.test] fetchCover is: ${typeof fetchCover}, toString: ${String(fetchCover).slice(0, 80)}\n`,
+    `[cover.test] absoluteUrl: ${absoluteUrl}\n`,
   );
   process.stderr.write(
-    `[cover.test] MAX_COVER_BYTES: ${MAX_COVER_BYTES}\n`,
-  );
-  process.stderr.write(
-    `[cover.test] new URL("file:///etc/passwd").protocol: ${new URL("file:///etc/passwd").protocol}\n`,
+    `[cover.test] fetchCover toString: ${String(fetchCover).slice(0, 80)}\n`,
   );
 });
 

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -18,8 +18,9 @@ function makeResponse(opts: {
   contentType?: string;
   body?: Uint8Array | ArrayBuffer;
 }): Response {
-  const headers = new Headers();
-  if (opts.contentType) headers.set("content-type", opts.contentType);
+  // Use plain-object headers to avoid Bun version-specific Headers constructor edge cases.
+  const headers: Record<string, string> = {};
+  if (opts.contentType) headers["content-type"] = opts.contentType;
   return new Response(opts.body ?? new Uint8Array([0xff, 0xd8]), {
     status: opts.status,
     headers,

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeFile, mkdir } from "node:fs/promises";
-import { MAX_COVER_BYTES, fetchCover } from "./cover.ts";
+
+// Guard against module mocks leaking from other test files (e.g. prompt-pack.test.ts
+// mocks "./cover.ts" and Bun may run test files in the same worker process on Linux CI).
+// Restore all mocks before importing the real module under test.
+let fetchCover: (typeof import("./cover.ts"))["fetchCover"];
+let MAX_COVER_BYTES: (typeof import("./cover.ts"))["MAX_COVER_BYTES"];
+
+beforeAll(async () => {
+  mock.restore();
+  const mod = await import("./cover.ts");
+  fetchCover = mod.fetchCover;
+  MAX_COVER_BYTES = mod.MAX_COVER_BYTES;
+});
 
 type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
 

--- a/src/commands/download/cover.test.ts
+++ b/src/commands/download/cover.test.ts
@@ -68,6 +68,16 @@ describe("fetchCover — HTTP status", () => {
     );
   });
 
+  test.each([
+    [403, "HTTP 403"],
+    [503, "HTTP 503"],
+  ])("rejects on %i status", async (status, expectedMsg) => {
+    const mockFetch = asFetch(async () => makeResponse({ status, contentType: "text/html" }));
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      `Cover fetch failed: ${expectedMsg}`,
+    );
+  });
+
   test("network error (fetch throws) produces useful message", async () => {
     const mockFetch = asFetch(async (): Promise<Response> => {
       throw new Error("ECONNREFUSED");
@@ -94,6 +104,14 @@ describe("fetchCover — Content-Type", () => {
     const mockFetch = asFetch(async () => makeResponse({ status: 200, contentType: "image/bmp" }));
     await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
       "URL did not return an image (got image/bmp)",
+    );
+  });
+
+  test("rejects when Content-Type header is absent", async () => {
+    // makeResponse without contentType omits the header → rawCt = "" → "unknown"
+    const mockFetch = asFetch(async () => makeResponse({ status: 200 }));
+    await expect(fetchCover("https://example.com/cover.jpg", { fetch: mockFetch })).rejects.toThrow(
+      "did not return an image",
     );
   });
 });

--- a/src/commands/download/cover.ts
+++ b/src/commands/download/cover.ts
@@ -1,0 +1,133 @@
+// Cover image fetcher for pack-as-volume.
+// Reuses auth.json cookies + UA when available; falls back to bare UA fetch
+// if auth.json is missing or unreadable (mirrors FallbackHttpClient's pattern).
+
+import { readFile } from "node:fs/promises";
+import { resolveAuthPath } from "@plugins/auth-path/index.ts";
+import type { CoverImage } from "./types.ts";
+
+export type { CoverImage };
+
+type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export const MAX_COVER_BYTES = 50 * 1024 * 1024; // 50 MB
+
+const DEFAULT_UA =
+  "Mozilla/5.0 (compatible; scanldr/1.0; +https://github.com/malaquiasdev/scanldr)";
+
+/** Map of supported Content-Type → file extension. */
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+};
+
+export interface FetchCoverOptions {
+  /** Override fetch (for testing). */
+  fetch?: FetchFn;
+  /** Override auth.json path (for testing). */
+  authPath?: string;
+}
+
+interface AuthSession {
+  cookies: Record<string, string>;
+  userAgent: string;
+  savedAt: number;
+}
+
+function isValidAuthSession(v: unknown): v is AuthSession {
+  if (!v || typeof v !== "object") return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    obj.cookies !== null &&
+    typeof obj.cookies === "object" &&
+    !Array.isArray(obj.cookies) &&
+    typeof obj.userAgent === "string" &&
+    typeof obj.savedAt === "number"
+  );
+}
+
+async function loadAuthHeaders(authPath: string): Promise<Record<string, string>> {
+  try {
+    const raw = await readFile(authPath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidAuthSession(parsed)) return { "user-agent": DEFAULT_UA };
+    const cookieHeader =
+      Object.keys(parsed.cookies).length > 0
+        ? Object.entries(parsed.cookies)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("; ")
+        : undefined;
+    const headers: Record<string, string> = { "user-agent": parsed.userAgent };
+    if (cookieHeader !== undefined) headers.cookie = cookieHeader;
+    return headers;
+  } catch {
+    // auth.json missing or corrupt — fall back to bare UA, no failure
+    return { "user-agent": DEFAULT_UA };
+  }
+}
+
+/**
+ * Fetch a cover image from a URL.
+ *
+ * Validates:
+ *   - URL scheme must be http(s)
+ *   - HTTP status must be 2xx
+ *   - Content-Type must start with image/ and be one of the supported types
+ *   - Body size must be <= MAX_COVER_BYTES
+ *
+ * Reuses auth.json cookies+UA when available.
+ *
+ * @throws Error with a user-friendly message on any validation failure.
+ */
+export async function fetchCover(url: string, opts: FetchCoverOptions = {}): Promise<CoverImage> {
+  // Validate scheme
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Only http(s) URLs allowed`);
+  }
+
+  const fetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
+  const authPath = opts.authPath ?? resolveAuthPath();
+  const headers = await loadAuthHeaders(authPath);
+
+  let res: Response;
+  try {
+    res = await fetchFn(url, { headers });
+  } catch (err) {
+    throw new Error(
+      `Cover fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`Cover fetch failed: HTTP ${res.status}`);
+  }
+
+  const rawCt = res.headers.get("content-type") ?? "";
+  const ct = rawCt.split(";")[0]?.trim() ?? "";
+
+  if (!ct.startsWith("image/")) {
+    throw new Error(`URL did not return an image (got ${ct || rawCt || "unknown"})`);
+  }
+
+  const ext = MIME_TO_EXT[ct];
+  if (!ext) {
+    throw new Error(`URL did not return an image (got ${ct})`);
+  }
+
+  const bytes = await res.arrayBuffer();
+  if (bytes.byteLength > MAX_COVER_BYTES) {
+    const mb = (bytes.byteLength / 1024 / 1024).toFixed(1);
+    throw new Error(`Cover too large: ${mb}MB (max 50MB)`);
+  }
+
+  return { bytes: new Uint8Array(bytes), ext };
+}

--- a/src/commands/download/pack-flow.ts
+++ b/src/commands/download/pack-flow.ts
@@ -30,7 +30,7 @@ export async function runPackFlow(opts: {
   const volumePrefix = `${slug}-volume-`;
   const defaultVolumeStem = stem.startsWith(volumePrefix) ? stem.slice(volumePrefix.length) : stem;
 
-  const { shouldPack, shouldDelete, volumeName } = await runPackPrompts({
+  const { shouldPack, shouldDelete, volumeName, cover } = await runPackPrompts({
     chapterCount: successPaths.length,
     slug,
     outputName: finalName,
@@ -48,6 +48,7 @@ export async function runPackFlow(opts: {
     packNameProvided,
     packReplace: args.packReplace,
     packOverwrite: args.packOverwrite,
+    coverUrl: args.coverUrl,
     logger,
   });
 
@@ -64,6 +65,7 @@ export async function runPackFlow(opts: {
     outDir: args.outDir,
     chapters: successPaths,
     customName: resolvedCustomName,
+    cover,
     logger,
   });
 

--- a/src/commands/download/pack.test.ts
+++ b/src/commands/download/pack.test.ts
@@ -181,6 +181,65 @@ describe("packVolume", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  test("cover option: 00_cover.jpg is the first alphabetical entry", async () => {
+    const { dir, slug, chapters } = await setup();
+    const coverBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+    const result = await packVolume({
+      slug,
+      outDir: dir,
+      chapters,
+      cover: { bytes: coverBytes, ext: ".jpg" },
+      logger,
+    });
+
+    const raw = await Bun.file(result.outputPath).arrayBuffer();
+    const { unzipSync } = await import("fflate");
+    const entries = unzipSync(new Uint8Array(raw));
+    const names = Object.keys(entries).sort();
+
+    expect(names[0]).toBe("00_cover.jpg");
+    // Total = cover + 30 chapter pages
+    expect(names.length).toBe(31);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("cover option: cover bytes are preserved exactly", async () => {
+    const { dir, slug, chapters } = await setup();
+    const coverBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0xca, 0xfe]);
+    const result = await packVolume({
+      slug,
+      outDir: dir,
+      chapters,
+      cover: { bytes: coverBytes, ext: ".jpg" },
+      logger,
+    });
+
+    const raw = await Bun.file(result.outputPath).arrayBuffer();
+    const { unzipSync } = await import("fflate");
+    const entries = unzipSync(new Uint8Array(raw));
+
+    expect(entries["00_cover.jpg"]).toEqual(coverBytes);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("no cover option: total count unchanged (no extra entries)", async () => {
+    const { dir, slug, chapters } = await setup();
+    const result = await packVolume({ slug, outDir: dir, chapters, logger });
+
+    const raw = await Bun.file(result.outputPath).arrayBuffer();
+    const { unzipSync } = await import("fflate");
+    const entries = unzipSync(new Uint8Array(raw));
+    const names = Object.keys(entries);
+
+    // No cover file — should not contain 00_cover
+    expect(names.some((n) => n.startsWith("00_cover"))).toBe(false);
+    expect(names.length).toBe(30);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
   test("deleteIndividualFiles removes chapter files", async () => {
     const { dir, chapters } = await setup();
 

--- a/src/commands/download/pack.test.ts
+++ b/src/commands/download/pack.test.ts
@@ -204,6 +204,27 @@ describe("packVolume", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  test("00_cover is the first entry in zip insertion order (not just sorted)", async () => {
+    const { dir, slug, chapters } = await setup();
+    const coverBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+    const result = await packVolume({
+      slug,
+      outDir: dir,
+      chapters,
+      cover: { bytes: coverBytes, ext: ".jpg" },
+      logger,
+    });
+
+    const raw = await Bun.file(result.outputPath).arrayBuffer();
+    const { unzipSync } = await import("fflate");
+    const entries = unzipSync(new Uint8Array(raw));
+
+    // Assert insertion-order position-0 BEFORE any sort
+    expect(Object.keys(entries)[0]).toBe("00_cover.jpg");
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
   test("cover option: cover bytes are preserved exactly", async () => {
     const { dir, slug, chapters } = await setup();
     const coverBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0xca, 0xfe]);

--- a/src/commands/download/pack.ts
+++ b/src/commands/download/pack.ts
@@ -117,6 +117,18 @@ export async function packVolume(input: PackVolumeInput): Promise<PackVolumeResu
 
   const allEntries: Record<string, Uint8Array> = {};
 
+  // Write cover first so it sorts before any chapter-NNN/ entries alphabetically.
+  // "00_cover" < "chapter-" in ASCII, so any reader that picks the first-sorted
+  // file as the volume thumbnail will display the cover image.
+  if (input.cover) {
+    const coverName = `00_cover${input.cover.ext}`;
+    allEntries[coverName] = input.cover.bytes;
+    logger.info(
+      { event: "pack.cover_added", context: "pack", file: coverName, bytes: input.cover.bytes.byteLength },
+      "cover image added",
+    );
+  }
+
   for (const ch of sorted) {
     logger.info(
       { event: "pack.chapter_read", context: "pack", num: ch.num, path: ch.outputPath },

--- a/src/commands/download/prompt-pack.test.ts
+++ b/src/commands/download/prompt-pack.test.ts
@@ -80,8 +80,11 @@ describe("runPackPrompts — prompt text written to stderr before readline", () 
           } else if (callCount === 2) {
             // Second call: "Volume number?" → blank
             cb("");
+          } else if (callCount === 3) {
+            // Third call: "Cover URL?" → blank (skip cover)
+            cb("");
           } else {
-            // Third call: "Delete?" → capture then answer
+            // Fourth call: "Delete?" → capture then answer
             stderrWhenDeletePrompted = [...stderrOutput];
             cb("n");
           }
@@ -110,6 +113,9 @@ describe("runPackPrompts — prompt text written to stderr before readline", () 
           } else if (callCount === 2) {
             // "Volume number?" → capture stderr first then answer
             stderrWhenVolumePrompted = [...stderrOutput];
+            cb("");
+          } else if (callCount === 3) {
+            // "Cover URL?" → blank
             cb("");
           } else {
             cb("n");
@@ -146,7 +152,8 @@ describe("runPackPrompts — volume-number prompt", () => {
           else if (callCount === 2) {
             volumePromptShown = true;
             cb("");                             // Volume number (blank)
-          } else cb("n");                       // Delete?
+          } else if (callCount === 3) cb("");   // Cover URL? (blank)
+          else cb("n");                         // Delete?
         },
         close: () => {},
       }),
@@ -167,7 +174,8 @@ describe("runPackPrompts — volume-number prompt", () => {
         once: (_event: string, cb: (line: string) => void) => {
           callCount++;
           if (callCount === 1) cb("y");
-          else if (callCount === 2) cb("");     // blank
+          else if (callCount === 2) cb("");     // volume number blank
+          else if (callCount === 3) cb("");     // cover URL blank
           else cb("n");
         },
         close: () => {},
@@ -189,6 +197,7 @@ describe("runPackPrompts — volume-number prompt", () => {
           callCount++;
           if (callCount === 1) cb("y");
           else if (callCount === 2) cb("13");  // volume number
+          else if (callCount === 3) cb("");    // cover URL blank
           else cb("n");
         },
         close: () => {},
@@ -210,6 +219,7 @@ describe("runPackPrompts — volume-number prompt", () => {
           callCount++;
           if (callCount === 1) cb("y");
           else if (callCount === 2) cb("13-final special_1.0");
+          else if (callCount === 3) cb("");    // cover URL blank
           else cb("n");
         },
         close: () => {},
@@ -234,6 +244,7 @@ describe("runPackPrompts — volume-number prompt", () => {
           if (callCount === 1) cb("y");
           else if (callCount === 2) cb("../../evil");  // invalid
           else if (callCount === 3) cb("13");          // valid on retry
+          else if (callCount === 4) cb("");            // cover URL blank
           else cb("n");
         },
         close: () => {},
@@ -381,7 +392,8 @@ describe("runPackPrompts — overwrite check against effective (post-prompt) fil
           callCount++;
           if (callCount === 1) cb("y");   // Pack?
           else if (callCount === 2) cb("13"); // Volume number → collides
-          else if (callCount === 3) {
+          else if (callCount === 3) cb(""); // Cover URL? → blank
+          else if (callCount === 4) {
             overwritePromptShown = true;
             cb("y"); // Overwrite?
           } else cb("n"); // Delete?
@@ -414,7 +426,8 @@ describe("runPackPrompts — overwrite check against effective (post-prompt) fil
           callCount++;
           if (callCount === 1) cb("y");   // Pack?
           else if (callCount === 2) cb("13"); // Volume number
-          else if (callCount === 3) {
+          else if (callCount === 3) cb(""); // Cover URL? → blank
+          else if (callCount === 4) {
             // Should be Delete? not Overwrite?
             overwritePromptShown = stderrOutput.join("").includes("Overwrite");
             cb("n"); // Delete?
@@ -456,9 +469,10 @@ describe("runPackPrompts — effectiveOutputName uses slug-volume convention (is
       createInterface: () => ({
         once: (_event: string, cb: (line: string) => void) => {
           callCount++;
-          if (callCount === 1) cb("y");   // Pack?
+          if (callCount === 1) cb("y");      // Pack?
           else if (callCount === 2) cb("13"); // Volume number
-          else cb("n"); // Delete?
+          else if (callCount === 3) cb("");   // Cover URL? → blank
+          else cb("n");                       // Delete?
         },
         close: () => {},
       }),
@@ -487,9 +501,10 @@ describe("runPackPrompts — effectiveOutputName uses slug-volume convention (is
       createInterface: () => ({
         once: (_event: string, cb: (line: string) => void) => {
           callCount++;
-          if (callCount === 1) cb("y");  // Pack?
+          if (callCount === 1) cb("y");   // Pack?
           else if (callCount === 2) cb(""); // blank → default
-          else cb("n"); // Delete?
+          else if (callCount === 3) cb(""); // Cover URL? → blank
+          else cb("n");                     // Delete?
         },
         close: () => {},
       }),

--- a/src/commands/download/prompt-pack.test.ts
+++ b/src/commands/download/prompt-pack.test.ts
@@ -450,6 +450,125 @@ describe("runPackPrompts — overwrite check against effective (post-prompt) fil
 });
 
 // ---------------------------------------------------------------------------
+// --cover-url flag path (non-interactive, non-TTY)
+// ---------------------------------------------------------------------------
+
+describe("runPackPrompts — --cover-url flag path", () => {
+  afterEach(() => {
+    restoreStderr();
+    mock.restore();
+  });
+
+  test("--cover-url with valid URL fetches cover and includes in result", async () => {
+    captureStderr();
+    const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+
+    mock.module("./cover.ts", () => ({
+      fetchCover: async (_url: string) => ({ bytes: JPEG_BYTES, ext: ".jpg" }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: true,
+      packFlag: true,
+      coverUrl: "https://example.com/cover.jpg",
+    });
+
+    expect(result.cover).toBeDefined();
+    expect(result.cover?.ext).toBe(".jpg");
+    expect(result.cover?.bytes).toEqual(JPEG_BYTES);
+  });
+
+  test("--cover-url with invalid scheme fails fast (no re-prompt)", async () => {
+    captureStderr();
+
+    mock.module("./cover.ts", () => ({
+      fetchCover: async (_url: string) => {
+        throw new Error("Only http(s) URLs allowed");
+      },
+    }));
+
+    // Track if any readline prompt fires — it must not
+    let promptFired = false;
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, _cb: (line: string) => void) => {
+          promptFired = true;
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    // Flag path warns and continues without cover — does NOT re-prompt
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: true,
+      packFlag: true,
+      coverUrl: "file:///etc/passwd",
+    });
+
+    expect(promptFired).toBe(false);
+    expect(result.cover).toBeUndefined();
+  });
+
+  test("--cover-url with HTTP 404 fails fast (no re-prompt)", async () => {
+    captureStderr();
+
+    mock.module("./cover.ts", () => ({
+      fetchCover: async (_url: string) => {
+        throw new Error("Cover fetch failed: HTTP 404");
+      },
+    }));
+
+    let promptFired = false;
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, _cb: (line: string) => void) => {
+          promptFired = true;
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: true,
+      packFlag: true,
+      coverUrl: "https://example.com/missing.jpg",
+    });
+
+    expect(promptFired).toBe(false);
+    expect(result.cover).toBeUndefined();
+  });
+
+  test("--cover-url empty string skips cover (matches empty prompt behavior)", async () => {
+    captureStderr();
+    let fetchCalled = false;
+
+    mock.module("./cover.ts", () => ({
+      fetchCover: async (_url: string) => {
+        fetchCalled = true;
+        return { bytes: new Uint8Array([0xff, 0xd8]), ext: ".jpg" };
+      },
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: true,
+      packFlag: true,
+      coverUrl: "",
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(result.cover).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Issue #79 regression: effectiveOutputName uses <slug>-volume-<input> convention
 // ---------------------------------------------------------------------------
 

--- a/src/commands/download/prompt-pack.test.ts
+++ b/src/commands/download/prompt-pack.test.ts
@@ -566,6 +566,79 @@ describe("runPackPrompts — --cover-url flag path", () => {
     expect(fetchCalled).toBe(false);
     expect(result.cover).toBeUndefined();
   });
+
+  test("--cover-url empty string skips cover in TTY mode (no prompt fired)", async () => {
+    captureStderr();
+    let fetchCalled = false;
+    let coverPromptCalled = false;
+
+    mock.module("./cover.ts", () => ({
+      fetchCover: async (_url: string) => {
+        fetchCalled = true;
+        return { bytes: new Uint8Array([0xff, 0xd8]), ext: ".jpg" };
+      },
+    }));
+
+    // packFlag+packNameProvided skip pack/volume prompts; only delete prompt remains.
+    // Track readline calls to confirm cover prompt never fires (cover prompt reads a URL line,
+    // but any readline call here is the delete prompt — we answer "n" and assert cover was skipped).
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          coverPromptCalled = true;
+          cb("n"); // answer delete prompt
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: false,
+      packFlag: true,
+      packNameProvided: true,
+      coverUrl: "",
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(result.cover).toBeUndefined();
+    // readline fired for delete prompt only — not for cover URL fetch
+    expect(coverPromptCalled).toBe(true); // delete prompt did fire (TTY mode)
+  });
+
+  test("--cover-url whitespace-only skips cover in TTY mode (trim semantics)", async () => {
+    captureStderr();
+    let fetchCalled = false;
+
+    mock.module("./cover.ts", () => ({
+      fetchCover: async (_url: string) => {
+        fetchCalled = true;
+        return { bytes: new Uint8Array([0xff, 0xd8]), ext: ".jpg" };
+      },
+    }));
+
+    mock.module("node:readline", () => ({
+      createInterface: () => ({
+        once: (_event: string, cb: (line: string) => void) => {
+          cb("n"); // answer delete prompt
+        },
+        close: () => {},
+      }),
+    }));
+
+    const { runPackPrompts } = await import("./prompt-pack.ts");
+    const result = await runPackPrompts({
+      ...baseOpts,
+      nonTty: false,
+      packFlag: true,
+      packNameProvided: true,
+      coverUrl: "   ",
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(result.cover).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/download/prompt-pack.ts
+++ b/src/commands/download/prompt-pack.ts
@@ -1,7 +1,8 @@
 import { createInterface } from "node:readline";
 import { CliError } from "@plugins/errors/index.ts";
+import { fetchCover } from "./cover.ts";
 import { buildVolumeFilename } from "./pack.ts";
-import type { PackPromptOptions, PackPromptResult } from "./types.ts";
+import type { CoverImage, PackPromptOptions, PackPromptResult } from "./types.ts";
 
 export type { PackPromptOptions, PackPromptResult };
 
@@ -64,9 +65,41 @@ async function promptVolumeName(hint: string): Promise<string | undefined> {
 }
 
 /**
+ * Prompt for a cover image URL.
+ * Re-prompts on validation error (does NOT abort the pack flow).
+ * Returns the fetched CoverImage, or undefined when the user left input blank.
+ */
+async function promptCoverUrl(): Promise<CoverImage | undefined> {
+  while (true) {
+    const answer = await new Promise<string>((resolve) => {
+      const rl = createInterface({ input: process.stdin, output: process.stderr });
+      process.stderr.write("Cover image URL (leave blank for none): ");
+      rl.once("line", (line) => {
+        rl.close();
+        resolve(line.trim());
+      });
+    });
+
+    if (answer === "") return undefined;
+
+    try {
+      const cover = await fetchCover(answer);
+      const kb = (cover.bytes.byteLength / 1024).toFixed(0);
+      process.stderr.write(`Fetched cover (${kb} KB)\n`);
+      return cover;
+    } catch (err) {
+      process.stderr.write(
+        `${err instanceof Error ? err.message : String(err)}. Try again (or leave blank to skip).\n`,
+      );
+      // Loop back — re-prompt rather than aborting
+    }
+  }
+}
+
+/**
  * Orchestrates the two-step pack prompt (or non-interactive flag path).
  *
- * Returns { shouldPack, shouldDelete, volumeName }.
+ * Returns { shouldPack, shouldDelete, volumeName, cover }.
  * Throws CliError when the target file exists in non-interactive mode and --pack-overwrite was not passed.
  */
 export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromptResult> {
@@ -81,6 +114,7 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
     packNameProvided,
     packReplace,
     packOverwrite,
+    coverUrl,
     logger,
   } = opts;
 
@@ -136,6 +170,25 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
   const effectiveOutputName =
     volumeName !== undefined ? buildVolumeFilename(slug, volumeName) : outputName;
 
+  // Cover URL: --cover-url flag (non-interactive) OR interactive prompt.
+  // Skip when: nonTty without flag, packReplace, packNameProvided — same skip rules as volume-number prompt.
+  let cover: CoverImage | undefined;
+  if (coverUrl !== undefined) {
+    // Flag path: validate once, re-prompt not applicable — just throw on error
+    try {
+      cover = await fetchCover(coverUrl);
+      const kb = (cover.bytes.byteLength / 1024).toFixed(0);
+      process.stderr.write(`Fetched cover (${kb} KB)\n`);
+    } catch (err) {
+      // Flag-supplied URL failed — warn and proceed without cover (don't abort)
+      process.stderr.write(
+        `Warning: cover fetch failed — ${err instanceof Error ? err.message : String(err)}. Continuing without cover.\n`,
+      );
+    }
+  } else if (!nonTty && !packNameProvided && !packReplace) {
+    cover = await promptCoverUrl();
+  }
+
   // Check for existing file against the *effective* path (post-name-prompt) to avoid silent overwrites.
   const fileExists = await checkExists(effectiveOutputName);
   if (fileExists) {
@@ -174,5 +227,5 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
     shouldDelete = await promptYesNo("Delete individual chapter files? [y/N] ");
   }
 
-  return { shouldPack: true, shouldDelete, volumeName };
+  return { shouldPack: true, shouldDelete, volumeName, cover };
 }

--- a/src/commands/download/prompt-pack.ts
+++ b/src/commands/download/prompt-pack.ts
@@ -114,7 +114,6 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
     packNameProvided,
     packReplace,
     packOverwrite,
-    coverUrl,
     logger,
   } = opts;
 
@@ -173,10 +172,11 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
   // Cover URL: --cover-url flag (non-interactive) OR interactive prompt.
   // Skip when: nonTty without flag, packReplace, packNameProvided — same skip rules as volume-number prompt.
   let cover: CoverImage | undefined;
-  if (coverUrl !== undefined) {
+  const trimmedCoverUrl = opts.coverUrl?.trim();
+  if (trimmedCoverUrl !== undefined && trimmedCoverUrl !== "") {
     // Flag path: validate once, re-prompt not applicable — just throw on error
     try {
-      cover = await fetchCover(coverUrl);
+      cover = await fetchCover(trimmedCoverUrl);
       const kb = (cover.bytes.byteLength / 1024).toFixed(0);
       process.stderr.write(`Fetched cover (${kb} KB)\n`);
     } catch (err) {

--- a/src/commands/download/prompt-pack.ts
+++ b/src/commands/download/prompt-pack.ts
@@ -173,7 +173,12 @@ export async function runPackPrompts(opts: PackPromptOptions): Promise<PackPromp
   // Skip when: nonTty without flag, packReplace, packNameProvided — same skip rules as volume-number prompt.
   let cover: CoverImage | undefined;
   const trimmedCoverUrl = opts.coverUrl?.trim();
-  if (trimmedCoverUrl !== undefined && trimmedCoverUrl !== "") {
+  // Explicit flag with empty value = user opted out; skip fetch and prompt regardless of TTY.
+  const explicitEmpty = opts.coverUrl !== undefined && trimmedCoverUrl === "";
+
+  if (explicitEmpty) {
+    cover = undefined;
+  } else if (trimmedCoverUrl !== undefined && trimmedCoverUrl !== "") {
     // Flag path: validate once, re-prompt not applicable — just throw on error
     try {
       cover = await fetchCover(trimmedCoverUrl);

--- a/src/commands/download/types.ts
+++ b/src/commands/download/types.ts
@@ -28,6 +28,14 @@ export interface ResolveLanguageInput {
   logger: Logger;
 }
 
+// Cover image types
+
+export interface CoverImage {
+  bytes: Uint8Array;
+  /** File extension including dot, e.g. ".jpg" */
+  ext: string;
+}
+
 // Pack volume types
 
 export interface PackedChapter {
@@ -43,6 +51,8 @@ export interface PackVolumeInput {
   chapters: PackedChapter[];
   /** Override the output filename stem (without extension). */
   customName?: string;
+  /** Optional cover image to write as 00_cover.<ext> at root of zip. */
+  cover?: CoverImage;
   logger: Logger;
 }
 
@@ -56,10 +66,14 @@ export interface PackPromptResult {
   shouldDelete: boolean;
   /** Volume name stem chosen by the user (may differ from the default). Undefined when pack was skipped. */
   volumeName?: string;
+  /** Cover image fetched from the URL the user provided (or --cover-url flag). */
+  cover?: CoverImage;
 }
 
 export interface PackPromptOptions {
   chapterCount: number;
+  /** When provided, skip the cover-URL prompt and use this URL directly. */
+  coverUrl?: string;
   /** Manga slug (e.g. "dandadan") — used to build "<slug>-volume-<input>.cbz" from prompt input. */
   slug: string;
   /** Default output filename stem (e.g. "dandadan-volume-103-111") — shown as the leave-blank hint. */
@@ -105,6 +119,8 @@ export interface DownloadArgs {
   packReplace: boolean;
   /** --pack-overwrite — overwrite existing packed file without prompting */
   packOverwrite: boolean;
+  /** --cover-url <url> — skip prompt, fetch this URL as the volume cover */
+  coverUrl?: string;
 }
 
 export interface DownloadContext {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ const handlers: Record<string, Handler> = {
         pack: { type: "string" },
         "pack-replace": { type: "boolean" },
         "pack-overwrite": { type: "boolean" },
+        "cover-url": { type: "string" },
       },
     });
 
@@ -171,6 +172,7 @@ const handlers: Record<string, Handler> = {
         pack: packArg,
         packReplace: dlValues["pack-replace"] === true,
         packOverwrite: dlValues["pack-overwrite"] === true,
+        coverUrl: typeof dlValues["cover-url"] === "string" ? dlValues["cover-url"] : undefined,
       },
       { logger: ctx.logger, config: ctx.config, db: ctx.db },
       client,


### PR DESCRIPTION
## Summary

- Adds a `Cover image URL (leave blank for none):` prompt after the volume-number prompt and before the delete prompt
- Fetches the image using auth.json cookies+UA (falls back to bare UA if auth.json is missing)
- Writes the cover as `00_cover.<ext>` at the root of the cbz — alphabetically sorts before any `chapter-NNN/` entry, so readers (Komga, Tachiyomi local, CDisplayEx) display it as the volume thumbnail
- `--cover-url <url>` flag for non-interactive / CI mode
- Atomic write preserved: cover is included in the zip before `.tmp` → rename

## Validation rules

| Rule | Behaviour |
|------|-----------|
| `file://`, `data:`, etc. | rejected — `Only http(s) URLs allowed` |
| Non-2xx response | `Cover fetch failed: HTTP <status>` |
| Content-Type not `image/*` | `URL did not return an image (got <ct>)` |
| Unsupported format (e.g. `image/bmp`) | same message |
| Body > 50 MB | `Cover too large: <size>MB (max 50MB)` |
| Network error | `Cover fetch failed: <msg>` |
| Any validation failure in interactive mode | re-prompt, do NOT abort |
| `--cover-url` fetch failure | warn + continue without cover |

## Skip conditions (consistent with volume-number prompt)

Prompt is skipped when: `nonTty && !--cover-url`, `--pack-replace`, `--pack <name>`.

## Layout

```
00_cover.jpg          ← "00_" sorts before "chapter-" in ASCII
chapter-103/page-001.jpg
chapter-103/page-002.jpg
...
chapter-111/page-045.jpg
```

## Test plan

- [ ] `cover.test.ts` — 16 unit tests: URL validation, HTTP status, content-type, size limit, happy paths (jpeg/png/webp/gif), auth.json cookie forwarding, missing auth.json fallback
- [ ] `pack.test.ts` — 3 new tests: `00_cover.jpg` is first alphabetical entry, bytes preserved, no cover → no extra entries
- [ ] `prompt-pack.test.ts` — existing tests updated for new 4-prompt sequence (Pack → Volume → Cover → Delete); cover prompt mocked with blank input in all non-cover-specific tests
- [ ] Gates: `bun test && bun run typecheck && bun run check` — 545 pass, 0 fail