### PR TITLE
feat(mangakakalot): route getVolumeMap through chapter-list API when inline DOM absent (closes #95)

### DIFF
--- a/src/integrations/mangakakalot/client/client.test.ts
+++ b/src/integrations/mangakakalot/client/client.test.ts
@@ -566,4 +566,101 @@ describe("createMangakakalotClient", () => {
       );
     });
   });
+
+  // ─── getVolumeMap ──────────────────────────────────────────────────────────
+
+  describe("getVolumeMap", () => {
+    it("API path: naruto fixture returns VolumeMap with 1 'unknown' bucket and 87 chapters", async () => {
+      const narutoHtml = readFixture("manga-page-naruto-real.html");
+      const page0Body = readFixture("api-chapters-naruto-page0.json");
+      const page750Body = readFixture("api-chapters-naruto-page750.json");
+
+      // Sequence-based mock: manga page HTML first, then API pages
+      let callCount = 0;
+      const http: FallbackHttpClient = {
+        get: mock(async (url: string) => {
+          callCount++;
+          if (callCount === 1) {
+            // manga detail page
+            return new Response(narutoHtml, {
+              status: 200,
+              headers: { "content-type": "text/html" },
+            });
+          }
+          if (url.includes("offset=0")) {
+            return new Response(page0Body, {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          // All subsequent pages: use page750 (has_more=false) so pagination stops
+          return new Response(page750Body, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }),
+      };
+
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+      const map = await client.getVolumeMap("naruto");
+
+      // Must have exactly 1 bucket
+      expect(map).toHaveLength(1);
+      expect(map[0]?.volume).toBe("unknown");
+
+      // page0 has 50 chapters, page750 has 37 → total 87
+      expect(map[0]?.chapters).toHaveLength(87);
+
+      // Chapters sorted ascending
+      const nums = (map[0]?.chapters ?? []).map((c) => Number(c.chapter));
+      expect(nums).toEqual([...nums].sort((a, b) => a - b));
+
+      // id format: naruto/<chapter-slug>
+      expect(map[0]?.chapters[0]?.id).toMatch(/^naruto\//);
+
+      // http.get called: 1 (manga page) + 2 (API pages) = 3
+      // @ts-ignore
+      expect(http.get).toHaveBeenCalledTimes(3);
+
+      // logged the placeholder detection
+      // @ts-ignore
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.api_placeholder_detected", slug: "naruto" }),
+        expect.any(String),
+      );
+    });
+
+    it("inline path: dandadan fixture returns VolumeMap without calling API", async () => {
+      const dandadanHtml = readFixture("manga-page-dandadan.html");
+      const http = makeHttp({
+        "https://www.mangakakalot.gg/manga/dandadan": { body: dandadanHtml },
+      });
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      const map = await client.getVolumeMap("dandadan");
+
+      // Inline path: has volume buckets from HTML
+      expect(map.length).toBeGreaterThan(0);
+      const volumes = map.map((b) => b.volume);
+      expect(volumes).toContain("13");
+
+      // http.get called exactly once (manga page only — no API calls)
+      // @ts-ignore
+      expect(http.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("drift path: manga-page-drift.html throws MangakakalotParseError", async () => {
+      const driftHtml = readFixture("manga-page-drift.html");
+      const http = makeHttp({
+        "https://www.mangakakalot.gg/manga/unknown-series": { body: driftHtml },
+      });
+      const client = createMangakakalotClient({ http, logger: makeLogger() });
+
+      await expect(client.getVolumeMap("unknown-series")).rejects.toBeInstanceOf(
+        MangakakalotParseError,
+      );
+    });
+  });
 });

--- a/src/integrations/mangakakalot/client/client.test.ts
+++ b/src/integrations/mangakakalot/client/client.test.ts
@@ -437,6 +437,49 @@ describe("createMangakakalotClient", () => {
       expect(http.get).toHaveBeenCalledTimes(2);
     });
 
+    it("stops at MAX_API_PAGES (20) when API always returns has_more:true and fires pagination_capped warn", async () => {
+      const infinitePage = JSON.stringify({
+        success: true,
+        data: {
+          chapters: [
+            {
+              chapter_name: "Chapter 1",
+              chapter_slug: "chapter-1",
+              chapter_num: 1,
+              updated_at: "2024-01-01T00:00:00.000000Z",
+              view: 0,
+            },
+          ],
+          pagination: { total: 9999, limit: 1, offset: 0, has_more: true },
+        },
+      });
+
+      const http: FallbackHttpClient = {
+        get: mock(async () => {
+          return new Response(infinitePage, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }),
+      };
+      const logger = makeLogger();
+      const client = createMangakakalotClient({ http, logger });
+
+      const chapters = await client.getChapterList("infinite-manga");
+
+      // @ts-ignore
+      expect(http.get).toHaveBeenCalledTimes(20);
+
+      // @ts-ignore
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "mangakakalot.pagination_capped" }),
+        expect.any(String),
+      );
+
+      // 1 chapter per page × 20 pages
+      expect(chapters.length).toBe(20);
+    });
+
     it("propagates CloudflareError without swallowing", async () => {
       const { CloudflareError } = await import("@integrations/fallback-http/types.ts");
       const http: FallbackHttpClient = {

--- a/src/integrations/mangakakalot/client/index.ts
+++ b/src/integrations/mangakakalot/client/index.ts
@@ -6,10 +6,15 @@ import type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts"
 import type { FallbackHttpClient } from "@integrations/fallback-http/types.ts";
 import type { ImageRef } from "@modules/downloader/types.ts";
 import type { Logger } from "@plugins/logger/index.ts";
-import { parseChapterImages, parseChapterListFromApi, parseSearchResults } from "./parser.ts";
+import {
+  detectChapterApiPlaceholder,
+  parseChapterImages,
+  parseChapterListFromApi,
+  parseSearchResults,
+} from "./parser.ts";
 import type { MangakakalotClient, VolumeMap } from "./types.ts";
 import { MangakakalotParseError } from "./types.ts";
-import { parseVolumeMapping } from "./volume-parser.ts";
+import { chaptersToVolumeMap, parseVolumeMapping } from "./volume-parser.ts";
 
 export type { ChapterRef, MangaCandidate } from "@integrations/_shared/manga.ts";
 export type { ImageRef } from "@modules/downloader/types.ts";
@@ -128,6 +133,26 @@ export function createMangakakalotClient(opts: {
   async function getVolumeMap(slug: string): Promise<VolumeMap> {
     const url = `${SITE_ROOT}/manga/${encodeURIComponent(slug)}`;
     const html = await fetchHtml(url);
+
+    // Route 1: if HTML embeds the chapter-list-container API placeholder,
+    // fetch via API and map to VolumeMap. This is the path Naruto takes today.
+    const placeholder = detectChapterApiPlaceholder(html);
+    if (placeholder) {
+      logger.info(
+        {
+          event: "mangakakalot.api_placeholder_detected",
+          context: "mangakakalot",
+          slug,
+          placeholderSlug: placeholder.slug,
+        },
+        "manga page uses client-side API placeholder; fetching chapter list from API",
+      );
+      const chapters = await getChapterList(placeholder.slug);
+      return chaptersToVolumeMap(chapters);
+    }
+
+    // Route 2: inline chapter list (current path for dandadan/jjk/etc).
+    // Drift detector still fires when neither inline list nor API placeholder is present.
     return runParser(url, () => parseVolumeMapping(html, url));
   }
 

--- a/src/integrations/mangakakalot/client/parser.test.ts
+++ b/src/integrations/mangakakalot/client/parser.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { detectChapterApiPlaceholder } from "./parser.ts";
+
+const fixturesDir = join(import.meta.dir, "../../../../tests/fixtures/mangakakalot");
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixturesDir, name), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// detectChapterApiPlaceholder
+// ---------------------------------------------------------------------------
+
+describe("detectChapterApiPlaceholder", () => {
+  it("returns { slug: 'naruto' } for manga-page-naruto-real.html", () => {
+    const html = readFixture("manga-page-naruto-real.html");
+    const result = detectChapterApiPlaceholder(html);
+    expect(result).toEqual({ slug: "naruto" });
+  });
+
+  it("returns null for manga-page-dandadan.html (no placeholder)", () => {
+    const html = readFixture("manga-page-dandadan.html");
+    expect(detectChapterApiPlaceholder(html)).toBeNull();
+  });
+
+  it("returns null for empty HTML", () => {
+    expect(detectChapterApiPlaceholder("")).toBeNull();
+  });
+
+  it("returns null for blank whitespace HTML", () => {
+    expect(detectChapterApiPlaceholder("   ")).toBeNull();
+  });
+
+  it("returns null when container div present but data-comic-slug is empty", () => {
+    const html = `<html><body>
+      <div id="chapter-list-container"
+           data-comic-slug=""
+           data-api-url="https://www.mangakakalot.gg/api/manga/__SLUG__/chapters">
+        Loading...
+      </div>
+    </body></html>`;
+    expect(detectChapterApiPlaceholder(html)).toBeNull();
+  });
+
+  it("returns null when container div present but data-api-url is missing", () => {
+    const html = `<html><body>
+      <div id="chapter-list-container" data-comic-slug="naruto">
+        Loading...
+      </div>
+    </body></html>`;
+    expect(detectChapterApiPlaceholder(html)).toBeNull();
+  });
+
+  it("returns null when container div present but data-comic-slug is missing", () => {
+    const html = `<html><body>
+      <div id="chapter-list-container"
+           data-api-url="https://www.mangakakalot.gg/api/manga/__SLUG__/chapters">
+        Loading...
+      </div>
+    </body></html>`;
+    expect(detectChapterApiPlaceholder(html)).toBeNull();
+  });
+
+  it("trims whitespace from slug", () => {
+    const html = `<html><body>
+      <div id="chapter-list-container"
+           data-comic-slug="  naruto  "
+           data-api-url="https://www.mangakakalot.gg/api/manga/__SLUG__/chapters">
+        Loading...
+      </div>
+    </body></html>`;
+    const result = detectChapterApiPlaceholder(html);
+    expect(result).toEqual({ slug: "naruto" });
+  });
+});

--- a/src/integrations/mangakakalot/client/parser.ts
+++ b/src/integrations/mangakakalot/client/parser.ts
@@ -174,6 +174,31 @@ export function parseChapterListFromApi(
 }
 
 /**
+ * Detects the client-side chapter-list API placeholder in a manga detail page HTML.
+ *
+ * mangakakalot.gg has migrated some series (e.g. naruto) to a placeholder div:
+ *   <div id="chapter-list-container" data-comic-slug="X" data-api-url="Y">Loading...</div>
+ *
+ * When present, the chapter list must be fetched from the API endpoint instead of
+ * parsed from the HTML. Returns { slug } when the placeholder is well-formed,
+ * or null otherwise.
+ *
+ * Slug must come from data-comic-slug (data-api-url contains "__SLUG__" template).
+ */
+export function detectChapterApiPlaceholder(html: string): { slug: string } | null {
+  const $ = cheerio.load(html);
+  const container = $("#chapter-list-container");
+  if (container.length === 0) return null;
+
+  const apiUrl = container.attr("data-api-url")?.trim() ?? "";
+  const slug = container.attr("data-comic-slug")?.trim() ?? "";
+
+  if (!apiUrl || !slug) return null;
+
+  return { slug };
+}
+
+/**
  * Parses chapter image URLs from a mangakakalot reader page.
  *
  * Throws MangakakalotParseError when zero images are found inside the reader container.

--- a/src/integrations/mangakakalot/client/volume-parser.test.ts
+++ b/src/integrations/mangakakalot/client/volume-parser.test.ts
@@ -258,6 +258,35 @@ describe("chaptersToVolumeMap", () => {
     expect(map[0]?.volume).toBe("unknown");
   });
 
+  it("non-numeric volume string (e.g. 'Special') is routed to 'unknown' bucket", () => {
+    const chapters = [makeChapter({ id: "test/ch-1", chapter: "1", volume: "Special" })];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map).toHaveLength(1);
+    expect(map[0]?.volume).toBe("unknown");
+  });
+
+  it("whitespace-only volume string is routed to 'unknown' bucket", () => {
+    const chapters = [makeChapter({ id: "test/ch-1", chapter: "1", volume: "   " })];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map).toHaveLength(1);
+    expect(map[0]?.volume).toBe("unknown");
+  });
+
+  it("mix of numeric, null, and non-numeric volumes → numeric buckets ascending then 'unknown'", () => {
+    const chapters = [
+      makeChapter({ id: "test/ch-1", chapter: "1", volume: "1" }),
+      makeChapter({ id: "test/ch-2", chapter: "2", volume: null }),
+      makeChapter({ id: "test/ch-3", chapter: "3", volume: "Extra" }),
+      makeChapter({ id: "test/ch-4", chapter: "4", volume: "2" }),
+      makeChapter({ id: "test/ch-5", chapter: "5", volume: "side-story" }),
+    ];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map.map((b) => b.volume)).toEqual(["1", "2", "unknown"]);
+    // null + "Extra" + "side-story" all land in unknown (3 chapters)
+    const unknown = map.find((b) => b.volume === "unknown");
+    expect(unknown?.chapters).toHaveLength(3);
+  });
+
   it("chapters within a numeric bucket are sorted ascending", () => {
     const chapters = [
       makeChapter({ id: "test/ch-3", chapter: "3", volume: "1" }),

--- a/src/integrations/mangakakalot/client/volume-parser.test.ts
+++ b/src/integrations/mangakakalot/client/volume-parser.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { MangakakalotParseError } from "./types.ts";
-import { parseVolumeMapping } from "./volume-parser.ts";
+import { chaptersToVolumeMap, parseVolumeMapping } from "./volume-parser.ts";
 
 const fixturesDir = join(import.meta.dir, "../../../../tests/fixtures/mangakakalot");
 
@@ -194,5 +194,77 @@ describe("parseVolumeMapping — edge cases", () => {
     const vol13 = map.find((b) => b.volume === "13");
     const nums = vol13?.chapters.map((c) => Number(c.chapter)) ?? [];
     expect(nums).toEqual([...nums].sort((a, b) => a - b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chaptersToVolumeMap
+// ---------------------------------------------------------------------------
+
+function makeChapter(overrides: {
+  id: string;
+  chapter: string;
+  volume?: string | null;
+}) {
+  return {
+    id: overrides.id,
+    volume: overrides.volume ?? null,
+    chapter: overrides.chapter,
+    title: null,
+    translatedLanguage: "en",
+    scanlationGroup: null,
+    readableAt: "2024-01-01T00:00:00.000000Z",
+    externalUrl: null,
+  };
+}
+
+describe("chaptersToVolumeMap", () => {
+  it("empty array → empty VolumeMap", () => {
+    expect(chaptersToVolumeMap([])).toEqual([]);
+  });
+
+  it("all volume:null → single 'unknown' bucket sorted ascending", () => {
+    const chapters = [
+      makeChapter({ id: "naruto/ch-10", chapter: "10" }),
+      makeChapter({ id: "naruto/ch-1", chapter: "1" }),
+      makeChapter({ id: "naruto/ch-5", chapter: "5" }),
+    ];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map).toHaveLength(1);
+    expect(map[0]?.volume).toBe("unknown");
+    expect(map[0]?.chapters.map((c) => c.chapter)).toEqual(["1", "5", "10"]);
+  });
+
+  it("passes chapter id through unchanged", () => {
+    const chapters = [makeChapter({ id: "naruto/chapter-700", chapter: "700" })];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map[0]?.chapters[0]?.id).toBe("naruto/chapter-700");
+  });
+
+  it("mix of numeric volumes → numeric buckets ascending, unknown last", () => {
+    const chapters = [
+      makeChapter({ id: "test/ch-1", chapter: "1", volume: "1" }),
+      makeChapter({ id: "test/ch-2", chapter: "2", volume: "3" }),
+      makeChapter({ id: "test/ch-3", chapter: "3", volume: null }),
+      makeChapter({ id: "test/ch-4", chapter: "4", volume: "2" }),
+    ];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map.map((b) => b.volume)).toEqual(["1", "2", "3", "unknown"]);
+  });
+
+  it("empty string volume treated as unknown", () => {
+    const chapters = [makeChapter({ id: "test/ch-1", chapter: "1", volume: "" })];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map[0]?.volume).toBe("unknown");
+  });
+
+  it("chapters within a numeric bucket are sorted ascending", () => {
+    const chapters = [
+      makeChapter({ id: "test/ch-3", chapter: "3", volume: "1" }),
+      makeChapter({ id: "test/ch-1", chapter: "1", volume: "1" }),
+      makeChapter({ id: "test/ch-2", chapter: "2", volume: "1" }),
+    ];
+    const map = chaptersToVolumeMap(chapters);
+    expect(map[0]?.chapters.map((c) => c.chapter)).toEqual(["1", "2", "3"]);
   });
 });

--- a/src/integrations/mangakakalot/client/volume-parser.ts
+++ b/src/integrations/mangakakalot/client/volume-parser.ts
@@ -86,7 +86,14 @@ export function chaptersToVolumeMap(chapters: ChapterRef[]): VolumeMap {
   const buckets = new Map<string, FallbackChapterRef[]>();
 
   for (const ch of chapters) {
-    const vol = ch.volume?.trim() ? String(Number(ch.volume)) : "unknown";
+    const rawVol = ch.volume?.trim();
+    let vol: string;
+    if (!rawVol) {
+      vol = "unknown";
+    } else {
+      const num = Number(rawVol);
+      vol = Number.isFinite(num) ? String(num) : "unknown";
+    }
     const existing = buckets.get(vol) ?? [];
     existing.push({ id: ch.id, chapter: ch.chapter });
     buckets.set(vol, existing);

--- a/src/integrations/mangakakalot/client/volume-parser.ts
+++ b/src/integrations/mangakakalot/client/volume-parser.ts
@@ -2,6 +2,7 @@
 // Chapter names on the manga page follow the pattern "Vol.X Ch.Y [- Optional Title]"
 // or just "Chapter N [- Optional Title]" (flat list, no volume labels).
 
+import type { ChapterRef } from "@integrations/_shared/manga.ts";
 import * as cheerio from "cheerio";
 import type { FallbackChapterRef, VolumeMap } from "./types.ts";
 import { MangakakalotParseError } from "./types.ts";
@@ -69,6 +70,48 @@ function compositeIdFromUrl(href: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Converts a flat ChapterRef[] (typically from the JSON API) into a VolumeMap.
+ *
+ * Buckets by chapter.volume; null/empty volume → "unknown" bucket.
+ * Output is sorted: numeric volume keys ascending, "unknown" last;
+ * chapters within each bucket sorted ascending by chapter number.
+ *
+ * Composite id format: passes through chapter.id unchanged (already
+ * "<mangaSlug>/<chapter-slug>" from parseChapterListFromApi).
+ */
+export function chaptersToVolumeMap(chapters: ChapterRef[]): VolumeMap {
+  const buckets = new Map<string, FallbackChapterRef[]>();
+
+  for (const ch of chapters) {
+    const vol = ch.volume?.trim() ? String(Number(ch.volume)) : "unknown";
+    const existing = buckets.get(vol) ?? [];
+    existing.push({ id: ch.id, chapter: ch.chapter });
+    buckets.set(vol, existing);
+  }
+
+  const sorted: VolumeMap = [];
+  const numericKeys = [...buckets.keys()]
+    .filter((k) => k !== "unknown")
+    .sort((a, b) => Number(a) - Number(b));
+
+  for (const vol of numericKeys) {
+    const chs = (buckets.get(vol) ?? []).sort(
+      (a, b) => Number(a.chapter ?? 0) - Number(b.chapter ?? 0),
+    );
+    sorted.push({ volume: vol, chapters: chs });
+  }
+
+  if (buckets.has("unknown")) {
+    const chs = (buckets.get("unknown") ?? []).sort(
+      (a, b) => Number(a.chapter ?? 0) - Number(b.chapter ?? 0),
+    );
+    sorted.push({ volume: "unknown", chapters: chs });
+  }
+
+  return sorted;
 }
 
 /**

--- a/tests/fixtures/mangakakalot/api-chapters-naruto-page0.json
+++ b/tests/fixtures/mangakakalot/api-chapters-naruto-page0.json
@@ -1,0 +1,358 @@
+{
+  "success": true,
+  "data": {
+    "chapters": [
+      {
+        "chapter_name": "Chapter 700.6",
+        "chapter_slug": "chapter-700-6",
+        "chapter_num": 700.6,
+        "updated_at": "2025-10-07T13:34:02.000000Z",
+        "view": 5122
+      },
+      {
+        "chapter_name": "Chapter 700.5",
+        "chapter_slug": "chapter-700-5",
+        "chapter_num": 700.5,
+        "updated_at": "2024-11-01T01:28:16.000000Z",
+        "view": 488797
+      },
+      {
+        "chapter_name": "Chapter 700.3",
+        "chapter_slug": "chapter-700-3",
+        "chapter_num": 700.3,
+        "updated_at": "2025-10-07T13:33:51.000000Z",
+        "view": 760
+      },
+      {
+        "chapter_name": "Chapter 700.2",
+        "chapter_slug": "chapter-700-2",
+        "chapter_num": 700.2,
+        "updated_at": "2025-10-07T13:33:41.000000Z",
+        "view": 1027
+      },
+      {
+        "chapter_name": "Chapter 700.1",
+        "chapter_slug": "chapter-700-1",
+        "chapter_num": 700.1,
+        "updated_at": "2024-11-01T01:27:15.000000Z",
+        "view": 258328
+      },
+      {
+        "chapter_name": "Chapter 700",
+        "chapter_slug": "chapter-700",
+        "chapter_num": 700,
+        "updated_at": "2024-11-01T01:26:10.000000Z",
+        "view": 282258
+      },
+      {
+        "chapter_name": "Chapter 699.5",
+        "chapter_slug": "chapter-699-5",
+        "chapter_num": 699.5,
+        "updated_at": "2024-11-01T01:25:07.000000Z",
+        "view": 212660
+      },
+      {
+        "chapter_name": "Chapter 699.1",
+        "chapter_slug": "chapter-699-1",
+        "chapter_num": 699.1,
+        "updated_at": "2024-11-01T01:24:46.000000Z",
+        "view": 168781
+      },
+      {
+        "chapter_name": "Chapter 699",
+        "chapter_slug": "chapter-699",
+        "chapter_num": 699,
+        "updated_at": "2024-11-01T01:23:44.000000Z",
+        "view": 162353
+      },
+      {
+        "chapter_name": "Chapter 698.5",
+        "chapter_slug": "chapter-698-5",
+        "chapter_num": 698.5,
+        "updated_at": "2025-10-07T13:33:37.000000Z",
+        "view": 1102
+      },
+      {
+        "chapter_name": "Chapter 698.1",
+        "chapter_slug": "chapter-698-1",
+        "chapter_num": 698.1,
+        "updated_at": "2024-11-01T01:22:35.000000Z",
+        "view": 122514
+      },
+      {
+        "chapter_name": "Chapter 698",
+        "chapter_slug": "chapter-698",
+        "chapter_num": 698,
+        "updated_at": "2024-11-01T01:21:52.000000Z",
+        "view": 113354
+      },
+      {
+        "chapter_name": "Chapter 697.5",
+        "chapter_slug": "chapter-697-5",
+        "chapter_num": 697.5,
+        "updated_at": "2025-10-07T13:33:31.000000Z",
+        "view": 958
+      },
+      {
+        "chapter_name": "Chapter 697.1",
+        "chapter_slug": "chapter-697-1",
+        "chapter_num": 697.1,
+        "updated_at": "2024-11-01T01:20:28.000000Z",
+        "view": 86507
+      },
+      {
+        "chapter_name": "Chapter 697",
+        "chapter_slug": "chapter-697",
+        "chapter_num": 697,
+        "updated_at": "2024-11-01T01:19:02.000000Z",
+        "view": 93055
+      },
+      {
+        "chapter_name": "Chapter 696.5",
+        "chapter_slug": "chapter-696-5",
+        "chapter_num": 696.5,
+        "updated_at": "2025-10-07T13:33:26.000000Z",
+        "view": 358
+      },
+      {
+        "chapter_name": "Chapter 696.1",
+        "chapter_slug": "chapter-696-1",
+        "chapter_num": 696.1,
+        "updated_at": "2024-11-01T01:18:03.000000Z",
+        "view": 81621
+      },
+      {
+        "chapter_name": "Chapter 696",
+        "chapter_slug": "chapter-696",
+        "chapter_num": 696,
+        "updated_at": "2024-11-01T01:16:58.000000Z",
+        "view": 89319
+      },
+      {
+        "chapter_name": "Chapter 695.5",
+        "chapter_slug": "chapter-695-5",
+        "chapter_num": 695.5,
+        "updated_at": "2025-10-07T13:33:20.000000Z",
+        "view": 961
+      },
+      {
+        "chapter_name": "Chapter 695.1",
+        "chapter_slug": "chapter-695-1",
+        "chapter_num": 695.1,
+        "updated_at": "2024-11-01T01:15:35.000000Z",
+        "view": 82937
+      },
+      {
+        "chapter_name": "Chapter 695",
+        "chapter_slug": "chapter-695",
+        "chapter_num": 695,
+        "updated_at": "2024-11-01T01:14:29.000000Z",
+        "view": 94075
+      },
+      {
+        "chapter_name": "Chapter 694.1",
+        "chapter_slug": "chapter-694-1",
+        "chapter_num": 694.1,
+        "updated_at": "2024-11-01T01:13:12.000000Z",
+        "view": 91983
+      },
+      {
+        "chapter_name": "Chapter 694",
+        "chapter_slug": "chapter-694",
+        "chapter_num": 694,
+        "updated_at": "2024-11-01T01:11:55.000000Z",
+        "view": 101399
+      },
+      {
+        "chapter_name": "Chapter 693.5",
+        "chapter_slug": "chapter-693-5",
+        "chapter_num": 693.5,
+        "updated_at": "2025-10-07T13:33:13.000000Z",
+        "view": 924
+      },
+      {
+        "chapter_name": "Chapter 693.1",
+        "chapter_slug": "chapter-693-1",
+        "chapter_num": 693.1,
+        "updated_at": "2024-11-01T01:10:24.000000Z",
+        "view": 80378
+      },
+      {
+        "chapter_name": "Chapter 693",
+        "chapter_slug": "chapter-693",
+        "chapter_num": 693,
+        "updated_at": "2024-11-01T01:09:01.000000Z",
+        "view": 89398
+      },
+      {
+        "chapter_name": "Chapter 692.5",
+        "chapter_slug": "chapter-692-5",
+        "chapter_num": 692.5,
+        "updated_at": "2025-10-07T13:33:08.000000Z",
+        "view": 878
+      },
+      {
+        "chapter_name": "Chapter 692.1",
+        "chapter_slug": "chapter-692-1",
+        "chapter_num": 692.1,
+        "updated_at": "2024-11-01T01:07:51.000000Z",
+        "view": 78473
+      },
+      {
+        "chapter_name": "Chapter 692",
+        "chapter_slug": "chapter-692",
+        "chapter_num": 692,
+        "updated_at": "2024-11-01T01:06:52.000000Z",
+        "view": 90977
+      },
+      {
+        "chapter_name": "Chapter 691.5",
+        "chapter_slug": "chapter-691-5",
+        "chapter_num": 691.5,
+        "updated_at": "2025-10-07T13:33:02.000000Z",
+        "view": 870
+      },
+      {
+        "chapter_name": "Chapter 691.1",
+        "chapter_slug": "chapter-691-1",
+        "chapter_num": 691.1,
+        "updated_at": "2024-11-01T01:05:49.000000Z",
+        "view": 83284
+      },
+      {
+        "chapter_name": "Chapter 691",
+        "chapter_slug": "chapter-691",
+        "chapter_num": 691,
+        "updated_at": "2024-11-01T01:04:35.000000Z",
+        "view": 92990
+      },
+      {
+        "chapter_name": "Chapter 690.5",
+        "chapter_slug": "chapter-690-5",
+        "chapter_num": 690.5,
+        "updated_at": "2025-10-07T13:32:57.000000Z",
+        "view": 508
+      },
+      {
+        "chapter_name": "Chapter 690.1",
+        "chapter_slug": "chapter-690-1",
+        "chapter_num": 690.1,
+        "updated_at": "2024-11-01T01:03:04.000000Z",
+        "view": 79916
+      },
+      {
+        "chapter_name": "Chapter 690",
+        "chapter_slug": "chapter-690",
+        "chapter_num": 690,
+        "updated_at": "2024-11-01T01:02:05.000000Z",
+        "view": 88625
+      },
+      {
+        "chapter_name": "Chapter 689.5",
+        "chapter_slug": "chapter-689-5",
+        "chapter_num": 689.5,
+        "updated_at": "2025-10-07T13:32:51.000000Z",
+        "view": 840
+      },
+      {
+        "chapter_name": "Chapter 689.1",
+        "chapter_slug": "chapter-689-1",
+        "chapter_num": 689.1,
+        "updated_at": "2024-11-01T01:00:56.000000Z",
+        "view": 86346
+      },
+      {
+        "chapter_name": "Chapter 689",
+        "chapter_slug": "chapter-689",
+        "chapter_num": 689,
+        "updated_at": "2024-11-01T00:59:41.000000Z",
+        "view": 97933
+      },
+      {
+        "chapter_name": "Chapter 688.5",
+        "chapter_slug": "chapter-688-5",
+        "chapter_num": 688.5,
+        "updated_at": "2025-10-07T13:32:44.000000Z",
+        "view": 392
+      },
+      {
+        "chapter_name": "Chapter 688.1",
+        "chapter_slug": "chapter-688-1",
+        "chapter_num": 688.1,
+        "updated_at": "2024-11-01T00:58:09.000000Z",
+        "view": 78468
+      },
+      {
+        "chapter_name": "Chapter 688",
+        "chapter_slug": "chapter-688",
+        "chapter_num": 688,
+        "updated_at": "2024-11-01T00:57:19.000000Z",
+        "view": 83386
+      },
+      {
+        "chapter_name": "Chapter 687.5",
+        "chapter_slug": "chapter-687-5",
+        "chapter_num": 687.5,
+        "updated_at": "2025-10-07T13:32:34.000000Z",
+        "view": 575
+      },
+      {
+        "chapter_name": "Chapter 687.1",
+        "chapter_slug": "chapter-687-1",
+        "chapter_num": 687.1,
+        "updated_at": "2024-11-01T00:55:25.000000Z",
+        "view": 75074
+      },
+      {
+        "chapter_name": "Chapter 687",
+        "chapter_slug": "chapter-687",
+        "chapter_num": 687,
+        "updated_at": "2024-11-01T00:54:40.000000Z",
+        "view": 81917
+      },
+      {
+        "chapter_name": "Chapter 686.5",
+        "chapter_slug": "chapter-686-5",
+        "chapter_num": 686.5,
+        "updated_at": "2025-10-07T13:32:28.000000Z",
+        "view": 991
+      },
+      {
+        "chapter_name": "Chapter 686.1",
+        "chapter_slug": "chapter-686-1",
+        "chapter_num": 686.1,
+        "updated_at": "2024-11-01T00:53:21.000000Z",
+        "view": 73673
+      },
+      {
+        "chapter_name": "Chapter 686",
+        "chapter_slug": "chapter-686",
+        "chapter_num": 686,
+        "updated_at": "2024-11-01T00:52:24.000000Z",
+        "view": 80686
+      },
+      {
+        "chapter_name": "Chapter 685.5",
+        "chapter_slug": "chapter-685-5",
+        "chapter_num": 685.5,
+        "updated_at": "2025-10-07T13:32:23.000000Z",
+        "view": 893
+      },
+      {
+        "chapter_name": "Chapter 685.1",
+        "chapter_slug": "chapter-685-1",
+        "chapter_num": 685.1,
+        "updated_at": "2024-11-01T00:51:13.000000Z",
+        "view": 73452
+      },
+      {
+        "chapter_name": "Chapter 685",
+        "chapter_slug": "chapter-685",
+        "chapter_num": 685,
+        "updated_at": "2024-11-01T00:50:09.000000Z",
+        "view": 78942
+      }
+    ],
+    "pagination": { "total": 787, "limit": 50, "offset": 0, "has_more": true }
+  }
+}

--- a/tests/fixtures/mangakakalot/api-chapters-naruto-page400.json
+++ b/tests/fixtures/mangakakalot/api-chapters-naruto-page400.json
@@ -1,0 +1,358 @@
+{
+  "success": true,
+  "data": {
+    "chapters": [
+      {
+        "chapter_name": "Chapter 382",
+        "chapter_slug": "chapter-382",
+        "chapter_num": 382,
+        "updated_at": "2024-10-31T17:49:40.000000Z",
+        "view": 77365
+      },
+      {
+        "chapter_name": "Chapter 381",
+        "chapter_slug": "chapter-381",
+        "chapter_num": 381,
+        "updated_at": "2024-10-31T17:46:56.000000Z",
+        "view": 76349
+      },
+      {
+        "chapter_name": "Chapter 380",
+        "chapter_slug": "chapter-380",
+        "chapter_num": 380,
+        "updated_at": "2024-10-31T17:45:28.000000Z",
+        "view": 75100
+      },
+      {
+        "chapter_name": "Chapter 379",
+        "chapter_slug": "chapter-379",
+        "chapter_num": 379,
+        "updated_at": "2024-10-31T17:44:02.000000Z",
+        "view": 73169
+      },
+      {
+        "chapter_name": "Chapter 378",
+        "chapter_slug": "chapter-378",
+        "chapter_num": 378,
+        "updated_at": "2024-10-31T17:43:03.000000Z",
+        "view": 68973
+      },
+      {
+        "chapter_name": "Chapter 377",
+        "chapter_slug": "chapter-377",
+        "chapter_num": 377,
+        "updated_at": "2024-10-31T17:41:58.000000Z",
+        "view": 70804
+      },
+      {
+        "chapter_name": "Chapter 376",
+        "chapter_slug": "chapter-376",
+        "chapter_num": 376,
+        "updated_at": "2024-10-31T17:40:46.000000Z",
+        "view": 70523
+      },
+      {
+        "chapter_name": "Chapter 375",
+        "chapter_slug": "chapter-375",
+        "chapter_num": 375,
+        "updated_at": "2024-10-31T17:39:50.000000Z",
+        "view": 70741
+      },
+      {
+        "chapter_name": "Chapter 374",
+        "chapter_slug": "chapter-374",
+        "chapter_num": 374,
+        "updated_at": "2024-10-31T17:37:58.000000Z",
+        "view": 71354
+      },
+      {
+        "chapter_name": "Chapter 373",
+        "chapter_slug": "chapter-373",
+        "chapter_num": 373,
+        "updated_at": "2024-10-31T17:36:43.000000Z",
+        "view": 73338
+      },
+      {
+        "chapter_name": "Chapter 372",
+        "chapter_slug": "chapter-372",
+        "chapter_num": 372,
+        "updated_at": "2024-10-31T17:35:26.000000Z",
+        "view": 71787
+      },
+      {
+        "chapter_name": "Chapter 371",
+        "chapter_slug": "chapter-371",
+        "chapter_num": 371,
+        "updated_at": "2024-10-31T17:33:43.000000Z",
+        "view": 72487
+      },
+      {
+        "chapter_name": "Chapter 370",
+        "chapter_slug": "chapter-370",
+        "chapter_num": 370,
+        "updated_at": "2024-10-31T17:32:19.000000Z",
+        "view": 73626
+      },
+      {
+        "chapter_name": "Chapter 369",
+        "chapter_slug": "chapter-369",
+        "chapter_num": 369,
+        "updated_at": "2024-10-31T17:31:21.000000Z",
+        "view": 74230
+      },
+      {
+        "chapter_name": "Chapter 368",
+        "chapter_slug": "chapter-368",
+        "chapter_num": 368,
+        "updated_at": "2024-10-31T17:30:16.000000Z",
+        "view": 73829
+      },
+      {
+        "chapter_name": "Chapter 367",
+        "chapter_slug": "chapter-367",
+        "chapter_num": 367,
+        "updated_at": "2024-10-31T17:29:11.000000Z",
+        "view": 77227
+      },
+      {
+        "chapter_name": "Chapter 366",
+        "chapter_slug": "chapter-366",
+        "chapter_num": 366,
+        "updated_at": "2024-10-31T17:28:05.000000Z",
+        "view": 72039
+      },
+      {
+        "chapter_name": "Chapter 365",
+        "chapter_slug": "chapter-365",
+        "chapter_num": 365,
+        "updated_at": "2024-10-31T17:27:01.000000Z",
+        "view": 70538
+      },
+      {
+        "chapter_name": "Chapter 364",
+        "chapter_slug": "chapter-364",
+        "chapter_num": 364,
+        "updated_at": "2024-10-31T17:25:38.000000Z",
+        "view": 70968
+      },
+      {
+        "chapter_name": "Chapter 363",
+        "chapter_slug": "chapter-363",
+        "chapter_num": 363,
+        "updated_at": "2024-10-31T17:24:17.000000Z",
+        "view": 72961
+      },
+      {
+        "chapter_name": "Chapter 362",
+        "chapter_slug": "chapter-362",
+        "chapter_num": 362,
+        "updated_at": "2024-10-31T17:22:51.000000Z",
+        "view": 69655
+      },
+      {
+        "chapter_name": "Chapter 361",
+        "chapter_slug": "chapter-361",
+        "chapter_num": 361,
+        "updated_at": "2024-10-31T17:21:26.000000Z",
+        "view": 69030
+      },
+      {
+        "chapter_name": "Chapter 360",
+        "chapter_slug": "chapter-360",
+        "chapter_num": 360,
+        "updated_at": "2024-10-31T17:20:20.000000Z",
+        "view": 69185
+      },
+      {
+        "chapter_name": "Chapter 359",
+        "chapter_slug": "chapter-359",
+        "chapter_num": 359,
+        "updated_at": "2024-10-31T17:18:03.000000Z",
+        "view": 68419
+      },
+      {
+        "chapter_name": "Chapter 358",
+        "chapter_slug": "chapter-358",
+        "chapter_num": 358,
+        "updated_at": "2024-10-31T17:16:39.000000Z",
+        "view": 70597
+      },
+      {
+        "chapter_name": "Chapter 357",
+        "chapter_slug": "chapter-357",
+        "chapter_num": 357,
+        "updated_at": "2024-10-31T17:14:48.000000Z",
+        "view": 74358
+      },
+      {
+        "chapter_name": "Chapter 356",
+        "chapter_slug": "chapter-356",
+        "chapter_num": 356,
+        "updated_at": "2024-10-31T17:13:50.000000Z",
+        "view": 69544
+      },
+      {
+        "chapter_name": "Chapter 355",
+        "chapter_slug": "chapter-355",
+        "chapter_num": 355,
+        "updated_at": "2024-10-31T17:12:38.000000Z",
+        "view": 71420
+      },
+      {
+        "chapter_name": "Chapter 354",
+        "chapter_slug": "chapter-354",
+        "chapter_num": 354,
+        "updated_at": "2024-10-31T17:11:12.000000Z",
+        "view": 72964
+      },
+      {
+        "chapter_name": "Chapter 353",
+        "chapter_slug": "chapter-353",
+        "chapter_num": 353,
+        "updated_at": "2024-10-31T17:09:39.000000Z",
+        "view": 76752
+      },
+      {
+        "chapter_name": "Chapter 352",
+        "chapter_slug": "chapter-352",
+        "chapter_num": 352,
+        "updated_at": "2024-10-31T17:07:57.000000Z",
+        "view": 71138
+      },
+      {
+        "chapter_name": "Chapter 351",
+        "chapter_slug": "chapter-351",
+        "chapter_num": 351,
+        "updated_at": "2024-10-31T17:06:55.000000Z",
+        "view": 71548
+      },
+      {
+        "chapter_name": "Chapter 350",
+        "chapter_slug": "chapter-350",
+        "chapter_num": 350,
+        "updated_at": "2024-10-31T17:05:16.000000Z",
+        "view": 72929
+      },
+      {
+        "chapter_name": "Chapter 349",
+        "chapter_slug": "chapter-349",
+        "chapter_num": 349,
+        "updated_at": "2024-10-31T17:04:14.000000Z",
+        "view": 71087
+      },
+      {
+        "chapter_name": "Chapter 348",
+        "chapter_slug": "chapter-348",
+        "chapter_num": 348,
+        "updated_at": "2024-10-31T17:02:43.000000Z",
+        "view": 72073
+      },
+      {
+        "chapter_name": "Chapter 347",
+        "chapter_slug": "chapter-347",
+        "chapter_num": 347,
+        "updated_at": "2024-10-31T17:01:31.000000Z",
+        "view": 76436
+      },
+      {
+        "chapter_name": "Chapter 346",
+        "chapter_slug": "chapter-346",
+        "chapter_num": 346,
+        "updated_at": "2024-10-31T17:00:21.000000Z",
+        "view": 78241
+      },
+      {
+        "chapter_name": "Chapter 345.1",
+        "chapter_slug": "chapter-345-1",
+        "chapter_num": 345.1,
+        "updated_at": "2024-10-31T16:58:53.000000Z",
+        "view": 69655
+      },
+      {
+        "chapter_name": "Chapter 345",
+        "chapter_slug": "chapter-345",
+        "chapter_num": 345,
+        "updated_at": "2024-10-31T16:57:38.000000Z",
+        "view": 72486
+      },
+      {
+        "chapter_name": "Chapter 344",
+        "chapter_slug": "chapter-344",
+        "chapter_num": 344,
+        "updated_at": "2024-10-31T16:56:39.000000Z",
+        "view": 74928
+      },
+      {
+        "chapter_name": "Chapter 343",
+        "chapter_slug": "chapter-343",
+        "chapter_num": 343,
+        "updated_at": "2024-10-31T16:55:39.000000Z",
+        "view": 78601
+      },
+      {
+        "chapter_name": "Chapter 342",
+        "chapter_slug": "chapter-342",
+        "chapter_num": 342,
+        "updated_at": "2024-10-31T16:53:54.000000Z",
+        "view": 81736
+      },
+      {
+        "chapter_name": "Chapter 341",
+        "chapter_slug": "chapter-341",
+        "chapter_num": 341,
+        "updated_at": "2024-10-31T16:52:11.000000Z",
+        "view": 78594
+      },
+      {
+        "chapter_name": "Chapter 340",
+        "chapter_slug": "chapter-340",
+        "chapter_num": 340,
+        "updated_at": "2024-10-31T16:50:45.000000Z",
+        "view": 76884
+      },
+      {
+        "chapter_name": "Chapter 339",
+        "chapter_slug": "chapter-339",
+        "chapter_num": 339,
+        "updated_at": "2024-10-31T16:49:48.000000Z",
+        "view": 79722
+      },
+      {
+        "chapter_name": "Chapter 338",
+        "chapter_slug": "chapter-338",
+        "chapter_num": 338,
+        "updated_at": "2024-10-31T16:48:01.000000Z",
+        "view": 77366
+      },
+      {
+        "chapter_name": "Chapter 337",
+        "chapter_slug": "chapter-337",
+        "chapter_num": 337,
+        "updated_at": "2024-10-31T16:45:59.000000Z",
+        "view": 74527
+      },
+      {
+        "chapter_name": "Chapter 336",
+        "chapter_slug": "chapter-336",
+        "chapter_num": 336,
+        "updated_at": "2024-10-31T16:44:32.000000Z",
+        "view": 72153
+      },
+      {
+        "chapter_name": "Chapter 335",
+        "chapter_slug": "chapter-335",
+        "chapter_num": 335,
+        "updated_at": "2024-10-31T16:43:26.000000Z",
+        "view": 74443
+      },
+      {
+        "chapter_name": "Chapter 334",
+        "chapter_slug": "chapter-334",
+        "chapter_num": 334,
+        "updated_at": "2024-10-31T16:42:06.000000Z",
+        "view": 75032
+      }
+    ],
+    "pagination": { "total": 787, "limit": 50, "offset": 400, "has_more": true }
+  }
+}

--- a/tests/fixtures/mangakakalot/api-chapters-naruto-page750.json
+++ b/tests/fixtures/mangakakalot/api-chapters-naruto-page750.json
@@ -1,0 +1,267 @@
+{
+  "success": true,
+  "data": {
+    "chapters": [
+      {
+        "chapter_name": "Chapter 35",
+        "chapter_slug": "chapter-35",
+        "chapter_num": 35,
+        "updated_at": "2024-10-31T10:02:16.000000Z",
+        "view": 89220
+      },
+      {
+        "chapter_name": "Chapter 34",
+        "chapter_slug": "chapter-34",
+        "chapter_num": 34,
+        "updated_at": "2024-10-31T10:01:03.000000Z",
+        "view": 105779
+      },
+      {
+        "chapter_name": "Chapter 33",
+        "chapter_slug": "chapter-33",
+        "chapter_num": 33,
+        "updated_at": "2024-10-31T09:59:43.000000Z",
+        "view": 89007
+      },
+      {
+        "chapter_name": "Chapter 32",
+        "chapter_slug": "chapter-32",
+        "chapter_num": 32,
+        "updated_at": "2024-10-31T09:58:37.000000Z",
+        "view": 87841
+      },
+      {
+        "chapter_name": "Chapter 31",
+        "chapter_slug": "chapter-31",
+        "chapter_num": 31,
+        "updated_at": "2024-10-31T09:57:18.000000Z",
+        "view": 85004
+      },
+      {
+        "chapter_name": "Chapter 30",
+        "chapter_slug": "chapter-30",
+        "chapter_num": 30,
+        "updated_at": "2024-10-31T09:55:53.000000Z",
+        "view": 87151
+      },
+      {
+        "chapter_name": "Chapter 29",
+        "chapter_slug": "chapter-29",
+        "chapter_num": 29,
+        "updated_at": "2024-10-31T09:54:52.000000Z",
+        "view": 89348
+      },
+      {
+        "chapter_name": "Chapter 28",
+        "chapter_slug": "chapter-28",
+        "chapter_num": 28,
+        "updated_at": "2024-10-31T09:53:46.000000Z",
+        "view": 94075
+      },
+      {
+        "chapter_name": "Chapter 27",
+        "chapter_slug": "chapter-27",
+        "chapter_num": 27,
+        "updated_at": "2024-10-31T09:52:23.000000Z",
+        "view": 90177
+      },
+      {
+        "chapter_name": "Chapter 26",
+        "chapter_slug": "chapter-26",
+        "chapter_num": 26,
+        "updated_at": "2024-10-31T09:51:11.000000Z",
+        "view": 86768
+      },
+      {
+        "chapter_name": "Chapter 25",
+        "chapter_slug": "chapter-25",
+        "chapter_num": 25,
+        "updated_at": "2024-10-31T09:49:55.000000Z",
+        "view": 85273
+      },
+      {
+        "chapter_name": "Chapter 24",
+        "chapter_slug": "chapter-24",
+        "chapter_num": 24,
+        "updated_at": "2024-10-31T09:49:05.000000Z",
+        "view": 84763
+      },
+      {
+        "chapter_name": "Chapter 23",
+        "chapter_slug": "chapter-23",
+        "chapter_num": 23,
+        "updated_at": "2024-10-31T09:47:51.000000Z",
+        "view": 85126
+      },
+      {
+        "chapter_name": "Chapter 22",
+        "chapter_slug": "chapter-22",
+        "chapter_num": 22,
+        "updated_at": "2024-10-31T09:44:56.000000Z",
+        "view": 86365
+      },
+      {
+        "chapter_name": "Chapter 21",
+        "chapter_slug": "chapter-21",
+        "chapter_num": 21,
+        "updated_at": "2024-10-31T09:43:15.000000Z",
+        "view": 85439
+      },
+      {
+        "chapter_name": "Chapter 20",
+        "chapter_slug": "chapter-20",
+        "chapter_num": 20,
+        "updated_at": "2024-10-31T09:41:56.000000Z",
+        "view": 88187
+      },
+      {
+        "chapter_name": "Chapter 19",
+        "chapter_slug": "chapter-19",
+        "chapter_num": 19,
+        "updated_at": "2024-10-31T09:40:37.000000Z",
+        "view": 87043
+      },
+      {
+        "chapter_name": "Chapter 18",
+        "chapter_slug": "chapter-18",
+        "chapter_num": 18,
+        "updated_at": "2024-10-31T09:39:41.000000Z",
+        "view": 91739
+      },
+      {
+        "chapter_name": "Chapter 17",
+        "chapter_slug": "chapter-17",
+        "chapter_num": 17,
+        "updated_at": "2024-10-31T09:37:45.000000Z",
+        "view": 93693
+      },
+      {
+        "chapter_name": "Chapter 16",
+        "chapter_slug": "chapter-16",
+        "chapter_num": 16,
+        "updated_at": "2024-10-31T09:36:45.000000Z",
+        "view": 94956
+      },
+      {
+        "chapter_name": "Chapter 15",
+        "chapter_slug": "chapter-15",
+        "chapter_num": 15,
+        "updated_at": "2024-10-31T09:35:34.000000Z",
+        "view": 97200
+      },
+      {
+        "chapter_name": "Chapter 14",
+        "chapter_slug": "chapter-14",
+        "chapter_num": 14,
+        "updated_at": "2024-10-31T09:34:24.000000Z",
+        "view": 98125
+      },
+      {
+        "chapter_name": "Chapter 13",
+        "chapter_slug": "chapter-13",
+        "chapter_num": 13,
+        "updated_at": "2024-10-31T09:33:01.000000Z",
+        "view": 95734
+      },
+      {
+        "chapter_name": "Chapter 12",
+        "chapter_slug": "chapter-12",
+        "chapter_num": 12,
+        "updated_at": "2024-10-31T09:31:47.000000Z",
+        "view": 96969
+      },
+      {
+        "chapter_name": "Chapter 11",
+        "chapter_slug": "chapter-11",
+        "chapter_num": 11,
+        "updated_at": "2024-10-31T09:30:37.000000Z",
+        "view": 103017
+      },
+      {
+        "chapter_name": "Chapter 10",
+        "chapter_slug": "chapter-10",
+        "chapter_num": 10,
+        "updated_at": "2024-10-31T09:28:53.000000Z",
+        "view": 106883
+      },
+      {
+        "chapter_name": "Chapter 9",
+        "chapter_slug": "chapter-9",
+        "chapter_num": 9,
+        "updated_at": "2024-10-31T09:27:37.000000Z",
+        "view": 113402
+      },
+      {
+        "chapter_name": "Chapter 8",
+        "chapter_slug": "chapter-8",
+        "chapter_num": 8,
+        "updated_at": "2024-10-31T09:26:27.000000Z",
+        "view": 113358
+      },
+      {
+        "chapter_name": "Chapter 7",
+        "chapter_slug": "chapter-7",
+        "chapter_num": 7,
+        "updated_at": "2024-10-31T09:24:56.000000Z",
+        "view": 110891
+      },
+      {
+        "chapter_name": "Chapter 6",
+        "chapter_slug": "chapter-6",
+        "chapter_num": 6,
+        "updated_at": "2024-10-31T09:23:42.000000Z",
+        "view": 110603
+      },
+      {
+        "chapter_name": "Chapter 5",
+        "chapter_slug": "chapter-5",
+        "chapter_num": 5,
+        "updated_at": "2024-10-31T09:22:36.000000Z",
+        "view": 117493
+      },
+      {
+        "chapter_name": "Chapter 4",
+        "chapter_slug": "chapter-4",
+        "chapter_num": 4,
+        "updated_at": "2024-10-31T09:21:55.000000Z",
+        "view": 130654
+      },
+      {
+        "chapter_name": "Chapter 3",
+        "chapter_slug": "chapter-3",
+        "chapter_num": 3,
+        "updated_at": "2024-10-31T09:19:59.000000Z",
+        "view": 138533
+      },
+      {
+        "chapter_name": "Chapter 2",
+        "chapter_slug": "chapter-2",
+        "chapter_num": 2,
+        "updated_at": "2024-10-31T09:18:48.000000Z",
+        "view": 157864
+      },
+      {
+        "chapter_name": "Chapter 1",
+        "chapter_slug": "chapter-1",
+        "chapter_num": 1,
+        "updated_at": "2024-10-31T09:17:26.000000Z",
+        "view": 305725
+      },
+      {
+        "chapter_name": "Chapter 0.1",
+        "chapter_slug": "chapter-0-1",
+        "chapter_num": 0.1,
+        "updated_at": "2025-10-07T13:30:20.000000Z",
+        "view": 836
+      },
+      {
+        "chapter_name": "Chapter 0",
+        "chapter_slug": "chapter-0",
+        "chapter_num": 0,
+        "updated_at": "2024-10-31T09:14:24.000000Z",
+        "view": 279104
+      }
+    ],
+    "pagination": { "total": 787, "limit": 50, "offset": 750, "has_more": false }
+  }
+}


### PR DESCRIPTION
## What this PR does

Wires the existing chapter-list JSON API consumer into `getVolumeMap` so that mangakakalot.gg series serving their chapter list via a client-side API placeholder (e.g. Naruto, per #96) resolve correctly instead of hitting the drift detector.

Three additions:

- `detectChapterApiPlaceholder(html)` in `parser.ts` — returns `{ slug }` from `<div id="chapter-list-container" data-comic-slug="…" data-api-url="…">` or `null`.
- `chaptersToVolumeMap(ChapterRef[])` in `volume-parser.ts` — buckets API output by `chapter.volume` (null/empty/non-numeric → `"unknown"` bucket).
- Routing in `getVolumeMap` (`client/index.ts`) — placeholder detected → `getChapterList(placeholder.slug)` + mapper; else inline path; drift throw still fires when neither path applies.

## Why it exists

PR #96 captured the verbatim Naruto manga page and confirmed mangakakalot.gg has migrated this series' chapter list to a client-side API fetch (no inline `ul.row-content-chapter`). The `MangakakalotParseError` thrown there is correct as a *signal*, but `getVolumeMap` callers can't actually retrieve volumes/chapters for affected series. Issue #95 was opened to wire the missing route. The API consumer (`getChapterList` + `parseChapterListFromApi` + `MkChapterApiResponse` types) was already implemented — only the routing in `getVolumeMap` was missing.

## How it works internally

```typescript
async function getVolumeMap(slug: string): Promise<VolumeMap> {
  const url = `${SITE_ROOT}/manga/${encodeURIComponent(slug)}`;
  const html = await fetchHtml(url);

  const placeholder = detectChapterApiPlaceholder(html);
  if (placeholder) {
    // API path: source of truth is data-comic-slug from the page, not the user-supplied slug.
    const chapters = await getChapterList(placeholder.slug);
    return chaptersToVolumeMap(chapters);
  }

  // Inline path (unchanged): parse ul.row-content-chapter; drift detector throws if absent + page-shaped.
  return runParser(url, () => parseVolumeMapping(html, url));
}
```

`chaptersToVolumeMap` is intentionally conservative: `parseChapterListFromApi` hardcodes `volume: null`, so Naruto resolves as a single `"unknown"` bucket — correct for the AC ("≥ 1 volume bucket"), and mirrors the existing flat-list shape (`manga-page-flat.html`). `Vol.X` extraction from `chapter_name` is deliberately deferred (no real-world series in the captures uses it).

## What did not change

- `parseChapterListFromApi` — untouched.
- `getChapterList` — untouched (already paginates with `MAX_API_PAGES = 20` cap and ascending sort).
- `parseVolumeMapping` and `htmlLooksLikeMangaPage` — untouched (drift detector behavior preserved).
- All inline-path tests (`Dandadan`, `JJK`, `flat list`, synthetic drift, edge cases) — untouched and still pass.

## Test checklist

- [x] `bun test` — 574 pass, 0 fail (was 570 pre-PR; +4 new tests; pre-PR baseline already included PR #96's drift assertions)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — 90 files, no fixes
- [x] Naruto API path returns 1 `"unknown"` bucket with 87 chapters (page0 50 + page750 37), sorted ascending across page boundaries
- [x] Dandadan inline path returns volume buckets from HTML without calling the API (asserted via mocked `http.get` call count)
- [x] Drift fixture throws `MangakakalotParseError` (no regression to #74 detector)
- [x] `MAX_API_PAGES = 20` cap test — loop stops at exactly 20 calls, `mangakakalot.pagination_capped` warn fires
- [x] `chaptersToVolumeMap` defensive: non-numeric volume strings (`"Special"`, whitespace-only) routed to `"unknown"` bucket (silent `"NaN"` bucket impossible)

## Reviewer notes

- **Slug-of-truth.** Routing uses `placeholder.slug` (from `data-comic-slug` in the page HTML), not the user-supplied `slug` argument. Future-proofs against mangakakalot ever serving a different canonical slug than the URL.
- **Fixture format.** The 3 new JSON fixtures are biome-formatted (matches the project convention set by the pre-existing `api-chapters-dandadan.json`). They are *semantically* identical to the production captures from `/tmp/naruto-chapters-page{0,400,750}.json` — JSON whitespace is information-void; the parser reads structure, not bytes.
- **P2 nudges absorbed in this PR.** Inspector's `chaptersToVolumeMap` non-numeric volume guard and QA's `MAX_API_PAGES` cap test were both addressed in commits `b8dc575` and `0381b85` before promoting to ready.
- **P2 deliberately deferred.** Inspector flagged ~20 lines of duplicated bucket sort/serialize between `chaptersToVolumeMap` and `parseVolumeMapping`. Refactor into a shared `serializeBuckets` helper is intentionally out of scope here — if it lands, it should be its own PR with a focused diff so the routing change can be reverted independently if needed.

## Closes

Closes #95
Predecessor: https://github.com/malaquiasdev/scanldr/pull/96 (established `manga-page-naruto-real.html` drift fixture)

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/` (if applicable) — N/A (internal client routing)