### PR TITLE
feat(logger): make JSON the default log format and surface fields in human mode

### DIFF
--- a/docs/overviewer.md
+++ b/docs/overviewer.md
@@ -284,7 +284,8 @@ Flags:
 | Flag | Effect |
 |---|---|
 | `--quiet` / `-q` | Raise the threshold to `warn`. Info lines are suppressed. |
-| `--json` | Emit one JSON object per log line (newline-delimited). Useful for piping into log shippers. |
+| `--json` | No-op alias kept for backward compatibility. JSON is the default format. |
+| `--human` | Switch to human-readable format: `<ts> <level> <msg> <fields-json>`. Fields are appended as a JSON object; omitted when empty. Sensitive keys are still redacted. |
 
 All log lines follow the pino convention: structured fields first, human message last — `logger.warn({ event, context, ...fields }, msg)`.
 

--- a/src/cli-flags.test.ts
+++ b/src/cli-flags.test.ts
@@ -3,19 +3,19 @@ import { parseArgs } from "node:util";
 import { normalizePackFlag, resolveLogConfig } from "./index.ts";
 
 describe("resolveLogConfig — flag wiring", () => {
-  test("default: info + human", () => {
-    expect(resolveLogConfig({})).toEqual({ level: "info", format: "human" });
+  test("default: info + json", () => {
+    expect(resolveLogConfig({})).toEqual({ level: "info", format: "json" });
   });
 
   test("--verbose keeps info level", () => {
-    expect(resolveLogConfig({ verbose: true })).toEqual({ level: "info", format: "human" });
+    expect(resolveLogConfig({ verbose: true })).toEqual({ level: "info", format: "json" });
   });
 
   test("--quiet raises threshold to warn", () => {
-    expect(resolveLogConfig({ quiet: true })).toEqual({ level: "warn", format: "human" });
+    expect(resolveLogConfig({ quiet: true })).toEqual({ level: "warn", format: "json" });
   });
 
-  test("--json switches format", () => {
+  test("--json is a no-op alias (still resolves to json)", () => {
     expect(resolveLogConfig({ json: true })).toEqual({ level: "info", format: "json" });
   });
 
@@ -24,6 +24,14 @@ describe("resolveLogConfig — flag wiring", () => {
       level: "info",
       format: "json",
     });
+  });
+
+  test("--human switches format to human", () => {
+    expect(resolveLogConfig({ human: true })).toEqual({ level: "info", format: "human" });
+  });
+
+  test("--human + --json throws CLI error (mutually exclusive)", () => {
+    expect(() => resolveLogConfig({ human: true, json: true })).toThrow(/mutually exclusive/i);
   });
 
   test("--verbose + --quiet together throws CLI error (mutual exclusion)", () => {

--- a/src/cli-flags.test.ts
+++ b/src/cli-flags.test.ts
@@ -37,6 +37,20 @@ describe("resolveLogConfig — flag wiring", () => {
   test("--verbose + --quiet together throws CLI error (mutual exclusion)", () => {
     expect(() => resolveLogConfig({ verbose: true, quiet: true })).toThrow(/mutually exclusive/i);
   });
+
+  test("--human + --quiet: format and level are orthogonal", () => {
+    expect(resolveLogConfig({ human: true, quiet: true })).toEqual({
+      level: "warn",
+      format: "human",
+    });
+  });
+
+  test("--human + --verbose: format and level are orthogonal", () => {
+    expect(resolveLogConfig({ human: true, verbose: true })).toEqual({
+      level: "info",
+      format: "human",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,17 +284,22 @@ export function resolveLogConfig(values: {
   verbose?: unknown;
   quiet?: unknown;
   json?: unknown;
+  human?: unknown;
 }): { level: LogLevel; format: LogFormat } {
   const verbose = values.verbose === true;
   const quiet = values.quiet === true;
-  const json = values.json === true;
+  const human = values.human === true;
+  // --json is kept as a silent no-op alias for backward compat; JSON is now the default.
 
   if (verbose && quiet) {
     throw new CliError("--verbose and --quiet are mutually exclusive", 2);
   }
+  if (human && values.json === true) {
+    throw new CliError("--human and --json are mutually exclusive", 2);
+  }
 
   const level: LogLevel = quiet ? "warn" : "info";
-  const format: LogFormat = json ? "json" : "human";
+  const format: LogFormat = human ? "human" : "json";
   return { level, format };
 }
 
@@ -342,6 +347,7 @@ export async function main(argv: string[]): Promise<void> {
       verbose: { type: "boolean" },
       quiet: { type: "boolean", short: "q" },
       json: { type: "boolean" },
+      human: { type: "boolean" },
     },
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,12 +289,13 @@ export function resolveLogConfig(values: {
   const verbose = values.verbose === true;
   const quiet = values.quiet === true;
   const human = values.human === true;
+  const json = values.json === true;
   // --json is kept as a silent no-op alias for backward compat; JSON is now the default.
 
   if (verbose && quiet) {
     throw new CliError("--verbose and --quiet are mutually exclusive", 2);
   }
-  if (human && values.json === true) {
+  if (human && json) {
     throw new CliError("--human and --json are mutually exclusive", 2);
   }
 

--- a/src/plugins/logger/index.ts
+++ b/src/plugins/logger/index.ts
@@ -36,7 +36,9 @@ export function createLogger(options: LoggerOptions): Logger {
       write(`${JSON.stringify(payload)}\n`);
       return;
     }
-    write(`${ts} ${level} ${msg}\n`);
+    const safeFields = redact(fields) as Record<string, unknown>;
+    const fieldsStr = Object.keys(safeFields).length > 0 ? ` ${JSON.stringify(safeFields)}` : "";
+    write(`${ts} ${level} ${msg}${fieldsStr}\n`);
   }
 
   return {

--- a/src/plugins/logger/index.ts
+++ b/src/plugins/logger/index.ts
@@ -30,13 +30,12 @@ export function createLogger(options: LoggerOptions): Logger {
   function emit(level: LogLevel, fields: Record<string, unknown>, msg: string): void {
     if (LEVELS[level] > threshold) return;
     const ts = now();
+    const safeFields = redact(fields) as Record<string, unknown>;
     if (options.format === "json") {
-      const safeFields = redact(fields) as Record<string, unknown>;
       const payload = { ts, level, msg, ...safeFields };
       write(`${JSON.stringify(payload)}\n`);
       return;
     }
-    const safeFields = redact(fields) as Record<string, unknown>;
     const fieldsStr = Object.keys(safeFields).length > 0 ? ` ${JSON.stringify(safeFields)}` : "";
     write(`${ts} ${level} ${msg}${fieldsStr}\n`);
   }

--- a/src/plugins/logger/logger.test.ts
+++ b/src/plugins/logger/logger.test.ts
@@ -84,6 +84,30 @@ describe("createLogger — human format", () => {
     expect(obj.url).toBe("https://example.com");
   });
 
+  test("redacts cf_clearance in human format", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    logger.info({ cf_clearance: "abcd1234efgh5678" }, "req");
+    const line = sink.lines[0] as string;
+    expect(line).toContain("[REDACTED]");
+    expect(line).not.toContain("abcd1234efgh5678");
+  });
+
+  test("redacts useragent in human format", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    logger.info({ useragent: "Mozilla/5.0 (Windows NT 10.0)" }, "req");
+    const line = sink.lines[0] as string;
+    expect(line).toContain("[REDACTED]");
+    expect(line).not.toContain("Mozilla/5.0 (Windows NT 10.0)");
+  });
+
+  test("redacts authorization in human format", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    logger.info({ authorization: "Bearer eyJhbGciOiJIUzI1NiJ9" }, "req");
+    const line = sink.lines[0] as string;
+    expect(line).toContain("[REDACTED]");
+    expect(line).not.toContain("Bearer eyJhbGciOiJIUzI1NiJ9");
+  });
+
   test("empty fields object emits no trailing space or empty object", () => {
     const { logger, sink } = makeLogger("info", "human");
     logger.warn({}, "clean");

--- a/src/plugins/logger/logger.test.ts
+++ b/src/plugins/logger/logger.test.ts
@@ -53,18 +53,52 @@ describe("createLogger — thresholds", () => {
     expect(sink.lines).toEqual([`${FIXED_TS} error e\n`, `${FIXED_TS} warn w\n`]);
   });
 });
+// Threshold tests use human format (default in makeLogger) with empty fields,
+// so they exercise the no-trailing-artefact path.
 
 describe("createLogger — human format", () => {
-  test("emits `<ts> <level> <message>`", () => {
+  test("emits `<ts> <level> <message>` with no trailing artefact when fields are empty", () => {
     const { logger, sink } = makeLogger("info", "human");
     logger.info({}, "hello world");
     expect(sink.lines).toEqual([`${FIXED_TS} info hello world\n`]);
   });
 
-  test("ignores fields in human format", () => {
+  test("appends JSON fields after message", () => {
     const { logger, sink } = makeLogger("info", "human");
-    logger.info({ foo: "bar", cookies: "secret" }, "msg");
-    expect(sink.lines).toEqual([`${FIXED_TS} info msg\n`]);
+    logger.info({ attempt: 1, waitMs: 500 }, "retrying");
+    expect(sink.lines).toHaveLength(1);
+    const line = sink.lines[0] as string;
+    expect(line.startsWith(`${FIXED_TS} info retrying `)).toBe(true);
+    expect(line.endsWith("\n")).toBe(true);
+    const fieldsStr = line.slice(`${FIXED_TS} info retrying `.length, -1);
+    expect(JSON.parse(fieldsStr)).toEqual({ attempt: 1, waitMs: 500 });
+  });
+
+  test("redacts cookies/cf_clearance/useragent/authorization in human format", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    logger.info({ cookies: "secret", url: "https://example.com" }, "req");
+    const line = sink.lines[0] as string;
+    const fieldsStr = line.slice(`${FIXED_TS} info req `.length, -1);
+    const obj = JSON.parse(fieldsStr);
+    expect(obj.cookies).toBe("[REDACTED]");
+    expect(obj.url).toBe("https://example.com");
+  });
+
+  test("empty fields object emits no trailing space or empty object", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    logger.warn({}, "clean");
+    expect(sink.lines[0]).toBe(`${FIXED_TS} warn clean\n`);
+  });
+
+  test("each human call is exactly one newline-delimited line", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    logger.error({ x: 1 }, "a");
+    logger.warn({}, "b");
+    expect(sink.lines).toHaveLength(2);
+    for (const line of sink.lines) {
+      expect(line.endsWith("\n")).toBe(true);
+      expect(line.indexOf("\n")).toBe(line.length - 1);
+    }
   });
 });
 


### PR DESCRIPTION
## What this PR does

- Flips the default log format from `human` to `json` — structured fields are now always emitted by default.
- Adds `--human` flag to opt back into text output (timestamp + level + message + redacted fields as JSON suffix).
- Keeps `--json` as a silent no-op alias for backward compatibility.
- Guards `--human` + `--json` as mutually exclusive (`CliError` code 2).
- Fixes the silent-drop bug: human format now appends redacted fields as a JSON object after the message; empty fields produce no trailing artefact.

## Why it exists

Real-world download of "Zom 100" via the mangakakalot fallback printed:

```
2026-05-10T16:29:38.976Z warn retrying after 588ms
```

The call-site in `src/integrations/fallback-http/service.ts` was already passing `event`, `attempt`, `status`, `url`, and `waitMs` to the logger — but `src/plugins/logger/index.ts` silently dropped all structured fields in human mode. Since `human` was the default, users always got the bare format. JSON is the right default for a developer-facing CLI.

## How it works internally

`resolveLogConfig` in `src/index.ts`: binds `human` and `json` flags, throws `CliError` if both are passed, returns `format: human ? "human" : "json"`.

`createLogger` in `src/plugins/logger/index.ts`: `redact(fields)` is hoisted before the format branch, so both json and human paths share a single redacted snapshot. Human `emit` serialises that snapshot to JSON and appends only when non-empty.

## What did not change

- Redaction denylist and logic untouched.
- `Logger` interface untouched.
- Logs still emit to stderr.
- `--json` still accepted (silent no-op).
- No third format introduced.
- Call-site logging untouched.

## Test checklist

- [x] `bun test` — 584 pass, 0 fail (was 574 baseline; +10 new tests across formatter and flag resolution)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean
- [x] Default format flipped to `json` in `src/cli-flags.test.ts`
- [x] `--human` → `format: "human"` test added
- [x] `--human + --json` mutual exclusivity test added (`CliError` code 2)
- [x] `--human + --quiet` and `--human + --verbose` orthogonality tests added
- [x] Human format with fields appends JSON suffix
- [x] Human format with empty fields emits no trailing artefact (single `\n`, no `{}`)
- [x] Human format redacts all four denylist keys (`cookies`, `cf_clearance`, `useragent`, `authorization`) with explicit asserts

## Reviewer notes

- **Default behavior change for downstream consumers.** Anyone scripting against the bare `${ts} ${level} ${msg}` text shape will now see an appended JSON object whenever fields are present. Pass `--human` for the legacy shape — fields will still be appended (silent data loss is worse than a format change).
- **P2 nudges absorbed in this PR** (commits `53fb92e` + `34b91ff`):
  - Hoisted `safeFields = redact(fields)` out of the format branches in `emit()` (-1 line, identical semantics; matches inspector P2).
  - Bound `const json = values.json === true` for symmetry with `verbose`/`quiet` in `resolveLogConfig` (matches inspector P2).
  - Added explicit redaction tests for `cf_clearance`, `useragent`, `authorization` in human mode (matches QA P2).
  - Added `--human + --quiet` and `--human + --verbose` orthogonality tests (matches QA P2).
- **Deliberately deferred** (P3 follow-ups, will land separately): circular-ref guard around `JSON.stringify(safeFields)`, comment-block placement in `logger.test.ts`, richer human format (issue #98).

## Closes

Related follow-up: #98 — richer human format (key=value style, URL truncation, TTY colors).

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [x] Docs updated in `docs/overviewer.md`