### PR TITLE
feat(traces,logger): SQLite trace store + revert default flip (Phase 1 of #116)

### DIFF
--- a/migrations/003_create_traces.sql
+++ b/migrations/003_create_traces.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS traces (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts          TEXT    NOT NULL,
+  level       TEXT    NOT NULL,
+  event       TEXT,
+  msg         TEXT    NOT NULL,
+  fields_json TEXT,
+  run_id      TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS traces_ts_idx ON traces(ts);

--- a/src/cli-flags.test.ts
+++ b/src/cli-flags.test.ts
@@ -3,30 +3,30 @@ import { parseArgs } from "node:util";
 import { normalizePackFlag, resolveLogConfig } from "./index.ts";
 
 describe("resolveLogConfig — flag wiring", () => {
-  test("default: info + json", () => {
-    expect(resolveLogConfig({})).toEqual({ level: "info", format: "json" });
+  test("default: info + human", () => {
+    expect(resolveLogConfig({})).toEqual({ level: "info", format: "human" });
   });
 
-  test("--verbose keeps info level", () => {
-    expect(resolveLogConfig({ verbose: true })).toEqual({ level: "info", format: "json" });
+  test("--verbose keeps info level, format stays human", () => {
+    expect(resolveLogConfig({ verbose: true })).toEqual({ level: "info", format: "human" });
   });
 
-  test("--quiet raises threshold to warn", () => {
-    expect(resolveLogConfig({ quiet: true })).toEqual({ level: "warn", format: "json" });
+  test("--quiet raises threshold to warn, format stays human", () => {
+    expect(resolveLogConfig({ quiet: true })).toEqual({ level: "warn", format: "human" });
   });
 
-  test("--json is a no-op alias (still resolves to json)", () => {
+  test("--json opts into json format", () => {
     expect(resolveLogConfig({ json: true })).toEqual({ level: "info", format: "json" });
   });
 
-  test("--verbose --json combine", () => {
+  test("--verbose --json combine: info level + json format", () => {
     expect(resolveLogConfig({ verbose: true, json: true })).toEqual({
       level: "info",
       format: "json",
     });
   });
 
-  test("--human switches format to human", () => {
+  test("--human is a silent no-op alias (resolves to human)", () => {
     expect(resolveLogConfig({ human: true })).toEqual({ level: "info", format: "human" });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { loadConfig } from "@plugins/config/index.ts";
 import { openDb, runMigrations } from "@plugins/db/index.ts";
 import { CliError } from "@plugins/errors/index.ts";
 import { type LogFormat, type LogLevel, createLogger } from "@plugins/logger/index.ts";
+import { createTraceStore } from "@plugins/trace/index.ts";
 import type { Handler } from "./cli/types.ts";
 
 const VERSION = "0.0.0";
@@ -290,7 +291,7 @@ export function resolveLogConfig(values: {
   const quiet = values.quiet === true;
   const human = values.human === true;
   const json = values.json === true;
-  // --json is kept as a silent no-op alias for backward compat; JSON is now the default.
+  // Default is human. --json opts into structured output. --human is a silent no-op alias.
 
   if (verbose && quiet) {
     throw new CliError("--verbose and --quiet are mutually exclusive", 2);
@@ -300,7 +301,7 @@ export function resolveLogConfig(values: {
   }
 
   const level: LogLevel = quiet ? "warn" : "info";
-  const format: LogFormat = human ? "human" : "json";
+  const format: LogFormat = json ? "json" : "human";
   return { level, format };
 }
 
@@ -363,17 +364,19 @@ export async function main(argv: string[]): Promise<void> {
   }
 
   const { level, format } = resolveLogConfig(values);
-  const logger = createLogger({ level, format });
+
+  const { config } = await loadConfig();
+  const db = openDb(config.db_path);
+  runMigrations(db);
+
+  const traceStore = createTraceStore({ db });
+  const logger = createLogger({ level, format }, traceStore);
 
   const handler = handlers[command];
   if (!handler) {
     process.stderr.write(`Unknown command: ${command}\n\n${USAGE}`);
     process.exit(1);
   }
-
-  const { config } = await loadConfig();
-  const db = openDb(config.db_path);
-  runMigrations(db);
 
   // postArgs is everything after the command — verbatim, so handler's parseArgs
   // sees the real flag values (e.g. --volume "13" not boolean true).

--- a/src/plugins/logger/index.ts
+++ b/src/plugins/logger/index.ts
@@ -1,28 +1,16 @@
 // Structured logger — see docs/overviewer.md §9.
 // Emits to stderr only. User-facing output (tables, prompts, exports) goes to stdout.
 
+import type { TraceStore } from "@plugins/trace/index.ts";
+import { redact } from "./redact.ts";
 import type { LogLevel, Logger, LoggerOptions } from "./types.ts";
 
 export type { Logger, LogFormat, LogLevel, LoggerOptions } from "./types.ts";
+export { redact } from "./redact.ts";
 
 const LEVELS: Record<LogLevel, number> = { error: 0, warn: 1, info: 2 };
 
-const DENYLIST = new Set(["cookies", "cf_clearance", "useragent", "authorization"]);
-const REDACTED = "[REDACTED]";
-
-function redact(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(redact);
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = DENYLIST.has(k.toLowerCase()) ? REDACTED : redact(v);
-    }
-    return out;
-  }
-  return value;
-}
-
-export function createLogger(options: LoggerOptions): Logger {
+export function createLogger(options: LoggerOptions, traceStore?: TraceStore): Logger {
   const threshold = LEVELS[options.level];
   const write = options.write ?? ((line: string) => process.stderr.write(line));
   const now = options.now ?? (() => new Date().toISOString());
@@ -31,13 +19,21 @@ export function createLogger(options: LoggerOptions): Logger {
     if (LEVELS[level] > threshold) return;
     const ts = now();
     const safeFields = redact(fields) as Record<string, unknown>;
+
+    if (traceStore) {
+      const fieldsJson =
+        Object.keys(safeFields).length > 0 ? JSON.stringify(safeFields) : undefined;
+      const event = typeof fields.event === "string" ? fields.event : undefined;
+      traceStore.insert({ ts, level, event, msg, fields_json: fieldsJson });
+    }
+
     if (options.format === "json") {
       const payload = { ts, level, msg, ...safeFields };
       write(`${JSON.stringify(payload)}\n`);
       return;
     }
-    const fieldsStr = Object.keys(safeFields).length > 0 ? ` ${JSON.stringify(safeFields)}` : "";
-    write(`${ts} ${level} ${msg}${fieldsStr}\n`);
+    // Human format: plain line, no fields suffix. Fields are captured in trace store only.
+    write(`${ts} ${level} ${msg}\n`);
   }
 
   return {

--- a/src/plugins/logger/logger.test.ts
+++ b/src/plugins/logger/logger.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { TraceStore } from "@plugins/trace/index.ts";
 import { type LogLevel, createLogger } from "./index.ts";
 
 const FIXED_TS = "2025-01-01T00:00:00.000Z";
@@ -13,14 +14,17 @@ function makeSink() {
   };
 }
 
-function makeLogger(level: LogLevel, format: "human" | "json" = "human") {
+function makeLogger(level: LogLevel, format: "human" | "json" = "human", traceStore?: TraceStore) {
   const sink = makeSink();
-  const logger = createLogger({
-    level,
-    format,
-    write: sink.write,
-    now: () => FIXED_TS,
-  });
+  const logger = createLogger(
+    {
+      level,
+      format,
+      write: sink.write,
+      now: () => FIXED_TS,
+    },
+    traceStore,
+  );
   return { logger, sink };
 }
 
@@ -53,59 +57,20 @@ describe("createLogger — thresholds", () => {
     expect(sink.lines).toEqual([`${FIXED_TS} error e\n`, `${FIXED_TS} warn w\n`]);
   });
 });
-// Threshold tests use human format (default in makeLogger) with empty fields,
-// so they exercise the no-trailing-artefact path.
+// Threshold tests use human format (default in makeLogger) with empty fields.
 
 describe("createLogger — human format", () => {
-  test("emits `<ts> <level> <message>` with no trailing artefact when fields are empty", () => {
+  test("default format is human — emits `<ts> <level> <message>` only", () => {
     const { logger, sink } = makeLogger("info", "human");
     logger.info({}, "hello world");
     expect(sink.lines).toEqual([`${FIXED_TS} info hello world\n`]);
   });
 
-  test("appends JSON fields after message", () => {
+  test("human format with fields emits ONLY `<ts> <level> <message>` — no JSON suffix", () => {
     const { logger, sink } = makeLogger("info", "human");
     logger.info({ attempt: 1, waitMs: 500 }, "retrying");
     expect(sink.lines).toHaveLength(1);
-    const line = sink.lines[0] as string;
-    expect(line.startsWith(`${FIXED_TS} info retrying `)).toBe(true);
-    expect(line.endsWith("\n")).toBe(true);
-    const fieldsStr = line.slice(`${FIXED_TS} info retrying `.length, -1);
-    expect(JSON.parse(fieldsStr)).toEqual({ attempt: 1, waitMs: 500 });
-  });
-
-  test("redacts cookies/cf_clearance/useragent/authorization in human format", () => {
-    const { logger, sink } = makeLogger("info", "human");
-    logger.info({ cookies: "secret", url: "https://example.com" }, "req");
-    const line = sink.lines[0] as string;
-    const fieldsStr = line.slice(`${FIXED_TS} info req `.length, -1);
-    const obj = JSON.parse(fieldsStr);
-    expect(obj.cookies).toBe("[REDACTED]");
-    expect(obj.url).toBe("https://example.com");
-  });
-
-  test("redacts cf_clearance in human format", () => {
-    const { logger, sink } = makeLogger("info", "human");
-    logger.info({ cf_clearance: "abcd1234efgh5678" }, "req");
-    const line = sink.lines[0] as string;
-    expect(line).toContain("[REDACTED]");
-    expect(line).not.toContain("abcd1234efgh5678");
-  });
-
-  test("redacts useragent in human format", () => {
-    const { logger, sink } = makeLogger("info", "human");
-    logger.info({ useragent: "Mozilla/5.0 (Windows NT 10.0)" }, "req");
-    const line = sink.lines[0] as string;
-    expect(line).toContain("[REDACTED]");
-    expect(line).not.toContain("Mozilla/5.0 (Windows NT 10.0)");
-  });
-
-  test("redacts authorization in human format", () => {
-    const { logger, sink } = makeLogger("info", "human");
-    logger.info({ authorization: "Bearer eyJhbGciOiJIUzI1NiJ9" }, "req");
-    const line = sink.lines[0] as string;
-    expect(line).toContain("[REDACTED]");
-    expect(line).not.toContain("Bearer eyJhbGciOiJIUzI1NiJ9");
+    expect(sink.lines[0]).toBe(`${FIXED_TS} info retrying\n`);
   });
 
   test("empty fields object emits no trailing space or empty object", () => {
@@ -127,7 +92,7 @@ describe("createLogger — human format", () => {
 });
 
 describe("createLogger — json format", () => {
-  test("emits NDJSON with ts/level/msg/...fields", () => {
+  test("--json opt-in still produces NDJSON with ts/level/msg/...fields", () => {
     const { logger, sink } = makeLogger("info", "json");
     logger.info({ port: 3000 }, "ready");
     expect(sink.lines).toHaveLength(1);
@@ -148,7 +113,7 @@ describe("createLogger — json format", () => {
   });
 });
 
-describe("createLogger — redaction", () => {
+describe("createLogger — redaction (json format)", () => {
   test("redacts top-level cookies / Authorization / userAgent / cf_clearance", () => {
     const { logger, sink } = makeLogger("warn", "json");
     logger.warn(
@@ -222,5 +187,60 @@ describe("createLogger — redaction", () => {
     expect(obj.Cookies).toBe("[REDACTED]");
     expect(obj.UserAgent).toBe("[REDACTED]");
     expect(obj.CF_CLEARANCE).toBe("[REDACTED]");
+  });
+});
+
+describe("createLogger — trace store injection", () => {
+  function makeFakeStore() {
+    const calls: Parameters<TraceStore["insert"]>[0][] = [];
+    const store: TraceStore = {
+      runId: "00000000-0000-4000-8000-000000000000",
+      insert: (row) => calls.push(row),
+      purge: () => {},
+      close: () => {},
+    };
+    return { store, calls };
+  }
+
+  test("with injected trace store, every emit calls traceStore.insert", () => {
+    const { store, calls } = makeFakeStore();
+    const { logger } = makeLogger("info", "human", store);
+    logger.info({ event: "test.event", x: 1 }, "hello");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.msg).toBe("hello");
+    expect(calls[0]?.level).toBe("info");
+    expect(calls[0]?.ts).toBe(FIXED_TS);
+    expect(calls[0]?.event).toBe("test.event");
+  });
+
+  test("fields_json is set when fields are non-empty", () => {
+    const { store, calls } = makeFakeStore();
+    const { logger } = makeLogger("info", "human", store);
+    logger.warn({ x: 42 }, "msg");
+    expect(calls[0]?.fields_json).toBeDefined();
+    const parsed = JSON.parse(calls[0]?.fields_json as string);
+    expect(parsed.x).toBe(42);
+  });
+
+  test("fields_json is undefined when fields are empty", () => {
+    const { store, calls } = makeFakeStore();
+    const { logger } = makeLogger("info", "human", store);
+    logger.info({}, "empty");
+    expect(calls[0]?.fields_json).toBeUndefined();
+  });
+
+  test("without trace store, logger does not throw and still emits to terminal", () => {
+    const { logger, sink } = makeLogger("info", "human");
+    expect(() => logger.info({ x: 1 }, "no store")).not.toThrow();
+    expect(sink.lines).toHaveLength(1);
+  });
+
+  test("trace store receives redacted fields_json", () => {
+    const { store, calls } = makeFakeStore();
+    const { logger } = makeLogger("info", "json", store);
+    logger.info({ cookies: "secret", url: "ok" }, "req");
+    const parsed = JSON.parse(calls[0]?.fields_json as string);
+    expect(parsed.cookies).toBe("[REDACTED]");
+    expect(parsed.url).toBe("ok");
   });
 });

--- a/src/plugins/logger/redact.ts
+++ b/src/plugins/logger/redact.ts
@@ -1,0 +1,14 @@
+const DENYLIST = new Set(["cookies", "cf_clearance", "useragent", "authorization"]);
+const REDACTED = "[REDACTED]";
+
+export function redact(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redact);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = DENYLIST.has(k.toLowerCase()) ? REDACTED : redact(v);
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/plugins/trace/index.ts
+++ b/src/plugins/trace/index.ts
@@ -1,0 +1,51 @@
+// Trace store — persists structured log rows to SQLite with TTL purge.
+// Each store instance tracks a single run_id (UUID v4) for the lifetime of the process.
+
+import { redact } from "@plugins/logger/redact.ts";
+import type { CreateTraceStoreOpts, TraceRow, TraceStore } from "./types.ts";
+
+export type { CreateTraceStoreOpts, TraceRow, TraceStore } from "./types.ts";
+
+export function createTraceStore(opts: CreateTraceStoreOpts): TraceStore {
+  const { db } = opts;
+  const runId = crypto.randomUUID();
+
+  // Purge stale rows eagerly on instantiation (3-day default).
+  purge(3);
+
+  const insertStmt = db.prepare<
+    void,
+    [string, string, string | null, string, string | null, string]
+  >("INSERT INTO traces (ts, level, event, msg, fields_json, run_id) VALUES (?, ?, ?, ?, ?, ?)");
+
+  function purge(maxAgeDays: number): void {
+    db.exec(`DELETE FROM traces WHERE ts < datetime('now', '-${maxAgeDays} days')`);
+  }
+
+  function insert(row: TraceRow): void {
+    let safeFieldsJson: string | null = null;
+    if (row.fields_json) {
+      try {
+        const parsed = JSON.parse(row.fields_json);
+        safeFieldsJson = JSON.stringify(redact(parsed));
+      } catch {
+        safeFieldsJson = row.fields_json;
+      }
+    }
+
+    insertStmt.run(
+      row.ts,
+      row.level,
+      row.event ?? null,
+      row.msg,
+      safeFieldsJson,
+      row.run_id ?? runId,
+    );
+  }
+
+  function close(): void {
+    // Store does not own the db; caller manages connection lifecycle.
+  }
+
+  return { insert, purge, close, runId };
+}

--- a/src/plugins/trace/trace.test.ts
+++ b/src/plugins/trace/trace.test.ts
@@ -1,0 +1,185 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createTraceStore } from "./index.ts";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function openTestDb(): Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS traces (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts          TEXT    NOT NULL,
+      level       TEXT    NOT NULL,
+      event       TEXT,
+      msg         TEXT    NOT NULL,
+      fields_json TEXT,
+      run_id      TEXT    NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS traces_ts_idx ON traces(ts);
+  `);
+  return db;
+}
+
+let db: Database;
+
+beforeEach(() => {
+  db = openTestDb();
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("createTraceStore — insert + select round-trip", () => {
+  test("inserted row is retrievable", () => {
+    const store = createTraceStore({ db });
+    const ts = new Date().toISOString();
+    store.insert({ ts, level: "info", msg: "hello", event: "test.event" });
+
+    const row = db
+      .prepare<{ ts: string; level: string; msg: string; event: string | null }, []>(
+        "SELECT ts, level, msg, event FROM traces LIMIT 1",
+      )
+      .get();
+
+    expect(row?.ts).toBe(ts);
+    expect(row?.level).toBe("info");
+    expect(row?.msg).toBe("hello");
+    expect(row?.event).toBe("test.event");
+  });
+
+  test("optional fields are nullable", () => {
+    const store = createTraceStore({ db });
+    store.insert({ ts: new Date().toISOString(), level: "warn", msg: "no event or fields" });
+    const row = db
+      .prepare<{ event: string | null; fields_json: string | null }, []>(
+        "SELECT event, fields_json FROM traces LIMIT 1",
+      )
+      .get();
+    expect(row?.event).toBeNull();
+    expect(row?.fields_json).toBeNull();
+  });
+});
+
+describe("createTraceStore — redaction", () => {
+  test("cookies key is redacted in fields_json before insert", () => {
+    const store = createTraceStore({ db });
+    store.insert({
+      ts: new Date().toISOString(),
+      level: "info",
+      msg: "req",
+      fields_json: JSON.stringify({ cookies: "secret", url: "https://example.com" }),
+    });
+    const row = db
+      .prepare<{ fields_json: string }, []>("SELECT fields_json FROM traces LIMIT 1")
+      .get();
+    const parsed = JSON.parse(row?.fields_json as string);
+    expect(parsed.cookies).toBe("[REDACTED]");
+    expect(parsed.url).toBe("https://example.com");
+  });
+
+  test("cf_clearance is redacted", () => {
+    const store = createTraceStore({ db });
+    store.insert({
+      ts: new Date().toISOString(),
+      level: "info",
+      msg: "req",
+      fields_json: JSON.stringify({ cf_clearance: "abcdef" }),
+    });
+    const row = db
+      .prepare<{ fields_json: string }, []>("SELECT fields_json FROM traces LIMIT 1")
+      .get();
+    const parsed = JSON.parse(row?.fields_json as string);
+    expect(parsed.cf_clearance).toBe("[REDACTED]");
+  });
+
+  test("useragent is redacted", () => {
+    const store = createTraceStore({ db });
+    store.insert({
+      ts: new Date().toISOString(),
+      level: "info",
+      msg: "req",
+      fields_json: JSON.stringify({ useragent: "Mozilla/5.0" }),
+    });
+    const row = db
+      .prepare<{ fields_json: string }, []>("SELECT fields_json FROM traces LIMIT 1")
+      .get();
+    const parsed = JSON.parse(row?.fields_json as string);
+    expect(parsed.useragent).toBe("[REDACTED]");
+  });
+
+  test("authorization is redacted", () => {
+    const store = createTraceStore({ db });
+    store.insert({
+      ts: new Date().toISOString(),
+      level: "info",
+      msg: "req",
+      fields_json: JSON.stringify({ authorization: "Bearer token123" }),
+    });
+    const row = db
+      .prepare<{ fields_json: string }, []>("SELECT fields_json FROM traces LIMIT 1")
+      .get();
+    const parsed = JSON.parse(row?.fields_json as string);
+    expect(parsed.authorization).toBe("[REDACTED]");
+  });
+});
+
+describe("createTraceStore — purge", () => {
+  test("purge(3) removes rows older than 3 days, keeps newer ones", () => {
+    const store = createTraceStore({ db });
+
+    // Insert a row 4 days old (should be purged).
+    const oldTs = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("INSERT INTO traces (ts, level, msg, run_id) VALUES (?, ?, ?, ?)").run(
+      oldTs,
+      "info",
+      "old row",
+      store.runId,
+    );
+
+    // Insert a row 1 hour old (should survive).
+    const newTs = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    db.prepare("INSERT INTO traces (ts, level, msg, run_id) VALUES (?, ?, ?, ?)").run(
+      newTs,
+      "info",
+      "new row",
+      store.runId,
+    );
+
+    store.purge(3);
+
+    const remaining = db
+      .prepare<{ msg: string }, []>("SELECT msg FROM traces ORDER BY ts ASC")
+      .all();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.msg).toBe("new row");
+  });
+});
+
+describe("createTraceStore — run_id", () => {
+  test("run_id is a valid UUID v4", () => {
+    const store = createTraceStore({ db });
+    expect(store.runId).toMatch(UUID_RE);
+  });
+
+  test("run_id is stable across multiple inserts from the same store instance", () => {
+    const store = createTraceStore({ db });
+    const ts = new Date().toISOString();
+    store.insert({ ts, level: "info", msg: "first" });
+    store.insert({ ts, level: "warn", msg: "second" });
+
+    const rows = db
+      .prepare<{ run_id: string }, []>("SELECT run_id FROM traces ORDER BY id ASC")
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.run_id).toBe(store.runId);
+    expect(rows[1]?.run_id).toBe(store.runId);
+  });
+
+  test("two separate store instances produce distinct run_ids", () => {
+    const store1 = createTraceStore({ db });
+    const store2 = createTraceStore({ db });
+    expect(store1.runId).not.toBe(store2.runId);
+  });
+});

--- a/src/plugins/trace/types.ts
+++ b/src/plugins/trace/types.ts
@@ -1,0 +1,22 @@
+import type { Database } from "bun:sqlite";
+
+export interface TraceRow {
+  ts: string;
+  level: string;
+  event?: string;
+  msg: string;
+  fields_json?: string;
+  run_id?: string;
+}
+
+export interface TraceStore {
+  insert(row: TraceRow): void;
+  purge(maxAgeDays: number): void;
+  close(): void;
+  runId: string;
+}
+
+export interface CreateTraceStoreOpts {
+  /** An already-open Database instance. The store will NOT close it. */
+  db: Database;
+}


### PR DESCRIPTION
## What this PR does

- Introduces a new SQLite trace store (`src/plugins/trace/`) that persists structured log rows with a 3-day TTL purge.
- Partially reverts PR #99: the default log format is now `human` again; `--json` opts into structured output; `--human` is a silent no-op alias.

## Why it exists

Part of Epic #116 (structured observability). The goal is to split log sinks: the terminal stays human-readable while every structured field is durably captured in SQLite for post-hoc inspection (Phase 2 will add a `trace` export command). PR #99 made JSON the default to enable field capture — this PR achieves the same without degrading terminal legibility by routing fields to the trace store instead.

## How it works internally

| Component | File(s) | Responsibility |
|---|---|---|
| Migration | `migrations/003_create_traces.sql` | Schema for `traces` table + `traces_ts_idx` index |
| Redact helper | `src/plugins/logger/redact.ts` | Extracted from logger; imported by both logger and trace store |
| Trace plugin | `src/plugins/trace/index.ts` | `createTraceStore({db})` — inserts rows, purges stale rows on init, no-op `close()` |
| Trace types | `src/plugins/trace/types.ts` | `TraceRow`, `TraceStore`, `CreateTraceStoreOpts` interfaces |
| Logger | `src/plugins/logger/index.ts` | `createLogger(opts, traceStore?)` — human sink = plain line; trace sink = structured insert |
| CLI wiring | `src/index.ts` | `createTraceStore({db})` called after `runMigrations`, passed to `createLogger` |

Flow on every log call:
1. `emit(level, fields, msg)` is called.
2. If `traceStore` is set → `traceStore.insert({ts, level, event, msg, fields_json})` (redacted).
3. Terminal output: `human` → `<ts> <level> <msg>\n`; `json` → NDJSON with all fields.

## What did not change

- `Logger` interface (`error/warn/info(fields, msg)`) is unchanged.
- No call sites in `src/integrations/`, `src/commands/`, or `src/modules/` were touched.
- `migrations/001_create_downloads.sql` and `migrations/002_create_subscriptions.sql` are untouched.
- No `--debug-trace` flag or trace export command (Phase 2).
- No mangakakalot/mangadex client code touched.

## Test checklist

- [x] `src/plugins/trace/trace.test.ts` — 8 new tests: insert round-trip, redaction (cookies/cf_clearance/useragent/authorization), purge removes rows older than 3 days, UUID v4 run_id, run_id stability across inserts, distinct run_ids per store instance.
- [x] `src/plugins/logger/logger.test.ts` — updated: human format emits only `<ts> <level> <msg>\n` (no JSON suffix), trace store injection calls `insert` on each emit, fields_json redacted before store, no-store path doesn't throw.
- [x] `src/cli-flags.test.ts` — updated: default is now `human`, `--json` → `json`, `--human` → `human` (no-op), `--human + --json` still throws.
- [x] Pre-baseline: 584 tests. Post: **595 tests** (11 added, 0 regressions).

## Reviewer notes

- **Partial revert of PR #99**: the JSON-suffix append on human lines is removed. Fields on human-format log lines now go exclusively to the trace store. If no trace store is wired (e.g. in unit tests), those fields are silently dropped from output — this is intentional and documented.
- **New migration `003_create_traces.sql`** will be applied automatically on next CLI boot via `runMigrations`.
- **New plugin `src/plugins/trace/`** — no classes, factory function pattern, interfaces in `types.ts`.
- `redact` is now in `src/plugins/logger/redact.ts`; logger re-exports it to preserve any existing imports.

## Closes

Refs: #116

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (if applicable)