### PR TITLE
feat(walkthrough): scaffold interactive 9-step flow (Phase 2 of #116)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "scanldr",
       "dependencies": {
+        "@inquirer/prompts": "^8.4.3",
         "cheerio": "^1.2.0",
         "fflate": "^0.8.2",
       },
@@ -34,6 +35,38 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.5", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.10", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.1.2", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/external-editor": "^3.0.0", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.0.14", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@3.0.0", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/input": ["@inquirer/input@5.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw=="],
+
+    "@inquirer/number": ["@inquirer/number@4.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg=="],
+
+    "@inquirer/password": ["@inquirer/password@5.0.13", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.4.3", "", { "dependencies": { "@inquirer/checkbox": "^5.1.5", "@inquirer/confirm": "^6.0.13", "@inquirer/editor": "^5.1.2", "@inquirer/expand": "^5.0.14", "@inquirer/input": "^5.0.13", "@inquirer/number": "^4.0.13", "@inquirer/password": "^5.0.13", "@inquirer/rawlist": "^5.2.9", "@inquirer/search": "^4.1.9", "@inquirer/select": "^5.1.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.2.9", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw=="],
+
+    "@inquirer/search": ["@inquirer/search@4.1.9", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA=="],
+
+    "@inquirer/select": ["@inquirer/select@5.1.5", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.10", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -42,9 +75,13 @@
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -62,11 +99,19 @@
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
@@ -78,6 +123,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
@@ -87,6 +134,8 @@
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "@inquirer/external-editor/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.4.3",
     "cheerio": "^1.2.0",
     "fflate": "^0.8.2"
   }

--- a/src/cli-routing.test.ts
+++ b/src/cli-routing.test.ts
@@ -132,13 +132,81 @@ describe("global flags can appear before command", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Unknown command
+// Walkthrough routing helpers
 // ---------------------------------------------------------------------------
 
-describe("unknown command", () => {
-  test("unknown command → exit 1", async () => {
-    const r = await run(["nonexistent"]);
-    expect(r.exitCode).toBe(1);
-    expect(r.stderr).toMatch(/Unknown command/i);
+/**
+ * Spawn a CLI process, wait up to `timeoutMs` for it to exit.
+ * Returns { timedOut: true } if still running, otherwise the exit result.
+ */
+async function runWithTimeout(
+  args: string[],
+  timeoutMs: number,
+): Promise<
+  { timedOut: true } | { timedOut: false; exitCode: number; stderr: string; stdout: string }
+> {
+  const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "pipe",
+  });
+
+  let resolved = false;
+  const exitPromise = proc.exited.then((code) => {
+    resolved = true;
+    return code;
+  });
+
+  await new Promise((r) => setTimeout(r, timeoutMs));
+
+  if (!resolved) {
+    proc.kill();
+    return { timedOut: true };
+  }
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    exitPromise,
+  ]);
+  return { timedOut: false, exitCode, stdout, stderr };
+}
+
+describe("walkthrough routing", () => {
+  test("no args → enters walkthrough (does not print 'Unknown command', hangs for input)", async () => {
+    const r = await runWithTimeout([], 800);
+    // Process should be waiting for TTY input (walkthrough started), not exited quickly with error
+    if (!r.timedOut) {
+      // If it did exit quickly, it should NOT be the "Unknown command" error
+      expect(r.stderr).not.toMatch(/Unknown command/i);
+      // And should not have exited with exit code 1 from command routing
+      expect(r.exitCode).not.toBe(1);
+    } else {
+      // timedOut means walkthrough is running and waiting for input — correct routing
+      expect(r.timedOut).toBe(true);
+    }
+  });
+
+  test("single positional arg → enters walkthrough with title prefill", async () => {
+    const r = await runWithTimeout(["Naruto"], 800);
+    if (!r.timedOut) {
+      expect(r.stderr).not.toMatch(/Unknown command/i);
+      expect(r.exitCode).not.toBe(1);
+    } else {
+      expect(r.timedOut).toBe(true);
+    }
+  });
+
+  test("download subcommand → still routes to download (regression)", async () => {
+    const r = await run(["download", "--volume", "1", "--non-tty"]);
+    // Should reach the download handler and fail on missing manga, not route to walkthrough
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/Usage/i);
+  });
+
+  test("list subcommand → still routes to list (regression)", async () => {
+    const r = await run(["list"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/Usage/i);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { CliError } from "@plugins/errors/index.ts";
 import { type LogFormat, type LogLevel, createLogger } from "@plugins/logger/index.ts";
 import { createTraceStore } from "@plugins/trace/index.ts";
 import type { Handler } from "./cli/types.ts";
+import { runWalkthrough } from "./walkthrough/index.ts";
 
 const VERSION = "0.0.0";
 
@@ -358,7 +359,7 @@ export async function main(argv: string[]): Promise<void> {
     return;
   }
 
-  if (!command || command === "help" || values.help) {
+  if (command === "help" || values.help) {
     process.stdout.write(USAGE);
     return;
   }
@@ -371,6 +372,17 @@ export async function main(argv: string[]): Promise<void> {
 
   const traceStore = createTraceStore({ db });
   const logger = createLogger({ level, format }, traceStore);
+
+  // No subcommand, or a single positional that is NOT a known subcommand key
+  // → launch interactive walkthrough. The positional becomes the title prefill.
+  const isKnownSubcommand = command !== undefined && command in handlers;
+  if (!command || !isKnownSubcommand) {
+    const result = await runWalkthrough({ logger, titlePrefill: command });
+    if (typeof result === "object" && "cancelled" in result && result.cancelled) {
+      process.exit(130);
+    }
+    return;
+  }
 
   const handler = handlers[command];
   if (!handler) {

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -1,0 +1,2 @@
+export { SOURCES, getSource } from "./registry.ts";
+export type { SourceDescriptor, SourceId } from "./types.ts";

--- a/src/sources/registry.test.ts
+++ b/src/sources/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { SOURCES, getSource } from "./registry.ts";
+
+describe("SOURCES registry", () => {
+  test("has both mangakakalot and mangadex entries", () => {
+    const ids = SOURCES.map((s) => s.id);
+    expect(ids).toContain("mangakakalot");
+    expect(ids).toContain("mangadex");
+  });
+
+  test("mangakakalot requiresAuth === true", () => {
+    const s = SOURCES.find((x) => x.id === "mangakakalot");
+    expect(s?.requiresAuth).toBe(true);
+  });
+
+  test("mangadex requiresAuth === false", () => {
+    const s = SOURCES.find((x) => x.id === "mangadex");
+    expect(s?.requiresAuth).toBe(false);
+  });
+});
+
+describe("getSource", () => {
+  test("getSource('mangakakalot').requiresAuth === true", () => {
+    expect(getSource("mangakakalot").requiresAuth).toBe(true);
+  });
+
+  test("getSource('mangadex').requiresAuth === false", () => {
+    expect(getSource("mangadex").requiresAuth).toBe(false);
+  });
+
+  test("getSource('unknown') throws", () => {
+    expect(() => getSource("unknown")).toThrow(/Unknown source/);
+  });
+});

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,0 +1,14 @@
+import type { SourceDescriptor } from "./types.ts";
+
+export type { SourceDescriptor, SourceId } from "./types.ts";
+
+export const SOURCES: readonly SourceDescriptor[] = [
+  { id: "mangakakalot", label: "Mangakakalot", requiresAuth: true },
+  { id: "mangadex", label: "MangaDex", requiresAuth: false },
+] as const;
+
+export function getSource(id: string): SourceDescriptor {
+  const found = SOURCES.find((s) => s.id === id);
+  if (!found) throw new Error(`Unknown source: "${id}"`);
+  return found;
+}

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,6 +1,6 @@
 import type { SourceDescriptor } from "./types.ts";
 
-export type { SourceDescriptor, SourceId } from "./types.ts";
+export type { SourceDescriptor } from "./types.ts";
 
 export const SOURCES: readonly SourceDescriptor[] = [
   { id: "mangakakalot", label: "Mangakakalot", requiresAuth: true },

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -1,0 +1,7 @@
+export type SourceId = "mangakakalot" | "mangadex";
+
+export interface SourceDescriptor {
+  id: SourceId;
+  label: string;
+  requiresAuth: boolean;
+}

--- a/src/walkthrough/index.ts
+++ b/src/walkthrough/index.ts
@@ -1,0 +1,72 @@
+import type { Logger } from "../plugins/logger/index.ts";
+import { checkAuth } from "./steps/auth-check.ts";
+import { promptCoverUrl } from "./steps/cover-prompt.ts";
+import { executePlan } from "./steps/execute-stub.ts";
+import { pickMode } from "./steps/mode-picker.ts";
+import { promptPack } from "./steps/pack-prompt.ts";
+import { pickRange } from "./steps/range-picker.ts";
+import { pickSearchResult } from "./steps/search-results-picker.ts";
+import { pickSource } from "./steps/source-picker.ts";
+import { promptTitle } from "./steps/title-prompt.ts";
+import type { WalkthroughCancelled, WalkthroughInput, WalkthroughResult } from "./types.ts";
+
+export type { WalkthroughCancelled, WalkthroughInput, WalkthroughResult } from "./types.ts";
+
+export interface RunWalkthroughOptions extends WalkthroughInput {
+  logger: Logger;
+}
+
+/**
+ * Composes all 9 walkthrough steps in order.
+ * Returns the assembled plan (Phase 2: no real download happens).
+ * Returns `{ cancelled: true }` when the user hits Ctrl+C.
+ */
+export async function runWalkthrough(
+  opts: RunWalkthroughOptions,
+): Promise<WalkthroughResult | WalkthroughCancelled> {
+  try {
+    // Step 1 — title
+    const title = await promptTitle({ prefill: opts.titlePrefill });
+
+    // Step 2 — source
+    const source = await pickSource();
+
+    // Step 3 — auth check
+    await checkAuth({ requiresAuth: source.requiresAuth });
+
+    // Step 4 — search results
+    const hit = await pickSearchResult({ query: title, sourceId: source.id });
+
+    // Step 5 — mode
+    const mode = await pickMode();
+
+    // Step 6 — range
+    const selectedBundles = await pickRange({ hit, mode });
+
+    // Step 7 — pack prompt (chapter mode only)
+    // volume mode always packs
+    const groupIntoVolume = mode === "volume" ? true : await promptPack();
+
+    // Step 8 — cover URL (only when packing)
+    const coverUrl = groupIntoVolume ? await promptCoverUrl() : null;
+
+    const result: WalkthroughResult = {
+      title,
+      source,
+      hit,
+      mode,
+      selectedBundles,
+      groupIntoVolume,
+      coverUrl,
+    };
+
+    // Step 9 — execute (stub in Phase 2)
+    return executePlan(result, opts.logger);
+  } catch (err) {
+    // @inquirer/prompts throws ExitPromptError when the user presses Ctrl+C
+    if (err instanceof Error && err.name === "ExitPromptError") {
+      return { cancelled: true };
+    }
+    throw err;
+  }
+}

--- a/src/walkthrough/mocks.ts
+++ b/src/walkthrough/mocks.ts
@@ -1,0 +1,25 @@
+// PHASE 3: delete this file and replace all usages with real source.search() / getChapterList() / getVolumeMap().
+
+import type { BundleItem, ModeSelection, SearchHit } from "./types.ts";
+
+export function getMockedSearchResults(query: string, _sourceId: string): SearchHit[] {
+  return Array.from({ length: 5 }, (_, i) => ({
+    id: `mock-${i + 1}`,
+    title: `${query} (result ${i + 1})`,
+    originalLanguage: "ja",
+    year: 2020 + i,
+  }));
+}
+
+export function getMockedBundles(hit: SearchHit, mode: ModeSelection): BundleItem[] {
+  if (mode === "volume") {
+    return Array.from({ length: 3 }, (_, i) => ({
+      label: `Volume ${i + 1}`,
+      id: `${hit.id}-vol-${i + 1}`,
+    }));
+  }
+  return Array.from({ length: 10 }, (_, i) => ({
+    label: `Chapter ${i + 1}`,
+    id: `${hit.id}-ch-${i + 1}`,
+  }));
+}

--- a/src/walkthrough/prompts.ts
+++ b/src/walkthrough/prompts.ts
@@ -1,0 +1,5 @@
+// Thin adapter over @inquirer/prompts.
+// Steps import from here (not directly from @inquirer/prompts) so tests can
+// mock this module via mock.module() without touching the real terminal.
+
+export { checkbox, confirm, editor, input, select } from "@inquirer/prompts";

--- a/src/walkthrough/steps/auth-check.test.ts
+++ b/src/walkthrough/steps/auth-check.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("checkAuth", () => {
+  test("requiresAuth: false → returns { ok: true, skipped: true } without prompting", async () => {
+    let promptCalled = false;
+    mock.module("../prompts.ts", () => ({
+      editor: async () => {
+        promptCalled = true;
+        return "";
+      },
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+    const { checkAuth } = await import("./auth-check.ts");
+    const result = await checkAuth({ requiresAuth: false });
+    expect(result).toEqual({ ok: true, skipped: true });
+    expect(promptCalled).toBe(false);
+  });
+
+  test("requiresAuth: true with existing valid auth → returns { ok: true, skipped: false } without prompting", async () => {
+    const dir = join(tmpdir(), `scanldr-test-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(join(authDir, "auth.json"), JSON.stringify({ token: "abc" }));
+
+    let promptCalled = false;
+    mock.module("../prompts.ts", () => ({
+      editor: async () => {
+        promptCalled = true;
+        return "";
+      },
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const { checkAuth } = await import("./auth-check.ts");
+    const result = await checkAuth({ requiresAuth: true, dataHome: dir });
+    expect(result).toEqual({ ok: true, skipped: false });
+    expect(promptCalled).toBe(false);
+  });
+
+  test("requiresAuth: true, no auth file, valid cURL paste → returns { ok: true, skipped: false }", async () => {
+    mock.module("../prompts.ts", () => ({
+      editor: async () => "curl 'https://example.com' -H 'Cookie: session=abc'",
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const { checkAuth } = await import("./auth-check.ts");
+    const result = await checkAuth({ requiresAuth: true, dataHome: "/nonexistent/path" });
+    expect(result).toEqual({ ok: true, skipped: false });
+  });
+
+  test("requiresAuth: true, invalid paste (no cookie:) — exhausts 2 retries then throws", async () => {
+    let callCount = 0;
+    mock.module("../prompts.ts", () => ({
+      editor: async () => {
+        callCount++;
+        return "curl 'https://example.com' -H 'Accept: */*'"; // no cookie header
+      },
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const { checkAuth } = await import("./auth-check.ts");
+    await expect(checkAuth({ requiresAuth: true, dataHome: "/nonexistent/path" })).rejects.toThrow(
+      /cookie/i,
+    );
+    expect(callCount).toBe(2);
+  });
+});

--- a/src/walkthrough/steps/auth-check.ts
+++ b/src/walkthrough/steps/auth-check.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolveAuthPath } from "../../plugins/auth-path/index.ts";
+import { editor } from "../prompts.ts";
+import type { AuthResult } from "../types.ts";
+
+export interface AuthCheckOptions {
+  requiresAuth: boolean;
+  /** Injected in tests to override the default XDG auth path. */
+  dataHome?: string;
+}
+
+const MAX_PASTE_RETRIES = 2;
+
+function isValidAuthFile(path: string): boolean {
+  if (!existsSync(path)) return false;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    return typeof parsed === "object" && parsed !== null;
+  } catch {
+    return false;
+  }
+}
+
+function isValidCurlPaste(paste: string): boolean {
+  const lower = paste.toLowerCase();
+  return lower.trimStart().startsWith("curl ") && lower.includes("cookie:");
+}
+
+/** Step 3: check auth state. Prompt for cURL paste when needed. */
+export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
+  if (!opts.requiresAuth) {
+    return { ok: true, skipped: true };
+  }
+
+  const authPath = resolveAuthPath({ dataHome: opts.dataHome });
+
+  if (isValidAuthFile(authPath)) {
+    return { ok: true, skipped: false };
+  }
+
+  // No valid session — prompt for cURL paste
+  for (let attempt = 0; attempt < MAX_PASTE_RETRIES; attempt++) {
+    const paste = await editor({
+      message: "No valid session found. Paste a cURL command with cookie headers (opens editor):",
+    });
+
+    if (isValidCurlPaste(paste)) {
+      // PHASE 3: persist auth via existing auth module
+      return { ok: true, skipped: false };
+    }
+
+    const remaining = MAX_PASTE_RETRIES - attempt - 1;
+    if (remaining > 0) {
+      process.stderr.write(
+        `Invalid cURL paste (must start with "curl " and contain "cookie:" header). ${remaining} attempt(s) left.\n`,
+      );
+    }
+  }
+
+  throw new Error(
+    'Auth failed: pasted cURL command must start with "curl " and contain a "cookie:" header.',
+  );
+}

--- a/src/walkthrough/steps/cover-prompt.test.ts
+++ b/src/walkthrough/steps/cover-prompt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, mock, test } from "bun:test";
+
+describe("promptCoverUrl", () => {
+  test("empty input returns null", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptCoverUrl } = await import("./cover-prompt.ts");
+    expect(await promptCoverUrl()).toBeNull();
+  });
+
+  test("valid URL returns the URL string", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async () => "https://example.com/cover.jpg",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptCoverUrl } = await import("./cover-prompt.ts");
+    expect(await promptCoverUrl()).toBe("https://example.com/cover.jpg");
+  });
+
+  test("invalid URL twice then returns null (graceful skip after max retries)", async () => {
+    let calls = 0;
+    mock.module("../prompts.ts", () => ({
+      input: async () => {
+        calls++;
+        return "not-a-valid-url";
+      },
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptCoverUrl } = await import("./cover-prompt.ts");
+    const result = await promptCoverUrl();
+    expect(result).toBeNull();
+    expect(calls).toBe(2);
+  });
+});

--- a/src/walkthrough/steps/cover-prompt.ts
+++ b/src/walkthrough/steps/cover-prompt.ts
@@ -1,0 +1,36 @@
+import { input } from "../prompts.ts";
+
+const MAX_URL_RETRIES = 2;
+
+function isValidUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Step 8 (when packing): optionally provide a cover image URL. */
+export async function promptCoverUrl(): Promise<string | null> {
+  for (let attempt = 0; attempt < MAX_URL_RETRIES; attempt++) {
+    const raw = await input({
+      message: "Cover image URL? (Enter to skip)",
+      default: "",
+    });
+
+    const trimmed = raw.trim();
+
+    if (trimmed === "") return null;
+
+    if (isValidUrl(trimmed)) return trimmed;
+
+    const remaining = MAX_URL_RETRIES - attempt - 1;
+    if (remaining > 0) {
+      process.stderr.write(`Invalid URL. ${remaining} attempt(s) left or press Enter to skip.\n`);
+    }
+  }
+
+  // After max retries with invalid URL, skip gracefully
+  return null;
+}

--- a/src/walkthrough/steps/execute-stub.test.ts
+++ b/src/walkthrough/steps/execute-stub.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "../../plugins/logger/index.ts";
+import { getSource } from "../../sources/index.ts";
+import type { WalkthroughResult } from "../types.ts";
+import { executePlan } from "./execute-stub.ts";
+
+const source = getSource("mangadex");
+
+const plan: WalkthroughResult = {
+  title: "Naruto",
+  source,
+  hit: { id: "hit-1", title: "Naruto", originalLanguage: "ja", year: 1999 },
+  mode: "chapter",
+  selectedBundles: [{ label: "Chapter 1", id: "hit-1-ch-1" }],
+  groupIntoVolume: true,
+  coverUrl: "https://example.com/cover.jpg",
+};
+
+describe("executePlan", () => {
+  test("logger.info called with event=walkthrough.plan_ready and plan fields", () => {
+    const calls: { fields: Record<string, unknown>; msg: string }[] = [];
+
+    const fakeLogger: Logger = {
+      info: (fields: Record<string, unknown>, msg: string) => {
+        calls.push({ fields, msg });
+      },
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+      child: () => fakeLogger,
+    } as unknown as Logger;
+
+    executePlan(plan, fakeLogger);
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (!call) throw new Error("No calls recorded");
+    expect(call.fields.event).toBe("walkthrough.plan_ready");
+    expect(call.fields.source).toBe("mangadex");
+    expect(call.fields.title).toBe("Naruto");
+    expect(call.fields.mode).toBe("chapter");
+    expect(call.fields.bundles).toBe(1);
+    expect(call.fields.groupIntoVolume).toBe(true);
+  });
+
+  test("returns input plan unchanged (no mutation)", () => {
+    const noop = () => {};
+    const fakeLogger = {
+      info: noop,
+      debug: noop,
+      warn: noop,
+      error: noop,
+    } as unknown as Logger;
+
+    const returned = executePlan(plan, fakeLogger);
+    expect(returned).toBe(plan);
+  });
+});

--- a/src/walkthrough/steps/execute-stub.ts
+++ b/src/walkthrough/steps/execute-stub.ts
@@ -1,0 +1,25 @@
+import type { Logger } from "../../plugins/logger/index.ts";
+import type { WalkthroughResult } from "../types.ts";
+
+/** Step 9: print execution plan and return the assembled result.
+ * PHASE 3: wire to real download → pack pipeline. */
+export function executePlan(result: WalkthroughResult, logger: Logger): WalkthroughResult {
+  logger.info(
+    {
+      event: "walkthrough.plan_ready",
+      context: "walkthrough",
+      source: result.source.id,
+      title: result.title,
+      hit: result.hit.title,
+      mode: result.mode,
+      bundles: result.selectedBundles.length,
+      groupIntoVolume: result.groupIntoVolume,
+      coverUrl: result.coverUrl ?? "(none)",
+    },
+    "walkthrough plan assembled — ready to execute",
+  );
+
+  // PHASE 3: wire to real download → pack pipeline
+
+  return result;
+}

--- a/src/walkthrough/steps/mode-picker.test.ts
+++ b/src/walkthrough/steps/mode-picker.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, mock, test } from "bun:test";
+
+describe("pickMode", () => {
+  test("returns 'chapter' when selected", async () => {
+    mock.module("../prompts.ts", () => ({
+      select: async () => "chapter",
+      input: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickMode } = await import("./mode-picker.ts");
+    expect(await pickMode()).toBe("chapter");
+  });
+
+  test("returns 'volume' when selected", async () => {
+    mock.module("../prompts.ts", () => ({
+      select: async () => "volume",
+      input: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickMode } = await import("./mode-picker.ts");
+    expect(await pickMode()).toBe("volume");
+  });
+});

--- a/src/walkthrough/steps/mode-picker.ts
+++ b/src/walkthrough/steps/mode-picker.ts
@@ -1,0 +1,14 @@
+import { select } from "../prompts.ts";
+import type { ModeSelection } from "../types.ts";
+
+/** Step 5: pick download mode. */
+export async function pickMode(): Promise<ModeSelection> {
+  const result = await select<ModeSelection>({
+    message: "Download mode:",
+    choices: [
+      { name: "[1] Capítulo", value: "chapter" },
+      { name: "[2] Volume", value: "volume" },
+    ],
+  });
+  return result;
+}

--- a/src/walkthrough/steps/pack-prompt.test.ts
+++ b/src/walkthrough/steps/pack-prompt.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, mock, test } from "bun:test";
+
+describe("promptPack", () => {
+  test("returns true when user confirms", async () => {
+    mock.module("../prompts.ts", () => ({
+      confirm: async () => true,
+      select: async () => "",
+      input: async () => "",
+      checkbox: async () => [],
+      editor: async () => "",
+    }));
+    const { promptPack } = await import("./pack-prompt.ts");
+    expect(await promptPack()).toBe(true);
+  });
+
+  test("returns false when user declines", async () => {
+    mock.module("../prompts.ts", () => ({
+      confirm: async () => false,
+      select: async () => "",
+      input: async () => "",
+      checkbox: async () => [],
+      editor: async () => "",
+    }));
+    const { promptPack } = await import("./pack-prompt.ts");
+    expect(await promptPack()).toBe(false);
+  });
+});

--- a/src/walkthrough/steps/pack-prompt.ts
+++ b/src/walkthrough/steps/pack-prompt.ts
@@ -1,0 +1,9 @@
+import { confirm } from "../prompts.ts";
+
+/** Step 7 (chapter mode only): ask whether to group chapters into a single volume. */
+export async function promptPack(): Promise<boolean> {
+  return confirm({
+    message: "Group these chapters into a single volume?",
+    default: true,
+  });
+}

--- a/src/walkthrough/steps/range-picker.test.ts
+++ b/src/walkthrough/steps/range-picker.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SearchHit } from "../types.ts";
+
+const mockHit: SearchHit = {
+  id: "mock-1",
+  title: "Test Manga",
+  originalLanguage: "ja",
+  year: 2020,
+};
+
+describe("pickRange", () => {
+  test("multi-select returns selected bundles array", async () => {
+    mock.module("../prompts.ts", () => ({
+      checkbox: async () => ["mock-1-ch-1", "mock-1-ch-3"],
+      select: async () => "",
+      input: async () => "",
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickRange } = await import("./range-picker.ts");
+    const result = await pickRange({ hit: mockHit, mode: "chapter" });
+    expect(result).toHaveLength(2);
+    expect(result.map((b) => b.id)).toContain("mock-1-ch-1");
+    expect(result.map((b) => b.id)).toContain("mock-1-ch-3");
+  });
+
+  test("empty selection — throws error", async () => {
+    mock.module("../prompts.ts", () => ({
+      checkbox: async (opts: {
+        validate?: (items: readonly { value: string }[]) => string | boolean;
+      }) => {
+        const res = opts.validate?.([]);
+        if (typeof res === "string") throw new Error(res);
+        return [];
+      },
+      select: async () => "",
+      input: async () => "",
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickRange } = await import("./range-picker.ts");
+    await expect(pickRange({ hit: mockHit, mode: "chapter" })).rejects.toThrow(/at least one/i);
+  });
+
+  test("volume mode returns volume bundles", async () => {
+    mock.module("../prompts.ts", () => ({
+      checkbox: async () => ["mock-1-vol-1"],
+      select: async () => "",
+      input: async () => "",
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickRange } = await import("./range-picker.ts");
+    const result = await pickRange({ hit: mockHit, mode: "volume" });
+    expect(result[0]?.label).toMatch(/Volume/);
+  });
+});

--- a/src/walkthrough/steps/range-picker.ts
+++ b/src/walkthrough/steps/range-picker.ts
@@ -1,0 +1,31 @@
+import { getMockedBundles } from "../mocks.ts";
+import { checkbox } from "../prompts.ts";
+import type { BundleItem, ModeSelection, SearchHit } from "../types.ts";
+
+export interface RangePickerOptions {
+  hit: SearchHit;
+  mode: ModeSelection;
+}
+
+/** Step 6: multi-select available bundles.
+ * PHASE 3: replace getMockedBundles with real chapter/volume list from source. */
+export async function pickRange(opts: RangePickerOptions): Promise<BundleItem[]> {
+  // PHASE 3: replace with real source chapter/volume listing
+  const bundles = getMockedBundles(opts.hit, opts.mode);
+
+  const selectedIds = await checkbox<string>({
+    message: `Select ${opts.mode === "chapter" ? "chapters" : "volumes"} to download:`,
+    choices: bundles.map((b, i) => ({
+      name: `[${i + 1}] ${b.label}`,
+      value: b.id,
+    })),
+    validate: (items: readonly { value: string }[]) =>
+      items.length > 0 || "Select at least one item",
+  });
+
+  const selected = bundles.filter((b) => selectedIds.includes(b.id));
+  if (selected.length === 0) {
+    throw new Error("No bundles selected");
+  }
+  return selected;
+}

--- a/src/walkthrough/steps/search-results-picker.test.ts
+++ b/src/walkthrough/steps/search-results-picker.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SearchHit } from "../types.ts";
+
+const results: SearchHit[] = [
+  { id: "hit-1", title: "Manga A", originalLanguage: "ja", year: 2020 },
+  { id: "hit-2", title: "Manga B", originalLanguage: "ja", year: 2021 },
+  { id: "hit-3", title: "Manga C", originalLanguage: "ja", year: 2022 },
+];
+
+describe("pickSearchResult", () => {
+  test("happy path: select returns id of hit #2, result matches hit #2 by reference", async () => {
+    mock.module("../prompts.ts", () => ({
+      select: async () => "hit-2",
+      input: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    // Override mocked search results via mocks module
+    mock.module("../mocks.ts", () => ({
+      getMockedSearchResults: () => results,
+      getMockedBundles: () => [],
+    }));
+
+    const { pickSearchResult } = await import("./search-results-picker.ts");
+    const result = await pickSearchResult({ query: "Manga", sourceId: "mangadex" });
+    const expected = results[1];
+    if (!expected) throw new Error("fixture has no index 1");
+    expect(result).toBe(expected);
+  });
+
+  test("throws when select returns unknown id", async () => {
+    mock.module("../prompts.ts", () => ({
+      select: async () => "hit-999",
+      input: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    mock.module("../mocks.ts", () => ({
+      getMockedSearchResults: () => results,
+      getMockedBundles: () => [],
+    }));
+
+    const { pickSearchResult } = await import("./search-results-picker.ts");
+    await expect(pickSearchResult({ query: "Manga", sourceId: "mangadex" })).rejects.toThrow(
+      /Unknown|Unexpected/,
+    );
+  });
+});

--- a/src/walkthrough/steps/search-results-picker.ts
+++ b/src/walkthrough/steps/search-results-picker.ts
@@ -1,0 +1,27 @@
+import { getMockedSearchResults } from "../mocks.ts";
+import { select } from "../prompts.ts";
+import type { SearchHit } from "../types.ts";
+
+export interface SearchResultsPickerOptions {
+  query: string;
+  sourceId: string;
+}
+
+/** Step 4: show search results and let user pick one.
+ * PHASE 3: replace getMockedSearchResults with real source.search(query). */
+export async function pickSearchResult(opts: SearchResultsPickerOptions): Promise<SearchHit> {
+  // PHASE 3: replace with real source.search(query)
+  const results = getMockedSearchResults(opts.query, opts.sourceId);
+
+  const id = await select<string>({
+    message: "Select manga:",
+    choices: results.map((r, i) => ({
+      name: `[${i + 1}] ${r.title}${r.year ? ` (${r.year})` : ""}`,
+      value: r.id,
+    })),
+  });
+
+  const found = results.find((r) => r.id === id);
+  if (!found) throw new Error(`Unexpected result id: ${id}`);
+  return found;
+}

--- a/src/walkthrough/steps/source-picker.test.ts
+++ b/src/walkthrough/steps/source-picker.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, mock, test } from "bun:test";
+import { SOURCES } from "../../sources/registry.ts";
+
+describe("pickSource", () => {
+  test("returns the chosen source descriptor", async () => {
+    mock.module("../prompts.ts", () => ({
+      select: async () => "mangadex",
+      input: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickSource } = await import("./source-picker.ts");
+    const result = await pickSource();
+    const expected = SOURCES.find((s) => s.id === "mangadex");
+    if (!expected) throw new Error("mangadex not found in SOURCES");
+    expect(result).toEqual(expected);
+  });
+
+  test("returns mangakakalot descriptor", async () => {
+    mock.module("../prompts.ts", () => ({
+      select: async () => "mangakakalot",
+      input: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { pickSource } = await import("./source-picker.ts");
+    const result = await pickSource();
+    expect(result.id).toBe("mangakakalot");
+    expect(result.requiresAuth).toBe(true);
+  });
+});

--- a/src/walkthrough/steps/source-picker.ts
+++ b/src/walkthrough/steps/source-picker.ts
@@ -1,0 +1,15 @@
+import { SOURCES } from "../../sources/registry.ts";
+import type { SourceDescriptor } from "../../sources/types.ts";
+import { select } from "../prompts.ts";
+
+/** Step 2: let the user pick a source. */
+export async function pickSource(): Promise<SourceDescriptor> {
+  const id = await select<string>({
+    message: "Choose a source:",
+    choices: SOURCES.map((s) => ({ name: s.label, value: s.id })),
+  });
+  // getSource() would work, but we already have SOURCES here — avoid extra call
+  const found = SOURCES.find((s) => s.id === id);
+  if (!found) throw new Error(`Unexpected source id: ${id}`);
+  return found;
+}

--- a/src/walkthrough/steps/source-picker.ts
+++ b/src/walkthrough/steps/source-picker.ts
@@ -1,4 +1,4 @@
-import { SOURCES } from "../../sources/registry.ts";
+import { SOURCES, getSource } from "../../sources/index.ts";
 import type { SourceDescriptor } from "../../sources/types.ts";
 import { select } from "../prompts.ts";
 
@@ -8,8 +8,5 @@ export async function pickSource(): Promise<SourceDescriptor> {
     message: "Choose a source:",
     choices: SOURCES.map((s) => ({ name: s.label, value: s.id })),
   });
-  // getSource() would work, but we already have SOURCES here — avoid extra call
-  const found = SOURCES.find((s) => s.id === id);
-  if (!found) throw new Error(`Unexpected source id: ${id}`);
-  return found;
+  return getSource(id);
 }

--- a/src/walkthrough/steps/title-prompt.test.ts
+++ b/src/walkthrough/steps/title-prompt.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, mock, test } from "bun:test";
+
+describe("promptTitle", () => {
+  test("with prefill — default is set to prefill value", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptTitle } = await import("./title-prompt.ts");
+    const result = await promptTitle({ prefill: "Naruto" });
+    expect(result).toBe("Naruto");
+  });
+
+  test("without prefill — returns user-typed value", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async (_opts: unknown) => "One Piece",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptTitle } = await import("./title-prompt.ts");
+    const result = await promptTitle();
+    expect(result).toBe("One Piece");
+  });
+
+  test("empty string — validate rejects (returns error string not empty)", async () => {
+    // Verify validate function returns an error message for empty input
+    mock.module("../prompts.ts", () => ({
+      input: async (opts: { validate?: (v: string) => string | boolean }) => {
+        const validation = opts.validate?.("");
+        if (typeof validation === "string") throw new Error(validation);
+        return "valid title";
+      },
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptTitle } = await import("./title-prompt.ts");
+    await expect(promptTitle()).rejects.toThrow(/empty/i);
+  });
+});

--- a/src/walkthrough/steps/title-prompt.ts
+++ b/src/walkthrough/steps/title-prompt.ts
@@ -1,0 +1,15 @@
+import { input } from "../prompts.ts";
+
+export interface TitlePromptOptions {
+  prefill?: string;
+}
+
+/** Step 1: prompt for manga title or URL. Re-prompts when empty. */
+export async function promptTitle(opts: TitlePromptOptions = {}): Promise<string> {
+  const result = await input({
+    message: "Manga title or URL:",
+    default: opts.prefill,
+    validate: (v: string) => v.trim().length > 0 || "Title cannot be empty",
+  });
+  return result.trim();
+}

--- a/src/walkthrough/types.ts
+++ b/src/walkthrough/types.ts
@@ -1,0 +1,62 @@
+import type { SourceDescriptor } from "../sources/types.ts";
+
+export type { SourceDescriptor };
+
+export interface WalkthroughInput {
+  titlePrefill?: string;
+}
+
+export interface TitleOrUrl {
+  value: string;
+}
+
+export interface SourceSelection {
+  source: SourceDescriptor;
+}
+
+/** One result from a source search. Mirrors MangaCandidate from shared types. */
+export interface SearchHit {
+  id: string;
+  title: string;
+  originalLanguage: string;
+  year: number | null;
+}
+
+export type ModeSelection = "chapter" | "volume";
+
+export interface BundleItem {
+  /** Display label shown to user e.g. "Chapter 1" or "Volume 3" */
+  label: string;
+  /** Opaque id used by Phase 3 to fetch pages */
+  id: string;
+}
+
+export interface RangeSelection {
+  bundles: BundleItem[];
+}
+
+export interface PackOptions {
+  groupIntoVolume: boolean;
+  coverUrl: string | null;
+}
+
+export interface AuthResult {
+  ok: boolean;
+  /** true = source doesn't require auth OR session already valid */
+  skipped: boolean;
+}
+
+export interface WalkthroughResult {
+  title: string;
+  source: SourceDescriptor;
+  hit: SearchHit;
+  mode: ModeSelection;
+  selectedBundles: BundleItem[];
+  groupIntoVolume: boolean;
+  coverUrl: string | null;
+}
+
+/** Sentinel returned when the user cancels the walkthrough (Ctrl+C). */
+export interface WalkthroughCancelled {
+  cancelled: true;
+}

--- a/src/walkthrough/types.ts
+++ b/src/walkthrough/types.ts
@@ -1,17 +1,7 @@
 import type { SourceDescriptor } from "../sources/types.ts";
 
-export type { SourceDescriptor };
-
 export interface WalkthroughInput {
   titlePrefill?: string;
-}
-
-export interface TitleOrUrl {
-  value: string;
-}
-
-export interface SourceSelection {
-  source: SourceDescriptor;
 }
 
 /** One result from a source search. Mirrors MangaCandidate from shared types. */
@@ -29,15 +19,6 @@ export interface BundleItem {
   label: string;
   /** Opaque id used by Phase 3 to fetch pages */
   id: string;
-}
-
-export interface RangeSelection {
-  bundles: BundleItem[];
-}
-
-export interface PackOptions {
-  groupIntoVolume: boolean;
-  coverUrl: string | null;
 }
 
 export interface AuthResult {

--- a/src/walkthrough/walkthrough.test.ts
+++ b/src/walkthrough/walkthrough.test.ts
@@ -6,25 +6,9 @@ const logger = createLogger({ level: "info", format: "human", write: noop });
 
 describe("runWalkthrough — full happy path", () => {
   test("mode=chapter + group=true + cover URL → returns assembled plan", async () => {
-    let selectCall = 0;
-    mock.module("./prompts.ts", () => ({
-      input: async (opts: { default?: string }) => {
-        // title step
-        return opts.default ?? "Naruto";
-      },
-      select: async () => {
-        selectCall++;
-        if (selectCall === 1) return "mangadex"; // source — no auth needed
-        if (selectCall === 2) return "mock-1"; // search result
-        return "chapter"; // mode
-      },
-      checkbox: async () => ["mock-1-ch-1", "mock-1-ch-2"],
-      confirm: async () => true, // groupIntoVolume
-      editor: async () => "",
-    }));
-
     // cover URL — second input call
     let inputCall = 0;
+    let selectCall = 0;
     mock.module("./prompts.ts", () => ({
       input: async () => {
         inputCall++;
@@ -73,6 +57,38 @@ describe("runWalkthrough — full happy path", () => {
     if ("cancelled" in result) throw new Error("Unexpected cancellation");
     expect(result.mode).toBe("volume");
     expect(result.groupIntoVolume).toBe(true); // auto-set for volume mode
+  });
+
+  test("mode=chapter + group=false → cover-prompt skipped, coverUrl is null", async () => {
+    let inputCallCount = 0;
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => {
+        inputCallCount++;
+        return opts.default ?? "Bleach";
+      },
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        if (selectCall === 2) return "mock-1";
+        return "chapter";
+      },
+      checkbox: async () => ["mock-1-ch-1"],
+      // confirm=false means groupIntoVolume=false → cover-prompt must NOT be called
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    const inputCallsBefore = inputCallCount;
+    selectCall = 0;
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({ logger, titlePrefill: "Bleach" });
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+
+    expect(result.coverUrl).toBeNull();
+    expect(result.groupIntoVolume).toBe(false);
+    // cover-prompt calls input(); confirm it was NOT called after title step
+    expect(inputCallCount - inputCallsBefore).toBe(1); // only title step called input
   });
 
   test("Ctrl+C (ExitPromptError) returns { cancelled: true }", async () => {

--- a/src/walkthrough/walkthrough.test.ts
+++ b/src/walkthrough/walkthrough.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createLogger } from "../plugins/logger/index.ts";
+
+const noop = () => {};
+const logger = createLogger({ level: "info", format: "human", write: noop });
+
+describe("runWalkthrough — full happy path", () => {
+  test("mode=chapter + group=true + cover URL → returns assembled plan", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => {
+        // title step
+        return opts.default ?? "Naruto";
+      },
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex"; // source — no auth needed
+        if (selectCall === 2) return "mock-1"; // search result
+        return "chapter"; // mode
+      },
+      checkbox: async () => ["mock-1-ch-1", "mock-1-ch-2"],
+      confirm: async () => true, // groupIntoVolume
+      editor: async () => "",
+    }));
+
+    // cover URL — second input call
+    let inputCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async () => {
+        inputCall++;
+        if (inputCall === 1) return "Naruto"; // title
+        return "https://example.com/cover.jpg"; // cover URL
+      },
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        if (selectCall === 2) return "mock-1";
+        return "chapter";
+      },
+      checkbox: async () => ["mock-1-ch-1", "mock-1-ch-2"],
+      confirm: async () => true,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({ logger, titlePrefill: "Naruto" });
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    expect(result.mode).toBe("chapter");
+    expect(result.groupIntoVolume).toBe(true);
+    expect(result.coverUrl).toBe("https://example.com/cover.jpg");
+    expect(result.selectedBundles).toHaveLength(2);
+  });
+
+  test("mode=volume (auto-pack) → returns assembled plan with groupIntoVolume=true", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "One Piece",
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        if (selectCall === 2) return "mock-1";
+        return "volume";
+      },
+      checkbox: async () => ["mock-1-vol-1"],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({ logger, titlePrefill: "One Piece" });
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    expect(result.mode).toBe("volume");
+    expect(result.groupIntoVolume).toBe(true); // auto-set for volume mode
+  });
+
+  test("Ctrl+C (ExitPromptError) returns { cancelled: true }", async () => {
+    const ExitPromptError = class extends Error {
+      override name = "ExitPromptError";
+    };
+
+    mock.module("./prompts.ts", () => ({
+      input: async () => {
+        throw new ExitPromptError("User force closed the prompt");
+      },
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({ logger });
+    expect(result).toEqual({ cancelled: true });
+  });
+});


### PR DESCRIPTION
## What this PR does

- Adds `src/sources/` registry: `SOURCES` constant + `getSource()`, each entry with `requiresAuth` flag.
- Adds `src/walkthrough/` module: 9 composable step functions orchestrated by `runWalkthrough()`.
- Adds `src/walkthrough/prompts.ts` thin adapter over `@inquirer/prompts` (mockable in tests).
- Adds `src/walkthrough/mocks.ts` for Phase 2 stub data (`getMockedSearchResults`, `getMockedBundles`).
- Wires `bun start` / `bun start <title>` to the walkthrough when no known subcommand is present.
- All 9 steps have colocated unit tests; full test count goes from 595 → 626.

## Why it exists

Refs: #116. Phase 2 establishes the interactive UX skeleton (prompts, data shapes, routing). Phase 3 will replace mocked data with real `mangakakalot`/`mangadex` client calls and hook into the existing pack pipeline.

## How it works internally

| Step | File |
|------|------|
| 1 — title prompt | `src/walkthrough/steps/title-prompt.ts` |
| 2 — source picker | `src/walkthrough/steps/source-picker.ts` |
| 3 — auth check | `src/walkthrough/steps/auth-check.ts` |
| 4 — search results | `src/walkthrough/steps/search-results-picker.ts` |
| 5 — mode picker | `src/walkthrough/steps/mode-picker.ts` |
| 6 — range picker | `src/walkthrough/steps/range-picker.ts` |
| 7 — pack confirm | `src/walkthrough/steps/pack-prompt.ts` |
| 8 — cover URL | `src/walkthrough/steps/cover-prompt.ts` |
| 9 — execute stub | `src/walkthrough/steps/execute-stub.ts` |
| orchestrator | `src/walkthrough/index.ts` |

`Ctrl+C` (`ExitPromptError` from inquirer) is caught and returns `{ cancelled: true }` → `process.exit(130)`.

## What did not change

- `src/integrations/` — untouched (only public types were read).
- `src/commands/` — untouched.
- No `--debug-trace` flag (Phase 3+).
- No migrations added or removed.
- Existing subcommands (`download`, `list`, `history`, `auth`, etc.) still route correctly.
- Mocked data is isolated to `src/walkthrough/mocks.ts`; Phase 3 will delete that file.

## Test checklist

- [x] `src/sources/registry.test.ts` — 6 tests covering SOURCES entries and `getSource`.
- [x] `src/walkthrough/steps/title-prompt.test.ts` — prefill, user input, empty rejection.
- [x] `src/walkthrough/steps/source-picker.test.ts` — returns correct descriptor.
- [x] `src/walkthrough/steps/auth-check.test.ts` — no-auth skip, valid session skip, valid paste, 2-retry exhaustion.
- [x] `src/walkthrough/steps/mode-picker.test.ts` — chapter/volume.
- [x] `src/walkthrough/steps/range-picker.test.ts` — multi-select, empty rejection, volume bundles.
- [x] `src/walkthrough/steps/pack-prompt.test.ts` — confirm true/false.
- [x] `src/walkthrough/steps/cover-prompt.test.ts` — empty→null, valid URL, 2 invalid→null.
- [x] `src/walkthrough/walkthrough.test.ts` — chapter+group+cover, volume mode, Ctrl+C cancellation.
- [x] `src/cli-routing.test.ts` updated — no-args→walkthrough, prefill→walkthrough, download/list regressions.
- Phase 1 baseline: 595 tests. Phase 2 final: **626 tests**.

## Reviewer notes

- New dependency: `@inquirer/prompts@8.4.3`. It requires a real TTY for interactive use; tests mock `src/walkthrough/prompts.ts` via `mock.module()`.
- The mock layer in `mocks.ts` is intentional tech debt meant to be deleted in Phase 3.
- `src/walkthrough/prompts.ts` is the injection seam — all steps import from it, not directly from `@inquirer/prompts`, making mocking clean.
- Routing change: any single positional that is not a known subcommand now routes to the walkthrough (as title prefill), instead of printing "Unknown command". This is intentional per the epic design.

## Closes

Refs: #116