### PR TITLE
docs(adr): supersede ADR-003 + withdraw ADR-004; new ADR-006 trace-as-state (Phase 5 of #116)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,37 +2,48 @@
 
 This document is the central index of all technical documentation for **scanldr**. It covers everything from high-level architecture to detailed flow diagrams.
 
-## 📌 Overview
+## Overview
 - [System Overview](overviewer.md)
 - [Software Architecture (C4 Model)](architecture_c4.md)
 
-## 🔄 Business Flows
+## Architecture Decision Records (ADRs)
+- [ADR-001: Cookie Replay over Playwright Stealth](adr/001-cookie-replay-strategy.md)
+- [ADR-002: MangaDex as Primary Metadata and Download Source](adr/002-mangadex-primary-source.md)
+- [ADR-002: Manual Cookie Paste (supersedes ADR-001 auth mechanism)](adr/002-manual-cookie-paste.md)
+- [ADR-003: SQLite for Download History](adr/003-sqlite-download-history.md) _(superseded by ADR-006)_
+- [ADR-004: Subscriptions Stored in SQLite](adr/004-subscriptions-in-sqlite.md) _(withdrawn)_
+- [ADR-006: Trace store as state, with TTL retention](adr/006-trace-store-as-state-with-ttl.md)
+
+## Historical Flows (pre-epic #116)
+
+> These flows describe commands (`download`, `list`, `sync`, `update`) removed in epic #116. Kept as historical record.
+
 - [Authentication Flow (Cloudflare bypass)](flows/auth_flow.md)
 - [List Flow](flows/list_flow.md)
 - [Download Flow](flows/download_flow.md)
 - [Update Flow](flows/update_flow.md)
 - [Sync Flow](flows/sync_flow.md)
 
-## 📊 Data Models
+## Historical Data Models (pre-epic #116)
+
+> These models describe tables (`downloads`, `subscriptions`) dropped in epic #116 Phase 4. Kept as historical record.
+
 - [Auth & Session Model](models/auth_model.md)
 - [Manga & Chapter Model](models/manga_model.md)
+- [History Model](models/history_model.md)
+- [Subscription Model](models/subscription_model.md)
 
-## 📝 Architecture Decision Records (ADRs)
-- [ADR-001: Cookie Replay over Playwright Stealth](adr/001-cookie-replay-strategy.md)
-- [ADR-002: MangaDex as Primary Metadata and Download Source](adr/002-mangadex-primary-source.md)
-- [ADR-003: SQLite for Download History](adr/003-sqlite-download-history.md)
-- [ADR-004: Subscriptions Stored in SQLite, Not a Flat-Text File](adr/004-subscriptions-in-sqlite.md)
-
-## ⚙️ CI/CD
+## CI/CD
 - [Quality & Security Stack](ci-cd.md)
 
-## 🛠 Technical Standards
+## Technical Standards
 - **Runtime:** Bun
 - **Language:** TypeScript
-- **Auth:** manual cURL paste captured from the user's real browser via DevTools
+- **Auth:** manual cURL paste from the user's real browser via DevTools (`parseCurl` in `src/plugins/auth-path/`)
 - **Metadata source:** MangaDex API
-- **Output formats:** CBZ / ZIP
-- **History persistence:** SQLite via `bun:sqlite`
+- **Output formats:** CBZ / ZIP (via `src/pack/`)
+- **Persistent state:** SQLite `traces` table only — 3-day TTL, one row per log event (`src/plugins/trace/`)
+- **CLI entrypoint:** `bun start` → single one-shot walkthrough (`src/walkthrough/`)
 - **Supported sources:** MangaDex (primary), mangakakalot.gg (fallback), others to be added
 
 ---

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,8 +3,7 @@
 This document is the central index of all technical documentation for **scanldr**. It covers everything from high-level architecture to detailed flow diagrams.
 
 ## Overview
-- [System Overview](overviewer.md)
-- [Software Architecture (C4 Model)](architecture_c4.md)
+- [System Overview](architecture_c4.md)
 
 ## Architecture Decision Records (ADRs)
 - [ADR-001: Cookie Replay over Playwright Stealth](adr/001-cookie-replay-strategy.md)
@@ -23,6 +22,10 @@ This document is the central index of all technical documentation for **scanldr*
 - [Download Flow](flows/download_flow.md)
 - [Update Flow](flows/update_flow.md)
 - [Sync Flow](flows/sync_flow.md)
+
+## Historical Overview (pre-epic #116)
+
+- [System Overview](overviewer.md) _(pre-epic #116 — historical record)_
 
 ## Historical Data Models (pre-epic #116)
 

--- a/docs/adr/003-sqlite-download-history.md
+++ b/docs/adr/003-sqlite-download-history.md
@@ -3,6 +3,8 @@
 **Date:** 2026-04-24
 **Status:** Accepted
 
+> **Status**: Superseded by [ADR-006](006-trace-store-as-state-with-ttl.md) on 2026-05-10.
+
 ## Context
 
 The user downloads complete volumes and then deletes the `.cbz` files after reading to free up disk space. The `update` and `sync` commands need to know what has already been downloaded to avoid re-downloading. The output directory cannot be used as the source of truth because the files may have been deleted.

--- a/docs/adr/004-subscriptions-in-sqlite.md
+++ b/docs/adr/004-subscriptions-in-sqlite.md
@@ -4,6 +4,7 @@
 **Status:** Accepted
 
 > **Status**: Withdrawn on 2026-05-10. The `subscriptions` feature was decommissioned in epic #116 Phase 4. No replacement.
+
 **Supersedes:** the `mangas.txt` design referenced by earlier drafts of `flows/sync_flow.md` and `overviewer.md`.
 
 ## Context

--- a/docs/adr/004-subscriptions-in-sqlite.md
+++ b/docs/adr/004-subscriptions-in-sqlite.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-05-01
 **Status:** Accepted
+
+> **Status**: Withdrawn on 2026-05-10. The `subscriptions` feature was decommissioned in epic #116 Phase 4. No replacement.
 **Supersedes:** the `mangas.txt` design referenced by earlier drafts of `flows/sync_flow.md` and `overviewer.md`.
 
 ## Context

--- a/docs/adr/006-trace-store-as-state-with-ttl.md
+++ b/docs/adr/006-trace-store-as-state-with-ttl.md
@@ -1,0 +1,65 @@
+# ADR-006: Trace store as state, with TTL retention
+
+**Date:** 2026-05-10
+**Status:** Accepted
+
+**Related:**
+- Supersedes [ADR-003](003-sqlite-download-history.md)
+- Withdraws [ADR-004](004-subscriptions-in-sqlite.md)
+- Implements the logging architecture decision captured in epic #116
+
+## Context
+
+Before Phase 1 of epic #116, scanldr persisted user-facing state in two SQLite tables:
+
+- `downloads` — history of completed chapter downloads, used by `update` and `sync` to skip already-downloaded chapters.
+- `subscriptions` — a watchlist of manga the user wanted to keep updated.
+
+The redesign captured in epic #116 dropped both tables in Phase 4. The CLI is now a single one-shot walkthrough (`bun start`); there is no library to manage and no history to track between runs.
+
+However, debug and post-mortem traceability is still required when a download misbehaves. Phase 1 introduced a `traces` table with structured per-event rows:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `ts` | TEXT | ISO-8601 timestamp |
+| `level` | TEXT | `info`, `warn`, or `error` |
+| `event` | TEXT | Structured event key (e.g. `downloader.chapter_start`) |
+| `msg` | TEXT | Human-readable message |
+| `fields_json` | TEXT | JSON blob of extra structured fields (redacted) |
+| `run_id` | TEXT | UUID v4 — unique per CLI invocation |
+
+## Decision
+
+The `traces` table is **the only persistent state** scanldr writes to its SQLite database.
+
+Retention is **3 days**, enforced by an eager `DELETE FROM traces WHERE ts < datetime('now', '-3 days')` that runs whenever the trace store is instantiated (i.e., once per CLI invocation).
+
+Each process gets a unique `run_id` (UUID v4) so traces from a single run can be filtered in isolation.
+
+Redaction (cookies, `cf_clearance`, `useragent`, `authorization`) is applied to `fields_json` before insertion.
+
+The trace store is the **structured sink** for the logger. The **terminal sink stays human-readable** — the partial revert introduced in Phase 1 of epic #116 (partially reverting #99).
+
+## Consequences
+
+### Positive
+
+- No "library state" surface to maintain, migrate, or back up.
+- Each run starts from a known baseline; no stale "skip already-downloaded" logic to debug.
+- Traces give support and post-mortem visibility for a recent time window.
+- Bounded disk footprint (3 days of retention).
+
+### Negative
+
+- User cannot answer "what did I download last month?" — the answer is "look at the output directory".
+- Logs that fall outside the 3-day window are gone; reproducing older issues requires the user to have captured logs externally.
+
+### Neutral
+
+- A future `export traces` command (deferred from Phase 1) would let users archive longer windows manually.
+
+## Alternatives Considered
+
+- **Keep `downloads` and `subscriptions`** — rejected. The new walkthrough-centric design removes the library-management surface entirely. See ADR-003 (superseded) and ADR-004 (withdrawn).
+- **Retain logs indefinitely** — rejected. Unbounded disk pressure and PII risk (cookies, clearance tokens in fields).
+- **File-based NDJSON logs instead of SQLite** — rejected. SQLite is already a hard dependency for traces, and queryability (filter by `run_id`, `level`, `event`) matters for support scenarios.

--- a/docs/adr/006-trace-store-as-state-with-ttl.md
+++ b/docs/adr/006-trace-store-as-state-with-ttl.md
@@ -4,8 +4,8 @@
 **Status:** Accepted
 
 **Related:**
-- Supersedes [ADR-003](003-sqlite-download-history.md)
-- Withdraws [ADR-004](004-subscriptions-in-sqlite.md)
+- Supersedes [ADR-003](./003-sqlite-download-history.md)
+- Withdraws [ADR-004](./004-subscriptions-in-sqlite.md)
 - Implements the logging architecture decision captured in epic #116
 
 ## Context
@@ -63,3 +63,13 @@ The trace store is the **structured sink** for the logger. The **terminal sink s
 - **Keep `downloads` and `subscriptions`** — rejected. The new walkthrough-centric design removes the library-management surface entirely. See ADR-003 (superseded) and ADR-004 (withdrawn).
 - **Retain logs indefinitely** — rejected. Unbounded disk pressure and PII risk (cookies, clearance tokens in fields).
 - **File-based NDJSON logs instead of SQLite** — rejected. SQLite is already a hard dependency for traces, and queryability (filter by `run_id`, `level`, `event`) matters for support scenarios.
+
+## Known follow-ups (independent of this ADR)
+
+The following issues capture deferred work that was scoped out of the epic phases but is relevant to the new architecture:
+
+- [#121](https://github.com/malaquiasdev/scanldr/issues/121) — mangadex `feedChapters` pagination.
+- [#122](https://github.com/malaquiasdev/scanldr/issues/122) — mangakakalot synthetic chapter num when source returns null.
+- [#123](https://github.com/malaquiasdev/scanldr/issues/123) — cover injection in volume mode.
+- [#124](https://github.com/malaquiasdev/scanldr/issues/124) — mangadex hardcoded `DEFAULT_CONFIG`.
+- A future `export traces` command (deferred from Phase 1).

--- a/docs/architecture_c4.md
+++ b/docs/architecture_c4.md
@@ -1,20 +1,23 @@
 # Architecture C4: scanldr
 
+> Last updated 2026-05-10 — reflects post-epic #116 state (walkthrough CLI, trace-as-state, no history/subscriptions).
+
 ## 1. Level 1: System Context
 
 ```mermaid
 graph TD
     User[User]
-    CLI[scanldr CLI]
+    CLI[scanldr CLI<br/>bun start]
     MangaDex[MangaDex API<br/>metadata + download]
     Fallback[Fallback Sites<br/>e.g. mangakakalot.gg]
     FS[Local Filesystem<br/>./download/]
+    DB[(scanldr.db<br/>traces only)]
 
-    User -->|runs commands| CLI
+    User -->|runs bun start| CLI
     CLI -->|REST API — metadata + images| MangaDex
     CLI -->|HTTP + cf_clearance — fallback images| Fallback
-    CLI -->|writes .cbz / .zip| FS
-    CLI -->|reads/writes history| DB[(scanldr.db)]
+    CLI -->|writes .cbz| FS
+    CLI -->|writes structured traces| DB
     FS -->|read by comic reader| User
 
     style CLI fill:#438dd5,color:#fff
@@ -34,61 +37,59 @@ graph TD
     User[User]
 
     subgraph scanldr [scanldr CLI]
-        Index[index.ts<br/>Arg parsing / routing]
-        MangaDexClient[sites/mangadex/client.ts<br/>MangaDex API client]
-        MangaDexParser[sites/mangadex/parser.ts<br/>API response mapping]
-        FallbackClient[sites/mangakakalot/client.ts<br/>HttpClient + cookie replay]
-        FallbackParser[sites/mangakakalot/parser.ts<br/>HTML/JSON extraction]
-        AuthService[sites/mangakakalot/auth/service.ts<br/>cURL paste auth — stdin]
-        Downloader[downloader.ts<br/>Image download + packaging]
-        History[history.ts<br/>SQLite download history]
-        AuthFile[($XDG_DATA_HOME/scanldr/auth.json)<br/>Saved Cloudflare session]
+        Index[index.ts<br/>boot: trace store + logger init]
+        Walkthrough[walkthrough/<br/>9-step orchestrator]
+        SourceAdapters[sources/adapters/<br/>MangaDex + Mangakakalot wrappers]
+        MangaDexClient[integrations/mangadex/<br/>MangaDex API client]
+        MangakakalotClient[integrations/mangakakalot/<br/>HTTP + cookie replay]
+        Downloader[modules/downloader/<br/>image fetch + packaging]
+        Pack[pack/<br/>CBZ/ZIP primitives]
+        TraceStore[plugins/trace/<br/>structured sink — 3-day TTL]
+        Logger[plugins/logger/<br/>terminal human sink + trace sink]
+        AuthPath[plugins/auth-path/<br/>parseCurl — session bootstrap]
     end
 
     subgraph External
         MangaDex[MangaDex API]
-        FallbackSite[Fallback Site<br/>mangakakalot.gg]
+        FallbackSite[mangakakalot.gg]
     end
 
-    DB[(scanldr.db<br/>SQLite)]
+    DB[(scanldr.db<br/>traces table)]
     FS[(Local Filesystem<br/>./download/)]
 
-    User -->|CLI args| Index
+    User -->|bun start| Index
+    Index -->|init| TraceStore
+    Index -->|init| Logger
+    Index -->|runWalkthrough| Walkthrough
 
-    Index -->|search + metadata| MangaDexClient
+    Walkthrough -->|source selection + metadata| SourceAdapters
+    SourceAdapters -->|calls| MangaDexClient
+    SourceAdapters -->|calls| MangakakalotClient
     MangaDexClient -->|REST| MangaDex
-    MangaDex -->|JSON| MangaDexParser
-    MangaDexParser -->|VolumeInfo, ChapterRef[]| Index
+    MangakakalotClient -->|HTTP + cookies| FallbackSite
 
-    Index -->|user chose fallback| FallbackClient
-    FallbackClient -->|reads| AuthFile
-    FallbackClient -->|HTTP + cookies| FallbackSite
-    FallbackSite -->|HTML| FallbackParser
-    FallbackParser -->|ChapterRef[]| Index
+    Walkthrough -->|download chapters| Downloader
+    Downloader -->|images| MangaDex
+    Downloader -->|images| FallbackSite
+    Downloader -->|pack primitives| Pack
+    Pack -->|.cbz| FS
 
-    Index -->|auth command| AuthService
-    AuthService -->|verifies session via parsed URL| FallbackSite
-    AuthService -->|atomic write| AuthFile
-
-    Index -->|download chapters| Downloader
-    Downloader -->|images from MangaDex| MangaDex
-    Downloader -->|images from fallback| FallbackSite
-    Downloader -->|.cbz / .zip| FS
-
-    Index -->|check / record| History
-    History -->|read/write| DB
+    Walkthrough -->|auth bootstrap| AuthPath
+    Logger -->|structured rows| TraceStore
+    TraceStore -->|read/write| DB
 
     style scanldr fill:#e1f5fe,stroke:#01579b,stroke-dasharray: 5 5
     style External fill:#f9f9f9,stroke:#333,stroke-dasharray: 5 5
     style Index fill:#438dd5,color:#fff
+    style Walkthrough fill:#438dd5,color:#fff
+    style SourceAdapters fill:#438dd5,color:#fff
     style MangaDexClient fill:#438dd5,color:#fff
-    style MangaDexParser fill:#438dd5,color:#fff
-    style FallbackClient fill:#438dd5,color:#fff
-    style FallbackParser fill:#438dd5,color:#fff
-    style AuthService fill:#438dd5,color:#fff
+    style MangakakalotClient fill:#438dd5,color:#fff
     style Downloader fill:#438dd5,color:#fff
-    style History fill:#438dd5,color:#fff
-    style AuthFile fill:#ff7043,color:#fff
+    style Pack fill:#438dd5,color:#fff
+    style TraceStore fill:#438dd5,color:#fff
+    style Logger fill:#438dd5,color:#fff
+    style AuthPath fill:#438dd5,color:#fff
     style MangaDex fill:#ff6740,color:#fff
     style FallbackSite fill:#757575,color:#fff
     style DB fill:#ff7043,color:#fff
@@ -99,9 +100,10 @@ graph TD
 
 ## 3. Key Architectural Decisions
 
-1. **MangaDex is the primary source** — metadata (volume→chapter mapping) and downloads come from MangaDex first. Fallback sites are only used when the user explicitly chooses them after being shown what MangaDex has available.
-2. **User controls language and source** — the CLI never silently picks a language or falls back to another site. It always presents options and waits for confirmation.
-3. **Auth uses manual cURL paste** — the user solves the Cloudflare challenge in a real browser, then copies the authenticated request via DevTools "Copy as cURL" and pastes it into `scanldr auth`. No headless browser or Playwright is involved. See `docs/auth-manual.md`.
-4. **Download history is decoupled from output files** — SQLite records what was downloaded. The user can freely delete `.cbz` files without the CLI re-downloading them.
-5. **One `.cbz` per volume** — chapters within a volume are merged into a single archive, matching how the user reads (complete volumes, not weekly chapters).
-6. **Parser is site-specific** — each source has its own module under `src/sites/`, keeping the core downloader generic.
+1. **Single one-shot walkthrough** — `bun start` runs a fixed 9-step orchestrator (`src/walkthrough/`). There are no sub-commands (`download`, `list`, `sync`, `update`, etc.) — those were removed in epic #116.
+2. **MangaDex is the primary source** — metadata (volume→chapter mapping) and downloads come from MangaDex first. Fallback sites are only used when the user explicitly chooses them.
+3. **User controls language and source** — the CLI never silently picks a language or falls back to another site. It always presents options and waits for confirmation.
+4. **Auth uses manual cURL paste** — the user solves the Cloudflare challenge in a real browser, then copies the authenticated request via DevTools "Copy as cURL" and pastes it into the walkthrough prompt. No headless browser. See `docs/auth-manual.md` and `src/plugins/auth-path/`.
+5. **Trace store is the only persistent state** — the `traces` table in `scanldr.db` is the single write path for the logger's structured sink. Retention is 3 days. No download history. No subscriptions. See ADR-006.
+6. **One `.cbz` per volume** — chapters within a volume are merged into a single archive via `src/pack/`, matching how the user reads (complete volumes, not weekly chapters).
+7. **Parser is site-specific** — each source has its own integration client under `src/integrations/`, surfaced through source adapters in `src/sources/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -4,10 +4,13 @@
 
 ```
 src/
-├── index.ts            # CLI entrypoint
-├── plugins/            # Infrastructure: config/, logger/, db/, errors/, guards/
+├── index.ts            # CLI entrypoint — trace store + logger init → runWalkthrough
+├── walkthrough/        # Orchestrates the 9-step one-shot download walkthrough
+├── sources/            # Source adapter layer (mangadex, mangakakalot wrappers)
+├── pack/               # CBZ/ZIP packaging primitives
+├── plugins/            # Infrastructure: config/, logger/, db/, errors/, guards/, trace/
 ├── modules/            # Business logic: downloader/
-└── integrations/       # External clients: mangadex/, mangakakalot/
+└── integrations/       # External site clients: mangadex/, mangakakalot/
 migrations/             # Versioned SQL migrations (applied in lexicographic order)
 ```
 


### PR DESCRIPTION
## What this PR does

- Adds **ADR-006** — _Trace store as state, with TTL retention_ — documenting that the `traces` table is the only persistent SQLite state scanldr writes, with a 3-day TTL enforced on each boot.
- Marks **ADR-003** (_SQLite for Download History_) as **Superseded by ADR-006** on 2026-05-10.
- Marks **ADR-004** (_Subscriptions Stored in SQLite_) as **Withdrawn** on 2026-05-10 — subscriptions were decommissioned in Phase 4.
- Syncs `docs/conventions.md`, `docs/SUMMARY.md`, and `docs/architecture_c4.md` with the post-epic #116 reality (walkthrough CLI, trace-as-state, no history/subscriptions).

## Why it exists

Refs: #116

Phase 5 — the final phase of epic #116 — closes the architectural work by aligning ADRs and docs with the new reality established across Phases 1–4:
- Single one-shot walkthrough (`bun start`).
- No `downloads` or `subscriptions` tables.
- `traces` table as the sole persistent state (3-day TTL).

## How it works internally

| ADR | Before | After |
|-----|--------|-------|
| ADR-003 | Accepted | Superseded by ADR-006 |
| ADR-004 | Accepted | Withdrawn |
| ADR-006 | (new) | Accepted |

ADR-006 documents:
- `traces` as sole persistent state.
- 3-day retention via eager DELETE on trace store instantiation.
- `run_id` (UUID v4) per CLI invocation.
- Redaction of cookies/clearance tokens from `fields_json`.
- Terminal sink stays human-readable; trace store is the structured sink.

`architecture_c4.md` was updated with new mermaid diagrams reflecting the walkthrough-centric topology (removed History, added TraceStore, Pack, SourceAdapters, AuthPath).

## What did not change

- No `src/` files touched.
- No migrations touched.
- ADR-001, ADR-002 (both files), and `002-manual-cookie-paste.md` are untouched.
- The duplicate `002` numbering is intentionally left alone per user decision.
- Test count unchanged (383 pass).

## Test checklist

- [x] `bun test` — 383 pass, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] `bun run check` (biome) — 0 fixes, exit 0

## Reviewer notes

- The existing duplicate ADR-002 numbering (`002-mangadex-primary-source.md` and `002-manual-cookie-paste.md`) is left deliberately untouched — the user made this call explicitly.
- `architecture_c4.md` is a full rewrite of the diagrams; the old diagrams referenced modules (`sites/`, `history.ts`) that no longer exist.
- Historical flow docs (`flows/`, `models/`) are preserved on disk and linked as historical record in SUMMARY.md — no files deleted.

## Closes

Refs: #116