### PR TITLE
docs(readme): rewrite for post-epic-#116 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
-<p align="center">
-  <img src="assets/banner.svg" alt="scanldr" width="800"/>
-</p>
+# scanldr
 
-A command-line tool to download manga from MangaDex and Mangakakalot, packaged as CBZ archives.
+Single-walkthrough CLI to download manga from MangaDex and Mangakakalot, packaged as CBZ archives.
 
 ## Features
 
-- Download manga volumes as `.cbz` files
-- Parallel image downloads with configurable concurrency
-- Rate-limit handling with exponential backoff
-- Cloudflare bypass via cookie replay (one-time interactive auth)
-- Download history tracked in SQLite
-- Subscription management (watch/unwatch series)
-- Structured JSON logs for log shippers
+- Single interactive walkthrough — `bun start [title]`.
+- Two sources: MangaDex (no auth) and Mangakakalot (cURL paste for Cloudflare bypass).
+- Visual pickers for source, search results, mode (chapter/volume), and range — no flag-based syntax.
+- Optional packing of selected chapters into a single CBZ with optional cover injection.
+- Structured 3-day trace store in SQLite for debug/post-mortem.
+- Human-readable terminal output by default; `--json` flag for structured stderr.
 
 ## Requirements
 
-- [Bun](https://bun.sh) v1.3 or later
+- [Bun](https://bun.sh) v1.x or later
 
 ## Installation
 
@@ -24,82 +21,111 @@ A command-line tool to download manga from MangaDex and Mangakakalot, packaged a
 git clone https://github.com/malaquiasdev/scanldr.git
 cd scanldr
 bun install
-bun link
 ```
 
 ## Usage
 
+There are no subcommands. Everything is a prompt.
+
 ```bash
-scanldr help
+bun start                  # interactive walkthrough
+bun start "Naruto"         # walkthrough with title pre-filled
+bun start --help           # show usage
+bun start --version        # show version
 ```
 
-```
-Commands:
-  auth                           Open browser for Cloudflare bypass, save session
-  list <manga>                   List volumes, chapters, languages, groups
-  download <manga> --volume <n>  Download volumes (e.g. 1, 1-5, 1,3,7)
-  download <manga> --chapter <n> Download chapters (same range syntax)
-  update <manga>                 Download what is missing in history
-  sync                           Run update for every active subscription
-  watch <manga>                  Add to subscription list
-  unwatch <manga>                Remove from subscription list (history kept)
-  watchlist [--paused]           List subscriptions
-  pause <manga>                  Skip a subscription on sync
-  resume <manga>                 Re-enable a paused subscription
-  import <file>                  Bootstrap subscriptions from a flat-text list
-  export [--out <file>]          Dump active subscriptions as plain text
-  history [--manga <m>]          Display download history
-```
+### Walkthrough steps
+
+1. **Title prompt** — free-text input; pre-filled if a positional argument was passed.
+2. **Source picker** — choose MangaDex or Mangakakalot.
+3. **Auth check** — if the chosen source requires auth and no valid session exists, prompts for a cURL paste; silently skipped for MangaDex.
+4. **Search results** — visual numbered picker, single select.
+5. **Mode picker** — Chapter or Volume.
+6. **Range picker** — visual multi-select list of available chapters or volumes; no range-string parser.
+7. **Pack prompt** (chapter mode only) — "Group these chapters into a single volume? [Y/n]".
+8. **Cover URL** (when packing) — optional; press Enter to skip.
+9. **Execute** — download images, pack into `.cbz`, write to output directory.
+
+### How to capture a cURL (Mangakakalot)
+
+Mangakakalot is protected by Cloudflare. The walkthrough asks you to paste a cURL command from a real browser session:
+
+1. Open the target manga page in your browser.
+2. Open DevTools (F12) and go to the **Network** tab.
+3. Reload the page.
+4. Right-click any request to `mangakakalot.gg` and choose **Copy as cURL**.
+5. Paste the copied command into the walkthrough prompt.
+
+The `cf_clearance` cookie extracted from the cURL is persisted to `~/.local/share/scanldr/auth.json` for the session.
 
 ## Configuration
 
-Create a `scanldr.json` in your project directory (or `~/.config/scanldr/scanldr.json` for global config):
+Create a `scanldr.json` in your project directory (or in `~/.config/scanldr/scanldr.json` for a global config):
 
 ```json
 {
-  "preferred_languages": ["en"],
-  "download_quality": "data",
-  "default_format": "cbz",
-  "default_out": "./downloads",
-  "image_concurrency": 4,
-  "chapter_delay_ms": 500
+  "db_path": "/custom/path/to/scanldr.db"
 }
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `preferred_languages` | `["en"]` | BCP 47 language tags in priority order |
-| `download_quality` | `"data"` | `"data"` or `"data-saver"` |
-| `default_format` | `"cbz"` | `"cbz"` or `"zip"` |
-| `default_out` | `"./downloads"` | Output directory |
-| `image_concurrency` | `4` | Max parallel image downloads |
-| `chapter_delay_ms` | `500` | Delay between chapters (ms) |
+**Discovery order** (first match wins):
+
+1. `--config <path>` flag.
+2. `$SCANLDR_CONFIG` environment variable.
+3. `./scanldr.json` in the current working directory.
+4. `$XDG_CONFIG_HOME/scanldr/scanldr.json` (falls back to `~/.config/scanldr/scanldr.json`).
+
+**Config keys consumed by production code:**
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `db_path` | `~/.local/share/scanldr/scanldr.db` | Path to the SQLite database file |
+
+All other keys in `DEFAULT_CONFIG` (`preferred_languages`, `download_quality`, `default_format`, `default_out`, `image_concurrency`, `chapter_delay_ms`) are validated and parsed but not read by the walkthrough code path. See [#124](https://github.com/malaquiasdev/scanldr/issues/124).
 
 ## Logging
 
+The logger has two sinks:
+
+- **Terminal** — human-readable output (`${ts} ${level} ${msg}\n`). This is the default.
+- **Trace store** — structured rows written to the `traces` table in SQLite, with 3-day TTL and automatic redaction of cookies and auth tokens.
+
 ```bash
-# Default (info level, human format)
-scanldr list <slug>
-
-# Quiet (warn + error only)
-scanldr download --volume 1 <slug> --quiet
-
-# JSON output (for log shippers)
-scanldr download --volume 1 <slug> --json
+bun start          # human-readable terminal output (default)
+bun start --json   # JSON output to stderr (for log shippers)
+bun start --human  # no-op alias for back-compat
+bun start -q       # suppress info logs (warn + error only)
 ```
+
+The trace store is located at `<db_path>` (default: `~/.local/share/scanldr/scanldr.db`), table `traces`. Each run gets a unique `run_id` (UUID v4) for filtering.
 
 ## Development
 
 ```bash
-# Run tests
 bun test
-
-# Type check
 bun run typecheck
-
-# Lint
 bun run check
 ```
+
+Dev loop with file watching:
+
+```bash
+bun --watch run src/index.ts
+```
+
+## Architecture / Documentation
+
+- [`docs/adr/006-trace-store-as-state-with-ttl.md`](docs/adr/006-trace-store-as-state-with-ttl.md) — current state architecture decision (supersedes ADR-003, withdraws ADR-004).
+- [`docs/architecture_c4.md`](docs/architecture_c4.md) — C4 diagrams.
+- [`docs/conventions.md`](docs/conventions.md) — code conventions.
+- [`docs/adr/`](docs/adr/) — full ADR history.
+
+## Known limitations
+
+- [#121](https://github.com/malaquiasdev/scanldr/issues/121) — long MangaDex series (>500 chapters) silently truncated.
+- [#122](https://github.com/malaquiasdev/scanldr/issues/122) — Mangakakalot synthetic chapter number when source returns null.
+- [#123](https://github.com/malaquiasdev/scanldr/issues/123) — cover injection in volume mode silently skipped.
+- [#124](https://github.com/malaquiasdev/scanldr/issues/124) — MangaDex adapter hardcodes language/quality, ignores user config.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ bun start --version        # show version
 
 ### Walkthrough steps
 
-1. **Title prompt** — free-text input; pre-filled if a positional argument was passed.
+1. **Title prompt** — free-text input ("Manga title or URL:"); pre-filled if a positional argument was passed.
 2. **Source picker** — choose MangaDex or Mangakakalot.
 3. **Auth check** — if the chosen source requires auth and no valid session exists, prompts for a cURL paste; silently skipped for MangaDex.
 4. **Search results** — visual numbered picker, single select.
 5. **Mode picker** — Chapter or Volume.
 6. **Range picker** — visual multi-select list of available chapters or volumes; no range-string parser.
-7. **Pack prompt** (chapter mode only) — "Group these chapters into a single volume? [Y/n]".
+7. **Pack prompt** (chapter mode only; volume mode always packs) — "Group these chapters into a single volume? [Y/n]".
 8. **Cover URL** (when packing) — optional; press Enter to skip.
 9. **Execute** — download images, pack into `.cbz`, write to output directory.
 
@@ -88,7 +88,7 @@ All other keys in `DEFAULT_CONFIG` (`preferred_languages`, `download_quality`, `
 The logger has two sinks:
 
 - **Terminal** — human-readable output (`${ts} ${level} ${msg}\n`). This is the default.
-- **Trace store** — structured rows written to the `traces` table in SQLite, with 3-day TTL and automatic redaction of cookies and auth tokens.
+- **Trace store** — structured rows written to the `traces` table in SQLite, with 3-day TTL; `cookies`, `cf_clearance`, `useragent`, and `authorization` fields are redacted to `[REDACTED]` before being written.
 
 ```bash
 bun start          # human-readable terminal output (default)


### PR DESCRIPTION
## What this PR does

Rewrites `README.md` end-to-end to reflect the post-epic-#116 state of scanldr: single interactive walkthrough, trace-store logging, no subcommands, no library management.

## Why it exists

The existing README described an entirely different CLI (12 subcommands, subscriptions, watchlists, `scanldr help`) that was decommissioned in epic #116. A developer opening the repo cold would have no accurate reference.

Closes #113.

## How it works internally

Docs-only. No `src/` files touched.

## What did not change

All source code, migrations, ADRs, and other docs are unchanged.

## Test checklist

- [x] `bun test` — 383 pass / 0 fail
- [x] `bun run typecheck` — exit 0
- [x] `bun run check` — exit 0

## Reviewer notes

**Vestigial config keys** — the following keys are present in `DEFAULT_CONFIG` and are validated/parsed by `src/plugins/config/index.ts`, but are **not consumed** by the walkthrough code path. They were omitted from the README config table (only `db_path` is documented as active):

- `preferred_languages` — loaded by config, but `src/sources/adapters/mangadex.ts` hardcodes `["en"]` internally. Tracked by #124.
- `download_quality` — same situation; adapter hardcodes `"data"`. Tracked by #124.
- `default_format` — adapter hardcodes `"cbz"`. Tracked by #124.
- `default_out` — adapter hardcodes `"."`. Tracked by #124.
- `image_concurrency` — adapter hardcodes `4`. Tracked by #124.
- `chapter_delay_ms` — consumed in `src/integrations/mangadex/http/index.ts`, but the value comes from the adapter's own internal `DEFAULT_CONFIG` (500 ms hardcoded), not the user's `loadConfig()`. Tracked by #124.

## Closes

Closes #113