### PR TITLE
docs(readme): restore banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/banner.svg" alt="scanldr" width="800"/>
+</p>
+
 # scanldr
 
 Single-walkthrough CLI to download manga from MangaDex and Mangakakalot, packaged as CBZ archives.


### PR DESCRIPTION
The banner block (`<p align="center"><img src="assets/banner.svg" .../></p>`) was dropped during the post-epic-116 README rewrite in PR #126. The asset `assets/banner.svg` was never deleted; this commit simply re-attaches the block at the top of `README.md`, before the `# scanldr` heading.