### PR TITLE
feat(walkthrough): probe session and auto-refresh on Cloudflare rejection

### DIFF
--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -59,7 +59,7 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
   } catch {
     logger.warn(
       { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "corrupt" },
-      `auth session at ${path} is corrupt; re-run scanldr auth`,
+      `auth session at ${path} is corrupt; the walkthrough will re-prompt for a fresh paste`,
     );
     throw new MissingAuthError(path);
   }

--- a/src/integrations/fallback-http/types.ts
+++ b/src/integrations/fallback-http/types.ts
@@ -1,5 +1,6 @@
 // Types and error classes for the fallback HTTP client.
 // Per ADR-001: replays all captured cookies + UA on every request.
+// The walkthrough auth-check step handles capturing and refreshing the session.
 
 import type { Logger } from "@plugins/logger/index.ts";
 
@@ -9,7 +10,9 @@ export type FetchFn = (url: string | URL | Request, init?: RequestInit) => Promi
 export class MissingAuthError extends Error {
   override readonly name = "MissingAuthError";
   constructor(public readonly path: string) {
-    super(`Auth session not found at ${path}. Run \`scanldr auth\` to capture one.`);
+    super(
+      `Auth session not found at ${path}. Run \`bun start\` to capture one through the interactive walkthrough.`,
+    );
   }
 }
 
@@ -17,13 +20,13 @@ export class CloudflareError extends Error {
   override readonly name = "CloudflareError";
   constructor(public readonly url: string) {
     super(
-      `Cloudflare rejected the request to ${url}. Run \`scanldr auth\` to refresh the session.`,
+      `Cloudflare rejected the request to ${url}. The session has likely expired; the walkthrough will prompt for a fresh cURL paste.`,
     );
   }
 }
 
 export interface FallbackHttpOptions {
-  /** Path to auth.json. If omitted, resolves via the same XDG logic used by `scanldr auth`. */
+  /** Path to auth.json. If omitted, resolves via the same XDG logic used by the walkthrough auth-check step. */
   authPath?: string;
   logger: Logger;
   /** Override fetch for testing. Defaults to globalThis.fetch. */

--- a/src/walkthrough/index.ts
+++ b/src/walkthrough/index.ts
@@ -1,3 +1,4 @@
+import { createFallbackHttp } from "../integrations/fallback-http/index.ts";
 import type { Logger } from "../plugins/logger/index.ts";
 import type { SourceAdapter } from "../sources/adapters/index.ts";
 import { getAdapter } from "../sources/adapters/index.ts";
@@ -11,10 +12,20 @@ import { pickRange } from "./steps/range-picker.ts";
 import { pickSearchResult } from "./steps/search-results-picker.ts";
 import { pickSource } from "./steps/source-picker.ts";
 import { promptTitle } from "./steps/title-prompt.ts";
-import type { WalkthroughCancelled, WalkthroughInput, WalkthroughResult } from "./types.ts";
+import type {
+  SessionProbeClientFactory,
+  WalkthroughCancelled,
+  WalkthroughInput,
+  WalkthroughResult,
+} from "./types.ts";
 import { WalkthroughError } from "./types.ts";
 
-export type { WalkthroughCancelled, WalkthroughInput, WalkthroughResult } from "./types.ts";
+export type {
+  WalkthroughCancelled,
+  WalkthroughInput,
+  WalkthroughResult,
+  SessionProbeClientFactory,
+} from "./types.ts";
 export { WalkthroughError } from "./types.ts";
 
 export interface RunWalkthroughOptions extends WalkthroughInput {
@@ -25,6 +36,12 @@ export interface RunWalkthroughOptions extends WalkthroughInput {
   adapterFactory?: (sourceId: string, opts: { logger: Logger }) => SourceAdapter;
   /** Override downloader/packer deps (tests inject fakes). */
   executeDeps?: ExecuteDeps;
+  /**
+   * Override the session probe client factory (tests inject fakes).
+   * Production default: real fallback-http client created lazily after auth.json is written.
+   * Pass null to disable probing (file-presence check only).
+   */
+  probeClientFactory?: SessionProbeClientFactory | null;
 }
 
 /** Returned when walkthrough errors out in a handled way (WalkthroughError). */
@@ -52,8 +69,21 @@ export async function runWalkthrough(
     // Step 2 — source
     const source = await pickSource();
 
-    // Step 3 — auth check
-    await checkAuth({ requiresAuth: source.requiresAuth, logger: opts.logger });
+    // Step 3 — auth check (probe session when factory provided; production uses real fallback-http)
+    const probeClientFactory: SessionProbeClientFactory | undefined =
+      opts.probeClientFactory === null
+        ? undefined
+        : (opts.probeClientFactory ??
+          ((): SessionProbeClientFactory => {
+            // Default production factory: create a new fallback-http client each call so it
+            // reads the auth.json that was just written by the paste prompt.
+            return () => createFallbackHttp({ logger: opts.logger });
+          })());
+    await checkAuth({
+      requiresAuth: source.requiresAuth,
+      logger: opts.logger,
+      probeClientFactory,
+    });
 
     // Resolve adapter for this source (after auth check so session is persisted if needed)
     const adapter = resolveAdapter(source.id, { logger: opts.logger });

--- a/src/walkthrough/steps/auth-check.test.ts
+++ b/src/walkthrough/steps/auth-check.test.ts
@@ -1,11 +1,57 @@
 import { describe, expect, mock, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../../plugins/logger/index.ts";
+import type { SessionProbeClient, SessionProbeClientFactory } from "../types.ts";
 
 const noop = () => {};
 const logger = createLogger({ level: "info", format: "human", write: noop });
+
+/** Build a fake probe client from a sequence of response factories. */
+function fakeProbeSequence(responses: Array<() => Promise<Response>>): SessionProbeClientFactory {
+  let idx = 0;
+  const client: SessionProbeClient = {
+    get: async (_url: string) => {
+      const factory = responses[idx++];
+      if (!factory) throw new Error("fakeProbeSequence exhausted");
+      return factory();
+    },
+  };
+  return async () => client;
+}
+
+/** 200 with real-looking HTML — session is valid. */
+function okResponse(): Promise<Response> {
+  return Promise.resolve(
+    new Response("<html><body>Manga list</body></html>", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    }),
+  );
+}
+
+/** 403 — triggers CloudflareError in the probe. */
+function cfRejectionResponse(): Promise<Response> {
+  // The probe client's get() throws CloudflareError on 403, but our fake returns the
+  // response directly (the real service.ts interprets 403 and throws).
+  // We simulate the service behavior: throw a CloudflareError-like error.
+  const err = Object.assign(new Error("Cloudflare rejected"), { name: "CloudflareError" });
+  return Promise.reject(err);
+}
+
+/** 500 response. */
+function serverErrorResponse(): Promise<Response> {
+  return Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+}
+
+/** Network error (connection refused). */
+function networkError(): Promise<Response> {
+  return Promise.reject(new Error("connect ECONNREFUSED 127.0.0.1:80"));
+}
+
+/** Valid cURL paste string. */
+const VALID_CURL = "curl 'https://example.com' -H 'Cookie: cf_clearance=abc; session=xyz'";
 
 describe("checkAuth", () => {
   test("requiresAuth: false → returns { ok: true, skipped: true } without prompting", async () => {
@@ -26,7 +72,7 @@ describe("checkAuth", () => {
     expect(promptCalled).toBe(false);
   });
 
-  test("requiresAuth: true with existing valid auth → returns { ok: true, skipped: false } without prompting", async () => {
+  test("requiresAuth: true with existing valid auth → returns { ok: true, skipped: false } without prompting (no probe)", async () => {
     const dir = join(tmpdir(), `scanldr-test-${Date.now()}`);
     const authDir = join(dir, "scanldr");
     mkdirSync(authDir, { recursive: true });
@@ -53,7 +99,7 @@ describe("checkAuth", () => {
   test("requiresAuth: true, no auth file, valid cURL paste → returns { ok: true, skipped: false, justAuthenticated: true }", async () => {
     const tmpDir = join(tmpdir(), `scanldr-auth-test-${Date.now()}`);
     mock.module("../prompts.ts", () => ({
-      editor: async () => "curl 'https://example.com' -H 'Cookie: cf_clearance=abc; session=xyz'",
+      editor: async () => VALID_CURL,
       input: async () => "",
       select: async () => "",
       checkbox: async () => [],
@@ -85,5 +131,189 @@ describe("checkAuth", () => {
       checkAuth({ requiresAuth: true, logger, dataHome: "/nonexistent/path" }),
     ).rejects.toThrow(/attempt/i);
     expect(callCount).toBe(2);
+  });
+
+  // --- Probe tests ---
+
+  test("probe success: valid session → returns { ok: true, skipped: false }; NO cURL prompt shown", async () => {
+    const dir = join(tmpdir(), `scanldr-probe-ok-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(
+      join(authDir, "auth.json"),
+      JSON.stringify({ cookies: { cf_clearance: "x" }, userAgent: "ua", savedAt: Date.now() }),
+    );
+
+    let promptCalled = false;
+    mock.module("../prompts.ts", () => ({
+      editor: async () => {
+        promptCalled = true;
+        return "";
+      },
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const { checkAuth } = await import("./auth-check.ts");
+    const result = await checkAuth({
+      requiresAuth: true,
+      logger,
+      dataHome: dir,
+      probeClientFactory: fakeProbeSequence([okResponse]),
+    });
+
+    expect(result).toEqual({ ok: true, skipped: false });
+    expect(promptCalled).toBe(false);
+  });
+
+  test("probe stale → re-prompt → persist → re-probe ok → returns { ok: true, refreshed: true }", async () => {
+    const dir = join(tmpdir(), `scanldr-probe-stale-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    const authJsonPath = join(authDir, "auth.json");
+    writeFileSync(
+      authJsonPath,
+      JSON.stringify({ cookies: { cf_clearance: "old" }, userAgent: "ua", savedAt: Date.now() }),
+    );
+
+    let promptCount = 0;
+    mock.module("../prompts.ts", () => ({
+      editor: async () => {
+        promptCount++;
+        return VALID_CURL;
+      },
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    // First probe: CF rejection. Second probe (after paste): ok.
+    const probeClientFactory = fakeProbeSequence([cfRejectionResponse, okResponse]);
+
+    const { checkAuth } = await import("./auth-check.ts");
+    const result = await checkAuth({
+      requiresAuth: true,
+      logger,
+      dataHome: dir,
+      probeClientFactory,
+    });
+
+    expect(result).toEqual({ ok: true, skipped: false, refreshed: true });
+    expect(promptCount).toBe(1);
+    // auth.json was deleted then re-written — must still exist with new content
+    expect(existsSync(authJsonPath)).toBe(true);
+    const written = JSON.parse(readFileSync(authJsonPath, "utf-8")) as {
+      cookies: Record<string, string>;
+    };
+    expect(written.cookies).toHaveProperty("cf_clearance", "abc");
+  });
+
+  test("probe stale → re-prompt → re-probe stale again → throws WalkthroughError", async () => {
+    const dir = join(tmpdir(), `scanldr-probe-stale-twice-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(
+      join(authDir, "auth.json"),
+      JSON.stringify({ cookies: { cf_clearance: "old" }, userAgent: "ua", savedAt: Date.now() }),
+    );
+
+    mock.module("../prompts.ts", () => ({
+      editor: async () => VALID_CURL,
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const probeClientFactory = fakeProbeSequence([cfRejectionResponse, cfRejectionResponse]);
+
+    const { checkAuth } = await import("./auth-check.ts");
+    await expect(
+      checkAuth({ requiresAuth: true, logger, dataHome: dir, probeClientFactory }),
+    ).rejects.toThrow(/Session refresh failed twice/);
+  });
+
+  test("probe network error → throws WalkthroughError; auth.json is NOT deleted", async () => {
+    const dir = join(tmpdir(), `scanldr-probe-net-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    const authJsonPath = join(authDir, "auth.json");
+    writeFileSync(
+      authJsonPath,
+      JSON.stringify({ cookies: { cf_clearance: "x" }, userAgent: "ua", savedAt: Date.now() }),
+    );
+
+    mock.module("../prompts.ts", () => ({
+      editor: async () => VALID_CURL,
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const probeClientFactory = fakeProbeSequence([networkError]);
+
+    const { checkAuth } = await import("./auth-check.ts");
+    await expect(
+      checkAuth({ requiresAuth: true, logger, dataHome: dir, probeClientFactory }),
+    ).rejects.toThrow(/Could not reach Mangakakalot/);
+
+    // auth.json must still be intact
+    expect(existsSync(authJsonPath)).toBe(true);
+  });
+
+  test("probe 5xx → throws WalkthroughError; auth.json is NOT deleted", async () => {
+    const dir = join(tmpdir(), `scanldr-probe-5xx-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    const authJsonPath = join(authDir, "auth.json");
+    writeFileSync(
+      authJsonPath,
+      JSON.stringify({ cookies: { cf_clearance: "x" }, userAgent: "ua", savedAt: Date.now() }),
+    );
+
+    mock.module("../prompts.ts", () => ({
+      editor: async () => VALID_CURL,
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const probeClientFactory = fakeProbeSequence([serverErrorResponse]);
+
+    const { checkAuth } = await import("./auth-check.ts");
+    await expect(
+      checkAuth({ requiresAuth: true, logger, dataHome: dir, probeClientFactory }),
+    ).rejects.toThrow(/unexpected status \(500\)/);
+
+    expect(existsSync(authJsonPath)).toBe(true);
+  });
+
+  test("first-run (no auth.json): paste → persist → probe ok → returns { ok: true, justAuthenticated: true }", async () => {
+    const dir = join(tmpdir(), `scanldr-fresh-probe-${Date.now()}`);
+
+    mock.module("../prompts.ts", () => ({
+      editor: async () => VALID_CURL,
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    const probeClientFactory = fakeProbeSequence([okResponse]);
+
+    const { checkAuth } = await import("./auth-check.ts");
+    const result = await checkAuth({
+      requiresAuth: true,
+      logger,
+      dataHome: dir,
+      probeClientFactory,
+    });
+
+    expect(result).toEqual({ ok: true, skipped: false, justAuthenticated: true });
   });
 });

--- a/src/walkthrough/steps/auth-check.ts
+++ b/src/walkthrough/steps/auth-check.ts
@@ -1,12 +1,12 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { parseCurl } from "../../integrations/mangakakalot/auth/curl-parser.ts";
 import type { AuthSession } from "../../integrations/mangakakalot/auth/types.ts";
 import { resolveAuthPath } from "../../plugins/auth-path/index.ts";
 import type { Logger } from "../../plugins/logger/index.ts";
 import { editor } from "../prompts.ts";
-import type { AuthResult } from "../types.ts";
+import type { AuthResult, SessionProbeClient, SessionProbeClientFactory } from "../types.ts";
 import { WalkthroughError } from "../types.ts";
 
 export interface AuthCheckOptions {
@@ -14,9 +14,19 @@ export interface AuthCheckOptions {
   logger: Logger;
   /** Injected in tests to override the default XDG auth path. */
   dataHome?: string;
+  /**
+   * Factory that creates the probe client on demand (after auth.json is written).
+   * When omitted, no network probe is performed (file-presence check only).
+   * Injected in tests; production callers provide via runWalkthrough options.
+   */
+  probeClientFactory?: SessionProbeClientFactory;
 }
 
 const MAX_PASTE_RETRIES = 2;
+/** Probe target: mangakakalot homepage — cheaper and less noisy than search URLs. */
+const PROBE_URL = "https://www.mangakakalot.gg/";
+/** Probe timeout in ms. */
+const PROBE_TIMEOUT_MS = 5000;
 
 function isValidAuthFile(path: string): boolean {
   if (!existsSync(path)) return false;
@@ -38,7 +48,6 @@ async function persistSession(session: AuthSession, authPath: string): Promise<v
     await rename(tmpPath, authPath);
   } catch (renameErr) {
     try {
-      const { unlink } = await import("node:fs/promises");
       await unlink(tmpPath);
     } catch {
       // best-effort cleanup — ignore unlink errors
@@ -47,19 +56,99 @@ async function persistSession(session: AuthSession, authPath: string): Promise<v
   }
 }
 
-/** Step 3: check auth state. Prompt for cURL paste when needed and persist via auth service. */
-export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
-  if (!opts.requiresAuth) {
-    return { ok: true, skipped: true };
+type ProbeOutcome =
+  | { kind: "ok" }
+  | { kind: "stale" }
+  | { kind: "network_error"; message: string }
+  | { kind: "transient_error"; status: number };
+
+/**
+ * Probes the session against PROBE_URL with a 5s timeout.
+ * Treats 403/503 with Cloudflare markers, and 200 with CF challenge HTML, as stale.
+ */
+async function probeSession(client: SessionProbeClient, logger: Logger): Promise<ProbeOutcome> {
+  logger.info(
+    { event: "walkthrough.auth_probe_start", context: "walkthrough", url: PROBE_URL },
+    "probing session against source",
+  );
+
+  let res: Response;
+  try {
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("probe timeout")), PROBE_TIMEOUT_MS),
+    );
+    res = await Promise.race([client.get(PROBE_URL), timeout]);
+  } catch (err) {
+    // CloudflareError is thrown by the client on 403 — treat as stale
+    if (err instanceof Error && err.name === "CloudflareError") {
+      logger.warn(
+        { event: "walkthrough.auth_probe_stale", context: "walkthrough", url: PROBE_URL },
+        "session probe: Cloudflare rejected the request — session is stale",
+      );
+      return { kind: "stale" };
+    }
+    const message =
+      err instanceof Error ? err.message : "unknown network error during session probe";
+    logger.warn(
+      {
+        event: "walkthrough.auth_probe_network_error",
+        context: "walkthrough",
+        url: PROBE_URL,
+        message,
+      },
+      "session probe: network error",
+    );
+    return { kind: "network_error", message };
   }
 
-  const authPath = resolveAuthPath({ dataHome: opts.dataHome });
-
-  if (isValidAuthFile(authPath)) {
-    return { ok: true, skipped: false };
+  // 5xx: transient
+  if (res.status >= 500) {
+    return { kind: "transient_error", status: res.status };
   }
 
-  // No valid session — prompt for cURL paste
+  // 4xx other than 403 (403 is thrown by client as CloudflareError above): transient
+  if (res.status >= 400) {
+    return { kind: "transient_error", status: res.status };
+  }
+
+  // 2xx — check body for CF challenge HTML
+  if (res.status >= 200 && res.status < 300) {
+    try {
+      const text = await res.text();
+      // Cloudflare challenge pages always include these markers
+      if (
+        text.includes("cf-browser-verification") ||
+        text.includes("challenge-platform") ||
+        text.includes("cdn-cgi/challenge-platform") ||
+        text.includes("jschl-answer") ||
+        (text.includes("cloudflare") && text.includes("cf_clearance") && text.length < 20000)
+      ) {
+        logger.warn(
+          { event: "walkthrough.auth_probe_stale", context: "walkthrough", url: PROBE_URL },
+          "session probe: CF challenge in 200 body — session is stale",
+        );
+        return { kind: "stale" };
+      }
+    } catch {
+      // If we can't read the body, assume ok (server responded with real content)
+    }
+    logger.info(
+      { event: "walkthrough.auth_probe_ok", context: "walkthrough", url: PROBE_URL },
+      "session probe: session is valid",
+    );
+    return { kind: "ok" };
+  }
+
+  // 3xx redirects — treat as ok (client follows redirects or server is live)
+  logger.info(
+    { event: "walkthrough.auth_probe_ok", context: "walkthrough", url: PROBE_URL },
+    "session probe: session is valid",
+  );
+  return { kind: "ok" };
+}
+
+/** Prompt cURL paste loop — returns a parsed AuthSession or throws WalkthroughError. */
+async function promptAndParseSession(logger: Logger): Promise<AuthSession> {
   for (let attempt = 0; attempt < MAX_PASTE_RETRIES; attempt++) {
     const paste = await editor({
       message: "No valid session found. Paste a cURL command with cookie headers (opens editor):",
@@ -73,22 +162,16 @@ export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
     }
 
     if (parsed !== null && Object.keys(parsed.cookies).length > 0) {
-      const session: AuthSession = {
+      return {
         cookies: parsed.cookies,
         userAgent: parsed.userAgent ?? "",
         savedAt: Date.now(),
       };
-      await persistSession(session, authPath);
-      opts.logger.info(
-        { event: "walkthrough.auth_persisted", context: "walkthrough", path: authPath },
-        "auth session saved",
-      );
-      return { ok: true, skipped: false, justAuthenticated: true };
     }
 
     const remaining = MAX_PASTE_RETRIES - attempt - 1;
     if (remaining > 0) {
-      opts.logger.warn(
+      logger.warn(
         {
           event: "walkthrough.auth_paste_invalid",
           context: "walkthrough",
@@ -102,5 +185,103 @@ export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
 
   throw new WalkthroughError(
     `Could not parse cURL paste after ${MAX_PASTE_RETRIES} attempts. Run the walkthrough again.`,
+  );
+}
+
+/** Step 3: check auth state. Prompt for cURL paste when needed and persist via auth service. */
+export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
+  if (!opts.requiresAuth) {
+    return { ok: true, skipped: true };
+  }
+
+  const authPath = resolveAuthPath({ dataHome: opts.dataHome });
+
+  // No probe factory provided — file-presence-only check (no network validation).
+  if (!opts.probeClientFactory) {
+    if (isValidAuthFile(authPath)) {
+      return { ok: true, skipped: false };
+    }
+
+    const session = await promptAndParseSession(opts.logger);
+    await persistSession(session, authPath);
+    opts.logger.info(
+      { event: "walkthrough.auth_persisted", context: "walkthrough", path: authPath },
+      "auth session saved",
+    );
+    return { ok: true, skipped: false, justAuthenticated: true };
+  }
+
+  // --- Probe path ---
+
+  if (isValidAuthFile(authPath)) {
+    // Session file exists — probe it
+    const client = await opts.probeClientFactory();
+    const outcome = await probeSession(client, opts.logger);
+
+    if (outcome.kind === "ok") {
+      return { ok: true, skipped: false };
+    }
+
+    if (outcome.kind === "stale") {
+      // Delete stale auth.json and re-prompt
+      try {
+        await unlink(authPath);
+      } catch {
+        // If deletion fails, continue anyway — user will overwrite via paste
+      }
+      const session = await promptAndParseSession(opts.logger);
+      await persistSession(session, authPath);
+      opts.logger.info(
+        { event: "walkthrough.auth_refresh_persisted", context: "walkthrough", path: authPath },
+        "stale session replaced — new auth saved",
+      );
+
+      // Re-probe once with a fresh client (reads new auth.json)
+      const freshClient = await opts.probeClientFactory();
+      const retry = await probeSession(freshClient, opts.logger);
+      if (retry.kind === "ok") {
+        return { ok: true, skipped: false, refreshed: true };
+      }
+      throw new WalkthroughError("Session refresh failed twice. Try again later.");
+    }
+
+    if (outcome.kind === "network_error") {
+      throw new WalkthroughError(
+        `Could not reach Mangakakalot to verify session. Check connectivity. (${outcome.message})`,
+      );
+    }
+
+    // transient 4xx/5xx — surface to caller, don't delete auth.json
+    throw new WalkthroughError(
+      `Mangakakalot returned an unexpected status (${outcome.status}) during session probe. Try again later.`,
+    );
+  }
+
+  // No valid session file — prompt for cURL paste
+  const session = await promptAndParseSession(opts.logger);
+  await persistSession(session, authPath);
+  opts.logger.info(
+    { event: "walkthrough.auth_persisted", context: "walkthrough", path: authPath },
+    "auth session saved",
+  );
+
+  // Probe the freshly-pasted session (client reads the file we just wrote)
+  const freshClient = await opts.probeClientFactory();
+  const outcome = await probeSession(freshClient, opts.logger);
+  if (outcome.kind === "ok") {
+    return { ok: true, skipped: false, justAuthenticated: true };
+  }
+  if (outcome.kind === "stale") {
+    throw new WalkthroughError(
+      "The pasted session was immediately rejected by Cloudflare. Ensure you copy the cURL from a fresh browser request and try again.",
+    );
+  }
+  if (outcome.kind === "network_error") {
+    throw new WalkthroughError(
+      `Could not reach Mangakakalot to verify session. Check connectivity. (${outcome.message})`,
+    );
+  }
+  throw new WalkthroughError(
+    `Mangakakalot returned an unexpected status (${outcome.status}) during session probe. Try again later.`,
   );
 }

--- a/src/walkthrough/types.ts
+++ b/src/walkthrough/types.ts
@@ -68,7 +68,27 @@ export interface AuthResult {
   skipped: boolean;
   /** true when the user just successfully pasted a new cURL */
   justAuthenticated?: boolean;
+  /** true when the session was stale and auto-refreshed via cURL re-paste */
+  refreshed?: boolean;
 }
+
+/**
+ * Minimal probe surface injected into auth-check.
+ * Keeps the walkthrough layer decoupled from the full fallback-http surface.
+ */
+export interface SessionProbeClient {
+  /**
+   * GET the target URL with authenticated headers.
+   * Resolves with a Response on success, throws on network error or CF rejection.
+   */
+  get(url: string, headers?: Record<string, string>): Promise<Response>;
+}
+
+/**
+ * Factory that creates a SessionProbeClient on demand.
+ * Called lazily by auth-check so auth.json exists when the client is constructed.
+ */
+export type SessionProbeClientFactory = () => Promise<SessionProbeClient>;
 
 export interface WalkthroughResult {
   title: string;


### PR DESCRIPTION
## What this PR does

- Replaces 4 stale references to the deleted `scanldr auth` command with messaging that points at `bun start` and the interactive walkthrough.
- Adds a session probe to `auth-check` (step 3): when `auth.json` is present and parseable, the step now GETs the Mangakakalot homepage via the existing fallback-http client before declaring the session valid.
- On Cloudflare rejection: deletes stale `auth.json`, re-prompts the user for a fresh cURL paste in the same run, persists the new session, and re-probes once. Second failure throws `WalkthroughError`.
- On network error or transient 4xx/5xx: throws `WalkthroughError` without touching `auth.json`.
- Adapter is created AFTER auth-check returns `{ ok: true }` — ordering was already correct in `runWalkthrough`, no reorder needed.

## Why it exists

Real bug surfaced when running `bun start zombie 100` with an expired session:
1. The error message pointed at `scanldr auth` — a command deleted in Phase 4. Misleading UX.
2. `auth-check` only verified file presence, so expired sessions passed step 3 silently and crashed on the first search. User had to relaunch manually.

## How it works internally

- `src/walkthrough/types.ts`: adds `SessionProbeClient` and `SessionProbeClientFactory` interfaces + `refreshed` field on `AuthResult`.
- `src/walkthrough/steps/auth-check.ts`: refactored into `probeSession()` + `promptAndParseSession()` helpers. Factory injected via `probeClientFactory` in `AuthCheckOptions` — no network call when omitted (backward-compatible).
- `src/walkthrough/index.ts`: threads `probeClientFactory` through `RunWalkthroughOptions`. Production default is a lazy factory that calls `createFallbackHttp` so it reads the `auth.json` that was just written by the paste prompt.
- `src/integrations/fallback-http/`: only the 4 stale messages were changed. No logic touched.

## What did not change

- MangaDex adapter — no auth requirement, unaffected.
- `src/integrations/fallback-http/service.ts` retry/throttle logic — untouched beyond the single message fix.
- No new tables, migrations, or plugins.

## Test checklist

- [x] `bun test` — 389 pass, 0 fail (baseline 383, +6 new probe scenario tests)
- [x] `bun run typecheck` — exit 0
- [x] `bun run check` (Biome) — exit 0
- [x] Probe success: valid session, no re-prompt
- [x] Probe stale -> re-prompt -> persist -> re-probe ok -> `{ refreshed: true }`
- [x] Probe stale -> re-prompt -> re-probe stale -> `WalkthroughError`
- [x] Probe network error -> `WalkthroughError`; `auth.json` untouched
- [x] Probe 5xx -> `WalkthroughError`; `auth.json` untouched
- [x] First-run (no auth.json) -> paste -> probe -> `{ justAuthenticated: true }`
- [x] Existing tests (requiresAuth false, requiresAuth true no probe, invalid paste) all pass

## Reviewer notes

- **Probe target**: `https://www.mangakakalot.gg/` (homepage) vs a search URL. Homepage preferred because search triggers stricter Cloudflare rules and produces noisier logs. A 200 real HTML response from the homepage is sufficient proof that cookies are honored.
- **5s timeout**: hard-coded `PROBE_TIMEOUT_MS`. Cloudflare rejections are fast; the timeout guards against stalled connections on bad networks.
- **Stale auth.json**: deleted (not renamed to `.stale`) — simpler; the fresh paste immediately replaces it. Forensics can be recovered from the `traces` table if needed.
- **Adapter ordering**: the adapter was already created AFTER `checkAuth` returns in `runWalkthrough`. No reorder was needed.
- **`probeClientFactory` vs `probeClient`**: factory pattern chosen because `createFallbackHttp` reads `auth.json` eagerly at construction — creating it lazily ensures it reads the file the paste prompt just wrote.

## Closes

No issue automatically closed. Independent of #121-#124.

### Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (if applicable) — no doc change required