### PR TITLE
refactor(walkthrough): drop title prefill; bun start always prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Single-walkthrough CLI to download manga from MangaDex and Mangakakalot, package
 
 ## Features
 
-- Single interactive walkthrough — `bun start [title]`.
+- Single interactive walkthrough — `bun start`.
 - Two sources: MangaDex (no auth) and Mangakakalot (cURL paste for Cloudflare bypass).
 - Visual pickers for source, search results, mode (chapter/volume), and range — no flag-based syntax.
 - Optional packing of selected chapters into a single CBZ with optional cover injection.
@@ -33,14 +33,13 @@ There are no subcommands. Everything is a prompt.
 
 ```bash
 bun start                  # interactive walkthrough
-bun start "Naruto"         # walkthrough with title pre-filled
 bun start --help           # show usage
 bun start --version        # show version
 ```
 
 ### Walkthrough steps
 
-1. **Title prompt** — free-text input ("Manga title or URL:"); pre-filled if a positional argument was passed.
+1. **Title prompt** — free-text input ("Manga title or URL:").
 2. **Source picker** — choose MangaDex or Mangakakalot.
 3. **Auth check** — if the chosen source requires auth and no valid session exists, prompts for a cURL paste; silently skipped for MangaDex.
 4. **Search results** — visual numbered picker, single select.

--- a/src/cli-routing.test.ts
+++ b/src/cli-routing.test.ts
@@ -107,8 +107,8 @@ describe("walkthrough routing", () => {
     }
   });
 
-  test("single positional arg → enters walkthrough with title prefill", async () => {
-    const r = await runWithTimeout(["Naruto"], 800);
+  test("positional args silently ignored → enters walkthrough", async () => {
+    const r = await runWithTimeout(["zombie", "100"], 800);
     if (!r.timedOut) {
       expect(r.stderr).not.toMatch(/Unknown command/i);
       expect(r.exitCode).not.toBe(1);
@@ -118,10 +118,8 @@ describe("walkthrough routing", () => {
   });
 
   test("any flag combination → walkthrough (not routed to dead subcommand)", async () => {
-    // Passing a known-old subcommand keyword now becomes a title prefill
     const r = await runWithTimeout(["download"], 800);
     if (!r.timedOut) {
-      // Should not exit with "Unknown command" — download is now treated as title prefill
       expect(r.stderr).not.toMatch(/Unknown command/i);
     } else {
       expect(r.timedOut).toBe(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ const USAGE = `scanldr — offline downloader for manga, HQ, manhwa, and webtoon
 
 Usage:
   bun start                  Interactive walkthrough
-  bun start <title-or-url>   Walkthrough with title pre-filled
 
 Flags:
   --help, -h      Show this help
@@ -82,10 +81,7 @@ export async function main(argv: string[]): Promise<void> {
   const traceStore = createTraceStore({ db });
   const logger = createLogger({ level, format }, traceStore);
 
-  // The first positional (if any) becomes the title prefill for the walkthrough.
-  const titlePrefill = positionals[0];
-
-  const result = await runWalkthrough({ logger, titlePrefill });
+  const result = await runWalkthrough({ logger });
   if (typeof result === "object" && "cancelled" in result && result.cancelled) {
     process.exit(130);
   }

--- a/src/walkthrough/index.ts
+++ b/src/walkthrough/index.ts
@@ -64,7 +64,7 @@ export async function runWalkthrough(
 
   try {
     // Step 1 — title
-    const title = await promptTitle({ prefill: opts.titlePrefill });
+    const title = await promptTitle();
 
     // Step 2 — source
     const source = await pickSource();

--- a/src/walkthrough/steps/title-prompt.test.ts
+++ b/src/walkthrough/steps/title-prompt.test.ts
@@ -1,20 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 describe("promptTitle", () => {
-  test("with prefill — default is set to prefill value", async () => {
-    mock.module("../prompts.ts", () => ({
-      input: async (opts: { default?: string }) => opts.default ?? "",
-      select: async () => "",
-      checkbox: async () => [],
-      confirm: async () => false,
-      editor: async () => "",
-    }));
-    const { promptTitle } = await import("./title-prompt.ts");
-    const result = await promptTitle({ prefill: "Naruto" });
-    expect(result).toBe("Naruto");
-  });
-
-  test("without prefill — returns user-typed value", async () => {
+  test("returns user-typed value", async () => {
     mock.module("../prompts.ts", () => ({
       input: async (_opts: unknown) => "One Piece",
       select: async () => "",

--- a/src/walkthrough/steps/title-prompt.ts
+++ b/src/walkthrough/steps/title-prompt.ts
@@ -1,14 +1,9 @@
 import { input } from "../prompts.ts";
 
-export interface TitlePromptOptions {
-  prefill?: string;
-}
-
 /** Step 1: prompt for manga title or URL. Re-prompts when empty. */
-export async function promptTitle(opts: TitlePromptOptions = {}): Promise<string> {
+export async function promptTitle(): Promise<string> {
   const result = await input({
     message: "Manga title or URL:",
-    default: opts.prefill,
     validate: (v: string) => v.trim().length > 0 || "Title cannot be empty",
   });
   return result.trim();

--- a/src/walkthrough/types.ts
+++ b/src/walkthrough/types.ts
@@ -12,9 +12,9 @@ export interface Packer {
   packVolume(input: PackVolumeInput): Promise<PackVolumeResult>;
 }
 
-export interface WalkthroughInput {
-  titlePrefill?: string;
-}
+/** @deprecated Empty — kept for backwards compat; will be removed in next major. */
+// biome-ignore lint/suspicious/noEmptyInterface: intentionally kept for API compatibility
+export interface WalkthroughInput {}
 
 /** One result from a source search. Mirrors MangaCandidate from shared types. */
 export interface SearchHit {

--- a/src/walkthrough/walkthrough.test.ts
+++ b/src/walkthrough/walkthrough.test.ts
@@ -95,7 +95,6 @@ describe("runWalkthrough — full happy path", () => {
     const result = await runWalkthrough({
       logger,
       outDir,
-      titlePrefill: "Naruto",
       adapterFactory: fakeAdapterFactory,
       executeDeps: { downloader: fakeDownloader, packer: fakePacker },
     });
@@ -140,7 +139,6 @@ describe("runWalkthrough — full happy path", () => {
     const result = await runWalkthrough({
       logger,
       outDir,
-      titlePrefill: "One Piece",
       adapterFactory: () => fakeAdapter,
       executeDeps: { downloader: fakeDownloader, packer: fakePacker },
     });
@@ -181,7 +179,6 @@ describe("runWalkthrough — full happy path", () => {
     const result = await runWalkthrough({
       logger,
       outDir,
-      titlePrefill: "Bleach",
       adapterFactory: fakeAdapterFactory,
       executeDeps: { downloader: fakeDownloader, packer: fakePacker },
     });
@@ -233,7 +230,6 @@ describe("runWalkthrough — full happy path", () => {
     const { runWalkthrough } = await import("./index.ts");
     const result = await runWalkthrough({
       logger,
-      titlePrefill: "Unknown Manga",
       adapterFactory: () => emptyAdapter,
     });
     if ("cancelled" in result) throw new Error("Unexpected cancellation");


### PR DESCRIPTION
Per maintainer request ("simplifica, deixa start sem titulo e mantem a pergunta"): removes the `titlePrefill` feature entirely. `bun start` now always launches the full interactive walkthrough beginning at the "Manga title or URL:" prompt — positional arguments other than `help` are silently ignored. Deletes ~40 lines across prompt, types, routing, and tests; test count drops by 2 (prefill-specific assertions removed).