### PR TITLE
feat(walkthrough): catch Cloudflare rejection mid-flow and auto-refresh (a+b)

### DIFF
--- a/src/integrations/fallback-http/fallback-http.test.ts
+++ b/src/integrations/fallback-http/fallback-http.test.ts
@@ -741,3 +741,126 @@ test("capitalized Cookie header from caller does not override auto-built cookie"
   // The attacker's value must not appear in the outgoing cookie header.
   expect(cookieParts).not.toContain("attacker=evil");
 });
+
+// ---------------------------------------------------------------------------
+// Test 19 (P2-2): Credential reload — after auth.json is rewritten, the next
+// request uses the NEW cookies, not the stale ones captured at construction.
+// This is the integration test that would have caught P0-1.
+// ---------------------------------------------------------------------------
+
+test("credential reload: after auth.json rewrite, next request sends new cookies", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  const capturedCookieHeaders: string[] = [];
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> = async (
+    _url,
+    init,
+  ) => {
+    const headers = init?.headers as Record<string, string>;
+    capturedCookieHeaders.push(headers.cookie ?? "");
+    return makeFakeResponse(200);
+  };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  // First request — should use VALID_SESSION cookies.
+  await client.get("https://example.com/first");
+  expect(capturedCookieHeaders[0]).toContain("cf_clearance=abc123");
+
+  // Simulate refreshSession: overwrite auth.json with new credentials.
+  const REFRESHED_SESSION = {
+    cookies: { cf_clearance: "NEW_TOKEN", __cf_bm: "NEW_BM" },
+    userAgent: "Mozilla/5.0 RefreshedUA",
+    savedAt: Date.now(),
+  };
+  // Small delay to guarantee mtime changes (filesystem resolution is ~1ms).
+  await new Promise((r) => setTimeout(r, 10));
+  await writeFile(path, JSON.stringify(REFRESHED_SESSION), "utf8");
+
+  // Second request — must pick up the NEW credentials from the rewritten file.
+  await client.get("https://example.com/second");
+
+  expect(capturedCookieHeaders).toHaveLength(2);
+  const secondCookies = capturedCookieHeaders[1] ?? "";
+  // Must contain new token.
+  expect(secondCookies).toContain("cf_clearance=NEW_TOKEN");
+  expect(secondCookies).toContain("__cf_bm=NEW_BM");
+  // Must NOT contain old stale token.
+  expect(secondCookies).not.toContain("cf_clearance=abc123");
+});
+
+// ---------------------------------------------------------------------------
+// Test 20 (P1-1): 200 with CF challenge HTML → throws CloudflareError
+// ---------------------------------------------------------------------------
+
+test("200 with CF challenge HTML body throws CloudflareError", async () => {
+  const { logger, calls } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  let fetchCount = 0;
+  const CF_CHALLENGE_BODY =
+    "<!DOCTYPE html><html><head><title>Just a moment...</title></head><body>" +
+    "<div id='cf-browser-verification'>cloudflare cf_clearance challenge</div>" +
+    "</body></html>";
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => {
+      fetchCount++;
+      return new Response(CF_CHALLENGE_BODY, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    };
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  await expect(client.get("https://example.com/")).rejects.toBeInstanceOf(CloudflareError);
+
+  // No retry on CF challenge.
+  expect(fetchCount).toBe(1);
+
+  const warnCall = calls.find(
+    (c) => c.level === "warn" && c.fields.event === "fallback_http.cloudflare_rejected",
+  );
+  expect(warnCall).toBeDefined();
+});
+
+// ---------------------------------------------------------------------------
+// Test 21: Normal 200 with real HTML is NOT falsely flagged as CF challenge
+// ---------------------------------------------------------------------------
+
+test("200 with real manga HTML is returned to caller without throwing", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  const REAL_HTML = "<html><body><div class='manga-list'><h2>Naruto Vol.1</h2></div></body></html>";
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () => new Response(REAL_HTML, { status: 200, headers: { "content-type": "text/html" } });
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.get("https://example.com/manga/naruto");
+  expect(res.status).toBe(200);
+  const body = await res.text();
+  expect(body).toContain("Naruto Vol.1");
+});

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -64,15 +64,9 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
     throw new MissingAuthError(path);
   }
 
-  logger.info(
-    {
-      event: "fallback_http.session_loaded",
-      context: "fallback-http",
-      path,
-      savedAt: session.savedAt,
-    },
-    "auth session loaded",
-  );
+  // "auth session loaded" log intentionally removed: every adapter and the probe client
+  // each construct a separate fallback-http instance, causing duplicate info lines per run.
+  // The trace store still captures the event if needed via structured fields elsewhere.
 
   // Build cookie header string once — session is immutable for process lifetime.
   // cookieHeader is undefined (not "") when cookies is empty so the header is

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -1,8 +1,10 @@
 // Fallback HTTP client factory.
-// Reads the captured auth session once at construction time, then replays
-// cookies + UA on every request per ADR-001.
+// Reads auth.json lazily on every request, caching by file mtime to avoid
+// re-reads when nothing has changed (ADR-001). This ensures that when
+// refreshSession writes new credentials, the next request automatically
+// picks them up without requiring a new client instance.
 
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import type { AuthSession } from "@integrations/mangakakalot/auth/types.ts";
 import { resolveAuthPath } from "@plugins/auth-path/index.ts";
 import { CloudflareError, MissingAuthError } from "./types.ts";
@@ -28,6 +30,13 @@ function isValidAuthSession(v: unknown): v is AuthSession {
   );
 }
 
+/** Cached auth credentials, keyed by file mtime to detect changes. */
+interface AuthCache {
+  mtimeMs: number;
+  cookieHeader: string | undefined;
+  userAgent: string;
+}
+
 export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<FallbackHttpClient> {
   const { logger } = opts;
   const fetchFn: FetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
@@ -37,54 +46,44 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
   // Resolve path once — either from opts or XDG.
   const path = opts.authPath ?? resolveAuthPath();
 
-  // Read auth.json eagerly — fail fast if missing or corrupt.
-  let raw: string;
-  try {
-    raw = await readFile(path, "utf8");
-  } catch {
-    logger.warn(
-      { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "missing" },
-      "auth.json not found",
-    );
-    throw new MissingAuthError(path);
-  }
+  // Eagerly verify the file exists and is valid at construction time (fail fast).
+  // The actual cached value is populated lazily on first request.
+  await loadAuth(path, logger);
 
-  let session: AuthSession;
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!isValidAuthSession(parsed)) {
-      throw new Error("shape mismatch");
-    }
-    session = parsed;
-  } catch {
-    logger.warn(
-      { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "corrupt" },
-      `auth session at ${path} is corrupt; the walkthrough will re-prompt for a fresh paste`,
-    );
-    throw new MissingAuthError(path);
-  }
-
-  // "auth session loaded" log intentionally removed: every adapter and the probe client
-  // each construct a separate fallback-http instance, causing duplicate info lines per run.
-  // The trace store still captures the event if needed via structured fields elsewhere.
-
-  // Build cookie header string once — session is immutable for process lifetime.
-  // cookieHeader is undefined (not "") when cookies is empty so the header is
-  // omitted entirely from the request — sending "Cookie: " confuses some servers.
-  const cookieHeader =
-    Object.keys(session.cookies).length > 0
-      ? Object.entries(session.cookies)
-          .map(([k, v]) => `${k}=${v}`)
-          .join("; ")
-      : undefined;
-
-  const userAgent = session.userAgent;
+  // Mtime-keyed cache: null means not yet loaded (though we verified above it exists).
+  let authCache: AuthCache | null = null;
 
   // Throttle state — serialized via promise chain so concurrent calls queue up.
   // null = no request made yet; number = timestamp of last request start.
   let lastRequestAt: number | null = null;
   // Pending chain for sequential dispatch (satisfies concurrency test #12).
   let chain: Promise<void> = Promise.resolve();
+
+  async function resolveAuth(): Promise<{ cookieHeader: string | undefined; userAgent: string }> {
+    // Read file mtime; re-parse only when it has changed since the last load.
+    let mtimeMs: number;
+    try {
+      const s = await stat(path);
+      mtimeMs = s.mtimeMs;
+    } catch {
+      // File was deleted between checks — reload will throw MissingAuthError below.
+      mtimeMs = -1;
+    }
+
+    if (authCache !== null && authCache.mtimeMs === mtimeMs) {
+      return { cookieHeader: authCache.cookieHeader, userAgent: authCache.userAgent };
+    }
+
+    const session = await loadAuth(path, logger);
+    const cookieHeader =
+      Object.keys(session.cookies).length > 0
+        ? Object.entries(session.cookies)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("; ")
+        : undefined;
+    authCache = { mtimeMs, cookieHeader, userAgent: session.userAgent };
+    return { cookieHeader, userAgent: session.userAgent };
+  }
 
   async function get(url: string, extraHeaders?: Record<string, string>): Promise<Response> {
     // Enqueue behind prior requests — enforces 1 req/s globally.
@@ -116,6 +115,11 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
       let fetchError: unknown;
 
       try {
+        // Reload auth credentials if auth.json changed since last request.
+        // This is the core fix for P0-1: after refreshSession writes new
+        // credentials, the next attempt automatically picks them up.
+        const { cookieHeader, userAgent } = await resolveAuth();
+
         // Build base headers; merge caller extras on top (caller wins on conflict).
         const headers: Record<string, string> = { "user-agent": userAgent };
         if (cookieHeader !== undefined) headers.cookie = cookieHeader;
@@ -143,7 +147,21 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
         throw new CloudflareError(url);
       }
 
-      // 2xx, 3xx, and 4xx other than 403: return to caller (no retry).
+      // 200 with CF challenge HTML — treat symmetrically with 403.
+      if (res && res.status >= 200 && res.status < 300) {
+        const body = await peekCfBody(res);
+        if (body !== null && isCfChallengeHtml(body)) {
+          logger.warn(
+            { event: "fallback_http.cloudflare_rejected", context: "fallback-http", url },
+            "Cloudflare challenge in 200 body — session is stale",
+          );
+          throw new CloudflareError(url);
+        }
+        // Return a synthetic response that re-streams the body we already consumed.
+        return rebuildResponse(res, body);
+      }
+
+      // 3xx and 4xx other than 403: return to caller (no retry).
       if (res && res.status < 500) {
         return res;
       }
@@ -183,4 +201,76 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
   }
 
   return { get: (url, headers) => get(url, headers) };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function loadAuth(
+  path: string,
+  logger: { warn: (fields: Record<string, unknown>, msg: string) => void },
+): Promise<AuthSession> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    logger.warn(
+      { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "missing" },
+      "auth.json not found",
+    );
+    throw new MissingAuthError(path);
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidAuthSession(parsed)) {
+      throw new Error("shape mismatch");
+    }
+    return parsed;
+  } catch {
+    logger.warn(
+      { event: "fallback_http.missing_auth", context: "fallback-http", path, reason: "corrupt" },
+      `auth session at ${path} is corrupt; the walkthrough will re-prompt for a fresh paste`,
+    );
+    throw new MissingAuthError(path);
+  }
+}
+
+/**
+ * Returns the CF challenge body markers we look for.
+ * Must be kept in sync with auth-check.ts probeSession().
+ */
+function isCfChallengeHtml(body: string): boolean {
+  return (
+    body.includes("cf-browser-verification") ||
+    body.includes("challenge-platform") ||
+    body.includes("cdn-cgi/challenge-platform") ||
+    body.includes("jschl-answer") ||
+    (body.includes("cloudflare") && body.includes("cf_clearance") && body.length < 20000)
+  );
+}
+
+/**
+ * Reads the response body for CF inspection without consuming it irrecoverably.
+ * Returns the text, or null if reading fails (caller treats null as "not CF").
+ */
+async function peekCfBody(res: Response): Promise<string | null> {
+  try {
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wraps an already-consumed body back into a Response so the caller can still
+ * call .text() / .json() on the returned response.
+ */
+function rebuildResponse(original: Response, body: string | null): Response {
+  return new Response(body, {
+    status: original.status,
+    statusText: original.statusText,
+    headers: original.headers,
+  });
 }

--- a/src/walkthrough/index.ts
+++ b/src/walkthrough/index.ts
@@ -2,6 +2,7 @@ import { createFallbackHttp } from "../integrations/fallback-http/index.ts";
 import type { Logger } from "../plugins/logger/index.ts";
 import type { SourceAdapter } from "../sources/adapters/index.ts";
 import { getAdapter } from "../sources/adapters/index.ts";
+import { refreshSession } from "./steps/auth-check.ts";
 import { checkAuth } from "./steps/auth-check.ts";
 import { promptCoverUrl } from "./steps/cover-prompt.ts";
 import { executeWalkthrough } from "./steps/execute.ts";
@@ -19,6 +20,7 @@ import type {
   WalkthroughResult,
 } from "./types.ts";
 import { WalkthroughError } from "./types.ts";
+import { isCloudflareError, withSessionRetry } from "./with-session-retry.ts";
 
 export type {
   WalkthroughCancelled,
@@ -42,6 +44,11 @@ export interface RunWalkthroughOptions extends WalkthroughInput {
    * Pass null to disable probing (file-presence check only).
    */
   probeClientFactory?: SessionProbeClientFactory | null;
+  /**
+   * Override the refresh function for tests.
+   * When provided, this is used instead of the real refreshSession for retry logic.
+   */
+  refreshFn?: () => Promise<void>;
 }
 
 /** Returned when walkthrough errors out in a handled way (WalkthroughError). */
@@ -85,21 +92,51 @@ export async function runWalkthrough(
       probeClientFactory,
     });
 
+    // Build a refresh closure reused by all adapter-call retry wrappers.
+    // In production this re-reads XDG auth path; in tests opts.refreshFn overrides.
+    const doRefresh: () => Promise<void> = opts.refreshFn
+      ? opts.refreshFn
+      : probeClientFactory
+        ? async () => {
+            const { resolveAuthPath } = await import("../plugins/auth-path/index.ts");
+            const authPath = resolveAuthPath();
+            await refreshSession({ authPath, probeClientFactory, logger: opts.logger });
+          }
+        : async () => {
+            // No probe factory — cannot refresh; surface as error
+            throw new WalkthroughError(
+              "Session expired but no probe factory is configured to refresh it.",
+            );
+          };
+
     // Resolve adapter for this source (after auth check so session is persisted if needed)
     const adapter = resolveAdapter(source.id, { logger: opts.logger });
 
-    // Step 4 — search results
-    const hit = await pickSearchResult({
-      query: title,
-      sourceLabel: source.label,
-      adapter,
-    });
+    // Step 4 — search results (with CF retry)
+    const hit = await withSessionRetry(
+      () =>
+        pickSearchResult({
+          query: title,
+          sourceLabel: source.label,
+          adapter,
+        }),
+      isCloudflareError,
+      doRefresh,
+      opts.logger,
+      "walkthrough.search_retry",
+    );
 
     // Step 5 — mode
     const mode = await pickMode();
 
-    // Step 6 — range
-    const selectedBundles = await pickRange({ hit, mode, adapter });
+    // Step 6 — range (with CF retry)
+    const selectedBundles = await withSessionRetry(
+      () => pickRange({ hit, mode, adapter }),
+      isCloudflareError,
+      doRefresh,
+      opts.logger,
+      "walkthrough.range_retry",
+    );
 
     // Step 7 — pack prompt (chapter mode only)
     // volume mode always packs
@@ -118,7 +155,7 @@ export async function runWalkthrough(
       coverUrl,
     };
 
-    // Step 9 — execute
+    // Step 9 — execute (fetchChapterInput calls are wrapped inside executeWalkthrough)
     await executeWalkthrough(
       {
         source,
@@ -130,6 +167,7 @@ export async function runWalkthrough(
         outDir,
         adapter,
         logger: opts.logger,
+        refreshFn: doRefresh,
       },
       opts.executeDeps,
     );

--- a/src/walkthrough/steps/auth-check.test.ts
+++ b/src/walkthrough/steps/auth-check.test.ts
@@ -316,4 +316,36 @@ describe("checkAuth", () => {
 
     expect(result).toEqual({ ok: true, skipped: false, justAuthenticated: true });
   });
+
+  test("probe URL contains /search/story/ (representative CF detection — not the homepage)", async () => {
+    const dir = join(tmpdir(), `scanldr-probe-url-${Date.now()}`);
+    const authDir = join(dir, "scanldr");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(
+      join(authDir, "auth.json"),
+      JSON.stringify({ cookies: { cf_clearance: "x" }, userAgent: "ua", savedAt: Date.now() }),
+    );
+
+    mock.module("../prompts.ts", () => ({
+      editor: async () => "",
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+    }));
+
+    let capturedUrl = "";
+    const client: SessionProbeClient = {
+      get: async (url: string) => {
+        capturedUrl = url;
+        return okResponse();
+      },
+    };
+    const probeClientFactory: SessionProbeClientFactory = async () => client;
+
+    const { checkAuth } = await import("./auth-check.ts");
+    await checkAuth({ requiresAuth: true, logger, dataHome: dir, probeClientFactory });
+
+    expect(capturedUrl).toContain("/search/story/");
+  });
 });

--- a/src/walkthrough/steps/auth-check.test.ts
+++ b/src/walkthrough/steps/auth-check.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CloudflareError } from "../../integrations/fallback-http/types.ts";
 import { createLogger } from "../../plugins/logger/index.ts";
 import type { SessionProbeClient, SessionProbeClientFactory } from "../types.ts";
 
@@ -35,9 +36,8 @@ function okResponse(): Promise<Response> {
 function cfRejectionResponse(): Promise<Response> {
   // The probe client's get() throws CloudflareError on 403, but our fake returns the
   // response directly (the real service.ts interprets 403 and throws).
-  // We simulate the service behavior: throw a CloudflareError-like error.
-  const err = Object.assign(new Error("Cloudflare rejected"), { name: "CloudflareError" });
-  return Promise.reject(err);
+  // We simulate the service behavior: throw a real CloudflareError.
+  return Promise.reject(new CloudflareError("https://example.com"));
 }
 
 /** 500 response. */

--- a/src/walkthrough/steps/auth-check.ts
+++ b/src/walkthrough/steps/auth-check.ts
@@ -23,8 +23,15 @@ export interface AuthCheckOptions {
 }
 
 const MAX_PASTE_RETRIES = 2;
-/** Probe target: mangakakalot homepage — cheaper and less noisy than search URLs. */
-const PROBE_URL = "https://www.mangakakalot.gg/";
+/**
+ * Probe target: the search endpoint, not the homepage.
+ * The homepage has weaker Cloudflare rules and gives false positives — a 200 there
+ * does NOT guarantee the session works for search, which has stricter CF rules.
+ * A benign query ("__scanldr_probe__") returns a "no results" page when the session
+ * is valid, and triggers a CF challenge when the session is stale — exactly the
+ * same behaviour the walkthrough encounters in step 4.
+ */
+const PROBE_URL = "https://www.mangakakalot.gg/search/story/__scanldr_probe__";
 /** Probe timeout in ms. */
 const PROBE_TIMEOUT_MS = 5000;
 
@@ -188,6 +195,43 @@ async function promptAndParseSession(logger: Logger): Promise<AuthSession> {
   );
 }
 
+export interface RefreshSessionOptions {
+  authPath: string;
+  probeClientFactory: SessionProbeClientFactory;
+  logger: Logger;
+}
+
+/**
+ * Shared refresh flow used by both auth-check (stale branch) and withSessionRetry.
+ * Deletes stale auth.json, prompts for a fresh cURL paste, persists it, and re-probes once.
+ * Returns { ok: true, refreshed: true } on success.
+ * Throws WalkthroughError if the second probe still fails.
+ */
+export async function refreshSession(opts: RefreshSessionOptions): Promise<AuthResult> {
+  const { authPath, probeClientFactory, logger } = opts;
+
+  try {
+    await unlink(authPath);
+  } catch {
+    // If deletion fails, continue — user will overwrite via paste
+  }
+
+  const session = await promptAndParseSession(logger);
+  await persistSession(session, authPath);
+  logger.info(
+    { event: "walkthrough.auth_refresh_persisted", context: "walkthrough", path: authPath },
+    "stale session replaced — new auth saved",
+  );
+
+  // Re-probe once with a fresh client (reads new auth.json)
+  const freshClient = await probeClientFactory();
+  const retry = await probeSession(freshClient, logger);
+  if (retry.kind === "ok") {
+    return { ok: true, skipped: false, refreshed: true };
+  }
+  throw new WalkthroughError("Session refresh failed twice. Try again later.");
+}
+
 /** Step 3: check auth state. Prompt for cURL paste when needed and persist via auth service. */
 export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
   if (!opts.requiresAuth) {
@@ -223,26 +267,11 @@ export async function checkAuth(opts: AuthCheckOptions): Promise<AuthResult> {
     }
 
     if (outcome.kind === "stale") {
-      // Delete stale auth.json and re-prompt
-      try {
-        await unlink(authPath);
-      } catch {
-        // If deletion fails, continue anyway — user will overwrite via paste
-      }
-      const session = await promptAndParseSession(opts.logger);
-      await persistSession(session, authPath);
-      opts.logger.info(
-        { event: "walkthrough.auth_refresh_persisted", context: "walkthrough", path: authPath },
-        "stale session replaced — new auth saved",
-      );
-
-      // Re-probe once with a fresh client (reads new auth.json)
-      const freshClient = await opts.probeClientFactory();
-      const retry = await probeSession(freshClient, opts.logger);
-      if (retry.kind === "ok") {
-        return { ok: true, skipped: false, refreshed: true };
-      }
-      throw new WalkthroughError("Session refresh failed twice. Try again later.");
+      return refreshSession({
+        authPath,
+        probeClientFactory: opts.probeClientFactory,
+        logger: opts.logger,
+      });
     }
 
     if (outcome.kind === "network_error") {

--- a/src/walkthrough/steps/auth-check.ts
+++ b/src/walkthrough/steps/auth-check.ts
@@ -210,12 +210,10 @@ export interface RefreshSessionOptions {
 export async function refreshSession(opts: RefreshSessionOptions): Promise<AuthResult> {
   const { authPath, probeClientFactory, logger } = opts;
 
-  try {
-    await unlink(authPath);
-  } catch {
-    // If deletion fails, continue — user will overwrite via paste
-  }
-
+  // Do NOT unlink here. persistSession writes atomically via .tmp + rename,
+  // so it will overwrite the stale file safely. Deleting upfront is purely
+  // destructive: if the user hits Ctrl+C during the paste prompt, they lose
+  // their existing credentials and cannot retry.
   const session = await promptAndParseSession(logger);
   await persistSession(session, authPath);
   logger.info(

--- a/src/walkthrough/steps/execute.ts
+++ b/src/walkthrough/steps/execute.ts
@@ -6,6 +6,8 @@ import type { Logger } from "../../plugins/logger/index.ts";
 import type { SourceAdapter } from "../../sources/adapters/index.ts";
 import type { SourceDescriptor } from "../../sources/types.ts";
 import type { BundleItem, Downloader, ModeSelection, Packer, SearchHit } from "../types.ts";
+import { isCloudflareError, withSessionRetry } from "../with-session-retry.ts";
+import type { RefreshSession } from "../with-session-retry.ts";
 
 export interface ExecuteWalkthroughInput {
   source: SourceDescriptor;
@@ -17,6 +19,12 @@ export interface ExecuteWalkthroughInput {
   outDir: string;
   adapter: SourceAdapter;
   logger: Logger;
+  /**
+   * Session refresh function threaded from the orchestrator.
+   * Used to auto-refresh when fetchChapterInput hits a CF rejection.
+   * When omitted, CF errors during execute are logged as bundle failures and skipped.
+   */
+  refreshFn?: RefreshSession;
 }
 
 export interface ExecuteDeps {
@@ -50,8 +58,18 @@ export async function executeWalkthrough(
   opts: ExecuteWalkthroughInput,
   deps: ExecuteDeps = createDefaultExecuteDeps(),
 ): Promise<ExecuteWalkthroughResult> {
-  const { source, hit, mode, selectedBundles, groupIntoVolume, coverUrl, outDir, adapter, logger } =
-    opts;
+  const {
+    source,
+    hit,
+    mode,
+    selectedBundles,
+    groupIntoVolume,
+    coverUrl,
+    outDir,
+    adapter,
+    logger,
+    refreshFn,
+  } = opts;
   const { downloader, packer } = deps;
 
   const slug = toSlug(hit.title);
@@ -87,16 +105,30 @@ export async function executeWalkthrough(
 
       let chapterInputs: import("../../modules/downloader/types.ts").ChapterInput[];
 
+      // Wrap fetchChapterInput with CF retry when a refreshFn is available.
+      // Falls back to plain call when no refreshFn is injected (tests that omit it).
+      const fetchWithRetry = refreshFn
+        ? (chapterId: string, chapterNum?: string) =>
+            withSessionRetry(
+              () => adapter.fetchChapterInput(chapterId, chapterNum),
+              isCloudflareError,
+              refreshFn,
+              logger,
+              "walkthrough.fetch_chapter_retry",
+            )
+        : (chapterId: string, chapterNum?: string) =>
+            adapter.fetchChapterInput(chapterId, chapterNum);
+
       if (bundle.kind === "volume") {
         // Expand volume into constituent chapters
         const ids = bundle.chapterIds ?? [];
         const nums = bundle.chapterNums ?? [];
         chapterInputs = await Promise.all(
-          ids.map((chapterId, i) => adapter.fetchChapterInput(chapterId, nums[i])),
+          ids.map((chapterId, i) => fetchWithRetry(chapterId, nums[i])),
         );
       } else {
         // Chapter mode: single fetch
-        chapterInputs = [await adapter.fetchChapterInput(bundle.id, bundle.num)];
+        chapterInputs = [await fetchWithRetry(bundle.id, bundle.num)];
       }
 
       const totalPages = chapterInputs.reduce((acc, ci) => acc + ci.pages.length, 0);

--- a/src/walkthrough/walkthrough.test.ts
+++ b/src/walkthrough/walkthrough.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { ChapterInput } from "../modules/downloader/types.ts";
 import { createLogger } from "../plugins/logger/index.ts";
 import type { SourceAdapter } from "../sources/adapters/index.ts";
+import { WalkthroughError } from "./types.ts";
 import type { ChapterListing, Downloader, Packer, SearchHit, VolumeListing } from "./types.ts";
 
 const noop = () => {};
@@ -209,6 +210,221 @@ describe("runWalkthrough — full happy path", () => {
     const { runWalkthrough } = await import("./index.ts");
     const result = await runWalkthrough({ logger, adapterFactory: fakeAdapterFactory });
     expect(result).toEqual({ cancelled: true });
+  });
+
+  test("non-CF error from search → propagates as { ok: false } without retry", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "Some Manga",
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        return "chapter";
+      },
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    let searchCallCount = 0;
+    const failAdapter = makeFakeAdapter({
+      search: async () => {
+        searchCallCount++;
+        throw new Error("unexpected database error");
+      },
+    });
+    let refreshCalled = false;
+    const { runWalkthrough } = await import("./index.ts");
+    // non-CF errors should bubble up, not be swallowed or retried
+    await expect(
+      runWalkthrough({
+        logger,
+        adapterFactory: () => failAdapter,
+        probeClientFactory: null,
+        refreshFn: async () => {
+          refreshCalled = true;
+        },
+      }),
+    ).rejects.toThrow("unexpected database error");
+    expect(searchCallCount).toBe(1);
+    expect(refreshCalled).toBe(false);
+  });
+
+  test("search hits CF first time, refresh succeeds, retry returns hits → success", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "Naruto",
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex"; // source
+        if (selectCall === 2) return "mock-1"; // search result
+        return "chapter"; // mode
+      },
+      checkbox: async () => ["mock-1-ch-1"],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    let searchCallCount = 0;
+    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const fakeAdapter = makeFakeAdapter({
+      search: async () => {
+        searchCallCount++;
+        if (searchCallCount === 1) throw cfError;
+        return fakeHits;
+      },
+    });
+    let refreshCallCount = 0;
+    const fakeDownloader = makeFakeDownloader();
+    const fakePacker = makeFakePacker();
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({
+      logger,
+      outDir,
+      adapterFactory: () => fakeAdapter,
+      probeClientFactory: null,
+      refreshFn: async () => {
+        refreshCallCount++;
+      },
+      executeDeps: { downloader: fakeDownloader, packer: fakePacker },
+    });
+
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    if ("ok" in result) throw new Error(`Unexpected failure: ${result.reason}`);
+    expect(searchCallCount).toBe(2);
+    expect(refreshCallCount).toBe(1);
+  });
+
+  test("search hits CF, refresh fails on second probe → returns { ok: false }", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "Naruto",
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        return "chapter";
+      },
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const fakeAdapter = makeFakeAdapter({
+      search: async () => {
+        throw cfError;
+      },
+    });
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({
+      logger,
+      adapterFactory: () => fakeAdapter,
+      probeClientFactory: null,
+      refreshFn: async () => {
+        throw new WalkthroughError("Session refresh failed twice. Try again later.");
+      },
+    });
+
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    expect("ok" in result && result.ok === false).toBe(true);
+    if ("ok" in result) {
+      expect(result.reason).toMatch(/refresh failed/i);
+    }
+  });
+
+  test("listChapters hits CF, refresh succeeds, retry returns chapters → success", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "Naruto",
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        if (selectCall === 2) return "mock-1";
+        return "chapter";
+      },
+      checkbox: async () => ["mock-1-ch-1"],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    let listChaptersCallCount = 0;
+    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const fakeAdapter = makeFakeAdapter({
+      listChapters: async () => {
+        listChaptersCallCount++;
+        if (listChaptersCallCount === 1) throw cfError;
+        return fakeChapters;
+      },
+    });
+    let refreshCallCount = 0;
+    const fakeDownloader = makeFakeDownloader();
+    const fakePacker = makeFakePacker();
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({
+      logger,
+      outDir,
+      adapterFactory: () => fakeAdapter,
+      probeClientFactory: null,
+      refreshFn: async () => {
+        refreshCallCount++;
+      },
+      executeDeps: { downloader: fakeDownloader, packer: fakePacker },
+    });
+
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    if ("ok" in result) throw new Error(`Unexpected failure: ${result.reason}`);
+    expect(listChaptersCallCount).toBe(2);
+    expect(refreshCallCount).toBe(1);
+  });
+
+  test("fetchChapterInput hits CF, refresh succeeds, retry completes → success", async () => {
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async (opts: { default?: string }) => opts.default ?? "Naruto",
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        if (selectCall === 2) return "mock-1";
+        return "chapter";
+      },
+      checkbox: async () => ["mock-1-ch-1"],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    let fetchCallCount = 0;
+    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const fakeAdapter = makeFakeAdapter({
+      fetchChapterInput: async () => {
+        fetchCallCount++;
+        if (fetchCallCount === 1) throw cfError;
+        return fakeChapterInput;
+      },
+    });
+    let refreshCallCount = 0;
+    const fakeDownloader = makeFakeDownloader();
+    const fakePacker = makeFakePacker();
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({
+      logger,
+      outDir,
+      adapterFactory: () => fakeAdapter,
+      probeClientFactory: null,
+      refreshFn: async () => {
+        refreshCallCount++;
+      },
+      executeDeps: { downloader: fakeDownloader, packer: fakePacker },
+    });
+
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    if ("ok" in result) throw new Error(`Unexpected failure: ${result.reason}`);
+    expect(fetchCallCount).toBe(2);
+    expect(refreshCallCount).toBe(1);
   });
 
   test("empty search results → returns { ok: false, reason: WalkthroughError message }", async () => {

--- a/src/walkthrough/walkthrough.test.ts
+++ b/src/walkthrough/walkthrough.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CloudflareError } from "../integrations/fallback-http/types.ts";
 import type { ChapterInput } from "../modules/downloader/types.ts";
 import { createLogger } from "../plugins/logger/index.ts";
 import type { SourceAdapter } from "../sources/adapters/index.ts";
@@ -268,7 +269,7 @@ describe("runWalkthrough — full happy path", () => {
 
     selectCall = 0;
     let searchCallCount = 0;
-    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const cfError = new CloudflareError("https://example.com/cf-rejected");
     const fakeAdapter = makeFakeAdapter({
       search: async () => {
         searchCallCount++;
@@ -312,7 +313,7 @@ describe("runWalkthrough — full happy path", () => {
     }));
 
     selectCall = 0;
-    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const cfError = new CloudflareError("https://example.com/cf-rejected");
     const fakeAdapter = makeFakeAdapter({
       search: async () => {
         throw cfError;
@@ -352,7 +353,7 @@ describe("runWalkthrough — full happy path", () => {
 
     selectCall = 0;
     let listChaptersCallCount = 0;
-    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const cfError = new CloudflareError("https://example.com/cf-rejected");
     const fakeAdapter = makeFakeAdapter({
       listChapters: async () => {
         listChaptersCallCount++;
@@ -398,7 +399,7 @@ describe("runWalkthrough — full happy path", () => {
 
     selectCall = 0;
     let fetchCallCount = 0;
-    const cfError = Object.assign(new Error("CF"), { name: "CloudflareError" });
+    const cfError = new CloudflareError("https://example.com/cf-rejected");
     const fakeAdapter = makeFakeAdapter({
       fetchChapterInput: async () => {
         fetchCallCount++;

--- a/src/walkthrough/with-session-retry.ts
+++ b/src/walkthrough/with-session-retry.ts
@@ -1,3 +1,4 @@
+import { CloudflareError } from "../integrations/fallback-http/types.ts";
 import type { Logger } from "../plugins/logger/index.ts";
 import { WalkthroughError } from "./types.ts";
 
@@ -38,5 +39,5 @@ export async function withSessionRetry<T>(
 
 /** Type guard for CloudflareError from fallback-http. */
 export function isCloudflareError(err: unknown): boolean {
-  return err instanceof Error && err.name === "CloudflareError";
+  return err instanceof CloudflareError;
 }

--- a/src/walkthrough/with-session-retry.ts
+++ b/src/walkthrough/with-session-retry.ts
@@ -1,0 +1,42 @@
+import type { Logger } from "../plugins/logger/index.ts";
+import { WalkthroughError } from "./types.ts";
+
+export type RefreshSession = () => Promise<void>;
+
+/**
+ * Wraps an adapter call with a single-retry on Cloudflare rejection.
+ * If the first attempt throws a CF error, `refresh` is called once to obtain a fresh session,
+ * then the call is retried. A second CF failure throws WalkthroughError (caught by orchestrator).
+ * All other errors are re-thrown immediately without retry.
+ */
+export async function withSessionRetry<T>(
+  fn: () => Promise<T>,
+  isStaleSession: (err: unknown) => boolean,
+  refresh: RefreshSession,
+  logger: Logger,
+  event: string,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isStaleSession(err)) throw err;
+    logger.warn(
+      { event, context: "walkthrough", attempt: 1 },
+      "Cloudflare rejected; refreshing session and retrying",
+    );
+    await refresh();
+    try {
+      return await fn();
+    } catch (retryErr) {
+      if (!isStaleSession(retryErr)) throw retryErr;
+      throw new WalkthroughError(
+        "Cloudflare rejected the request after session refresh. Try again later.",
+      );
+    }
+  }
+}
+
+/** Type guard for CloudflareError from fallback-http. */
+export function isCloudflareError(err: unknown): boolean {
+  return err instanceof Error && err.name === "CloudflareError";
+}


### PR DESCRIPTION
## Why

Real bug report from a user running \`bun start\` against Mangakakalot. The probe introduced in #128 checked the **homepage** (\`https://www.mangakakalot.gg/\`), which has weaker Cloudflare rules. The homepage returned 200, probe reported session valid, but **step 4 search** has stricter CF rules and was immediately rejected — exiting with code 1 and no re-prompt.

Two compounding problems:
1. Probe was on the wrong URL — false positive.
2. Any CF rejection after step 3 bubbled up uncaught. The error message promised a re-prompt that never happened.

## What changes

- **Representative probe**: `PROBE_URL` changed from `https://www.mangakakalot.gg/` to `https://www.mangakakalot.gg/search/story/__scanldr_probe__`. A benign query returns a "no results" page when the session is valid; triggers a CF challenge when stale — exactly what step 4 hits.
- **`withSessionRetry` helper** (`src/walkthrough/with-session-retry.ts`): wraps any adapter call with a single retry after a CF rejection. Second CF failure throws `WalkthroughError` (caught by orchestrator → `{ ok: false, reason }`).
- **Retry wired at all four adapter call sites**: `adapter.search` (step 4), `adapter.listChapters`/`listVolumes` (step 6 via `pickRange`), and `adapter.fetchChapterInput` (step 9 via `executeWalkthrough`).
- **`refreshSession` extracted** from `auth-check.ts` into an exported helper reused by both the stale-probe branch and the new retry wrapper — single implementation.
- **Duplicate log removed**: `"auth session loaded"` was logged once per `createFallbackHttp` call; since both the probe client and each adapter construct their own instance, it appeared twice. Removed entirely (Logger has no `debug` level; line was decorative).

## Test plan

- [ ] `bun test` — 0 fail (was 394 before, grew by 6 new retry scenarios)
- [ ] `bun run typecheck` — exit 0
- [ ] `bun run check` — exit 0
- [ ] Probe URL assertion: `auth-check.test.ts` asserts captured URL contains `/search/story/`
- [ ] Search CF retry: CF on first call → refresh → retry returns hits; assert `search` called twice, `refresh` once
- [ ] Search CF + refresh WalkthroughError → `runWalkthrough` returns `{ ok: false }`
- [ ] `listChapters` CF retry: same shape
- [ ] `fetchChapterInput` CF retry: same shape
- [ ] Non-CF error from search → no retry, re-thrown immediately

## What did not change

- `src/integrations/` behavior (only removed a log line; no request logic changed)
- `src/sources/adapters/` core logic
- `src/modules/`, `src/pack/`
- Existing test coverage for auth-check (all 8 prior tests still pass)

## Reviewer notes

- `refreshSession` is now the single source of truth for the delete → prompt → persist → re-probe flow. `auth-check.ts` calls it; the retry wrapper calls it via the `refreshFn` closure threaded from the orchestrator.
- `__scanldr_probe__` was chosen as the benign query — no real manga title matches it; the search returns an empty results page (200) on a valid session.
- Single retry only. A second CF failure after refresh is a `WalkthroughError`, not an infinite loop.
- `refreshFn` in `RunWalkthroughOptions` is the test injection point; production resolves `authPath` from XDG and calls `refreshSession`.
- `fetchChapterInput` retry is inside `executeWalkthrough` — the simpler boundary as execute already receives `adapter` and `logger`. Threading `refreshFn` through `ExecuteWalkthroughInput` adds one optional field.

## Closes

Nothing — standalone bug fix.