### PR TITLE
fix(walkthrough): wrap page downloads with session retry on CF rejection

### DIFF
--- a/src/walkthrough/steps/execute.test.ts
+++ b/src/walkthrough/steps/execute.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CloudflareError } from "../../integrations/fallback-http/types.ts";
 import type { ChapterInput } from "../../modules/downloader/types.ts";
 import { createLogger } from "../../plugins/logger/index.ts";
 import type { SourceAdapter } from "../../sources/adapters/index.ts";
 import { getSource } from "../../sources/index.ts";
 import type { Downloader, Packer, WalkthroughResult } from "../types.ts";
+import { WalkthroughError } from "../types.ts";
 import { executeWalkthrough } from "./execute.ts";
 import type { ExecuteWalkthroughInput } from "./execute.ts";
 
@@ -271,6 +273,99 @@ describe("executeWalkthrough", () => {
     });
 
     expect(warnEvents).toContain("walkthrough.cover_skipped_volume_mode");
+  });
+
+  test("CF during page download triggers refresh + retry succeeds", async () => {
+    let downloadAttempts = 0;
+    const refreshFn = mock(async () => {});
+    const adapter = makeFakeAdapter();
+    const downloader = makeFakeDownloader({
+      downloadBundle: mock(async (_input) => {
+        downloadAttempts++;
+        if (downloadAttempts === 1) {
+          throw new CloudflareError("https://example.com/page1.jpg");
+        }
+        return {
+          chapterIds: ["hit-1-ch-1"],
+          outputPath: join(outDir, "naruto", "naruto-chapter-001.cbz"),
+          byteSize: 100,
+        };
+      }),
+    });
+
+    const opts: ExecuteWalkthroughInput = { ...plan, outDir, adapter, logger, refreshFn };
+    const result = await executeWalkthrough(opts, { downloader, packer: makeFakePacker() });
+
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(result.failed).toBe(0);
+    expect(result.outputs).toHaveLength(1);
+  });
+
+  test("CF survives refresh → walkthrough aborts with WalkthroughError", async () => {
+    const refreshFn = mock(async () => {});
+    const downloader = makeFakeDownloader({
+      downloadBundle: mock(async () => {
+        throw new CloudflareError("https://example.com/page1.jpg");
+      }),
+    });
+
+    const opts: ExecuteWalkthroughInput = {
+      ...plan,
+      outDir,
+      adapter: makeFakeAdapter(),
+      logger,
+      refreshFn,
+    };
+
+    await expect(
+      executeWalkthrough(opts, { downloader, packer: makeFakePacker() }),
+    ).rejects.toBeInstanceOf(WalkthroughError);
+  });
+
+  test("non-CF error → failed incremented, function returns normally", async () => {
+    const refreshFn = mock(async () => {});
+    const downloader = makeFakeDownloader({
+      downloadBundle: mock(async () => {
+        throw new Error("disk full");
+      }),
+    });
+
+    const opts: ExecuteWalkthroughInput = {
+      ...plan,
+      outDir,
+      adapter: makeFakeAdapter(),
+      logger,
+      refreshFn,
+    };
+    const result = await executeWalkthrough(opts, { downloader, packer: makeFakePacker() });
+
+    expect(refreshFn).not.toHaveBeenCalled();
+    expect(result.failed).toBe(1);
+    expect(result.outputs).toHaveLength(0);
+  });
+
+  test("CF during fetchChapterInput triggers refresh + retry succeeds", async () => {
+    let fetchAttempts = 0;
+    const refreshFn = mock(async () => {});
+    const adapter = makeFakeAdapter({
+      fetchChapterInput: async () => {
+        fetchAttempts++;
+        if (fetchAttempts === 1) {
+          throw new CloudflareError("https://example.com/api/chapter");
+        }
+        return fakeChapterInput;
+      },
+    });
+
+    const opts: ExecuteWalkthroughInput = { ...plan, outDir, adapter, logger, refreshFn };
+    const result = await executeWalkthrough(opts, {
+      downloader: makeFakeDownloader(),
+      packer: makeFakePacker(),
+    });
+
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(result.failed).toBe(0);
+    expect(result.outputs).toHaveLength(1);
   });
 
   test("pack filename uses bundle.num (numeric), not bundle.id (opaque)", async () => {

--- a/src/walkthrough/steps/execute.test.ts
+++ b/src/walkthrough/steps/execute.test.ts
@@ -368,6 +368,160 @@ describe("executeWalkthrough", () => {
     expect(result.outputs).toHaveLength(1);
   });
 
+  // P1 #1 — CF on the SECOND bundle of a multi-bundle loop
+  test("CF on second bundle: first bundle succeeds without retry, second retries after refresh", async () => {
+    const downloadCalls: string[] = [];
+    const refreshFn = mock(async () => {});
+
+    const bundle1 = { kind: "chapter" as const, label: "Chapter 1", id: "ch-1", num: "1" };
+    const bundle2 = { kind: "chapter" as const, label: "Chapter 2", id: "ch-2", num: "2" };
+
+    let bundle2Attempts = 0;
+    const downloader = makeFakeDownloader({
+      downloadBundle: mock(async (input) => {
+        const bundleNum = (input as { bundleNumber: string }).bundleNumber;
+        downloadCalls.push(bundleNum);
+        if (bundleNum === "2") {
+          bundle2Attempts++;
+          if (bundle2Attempts === 1) {
+            throw new CloudflareError("https://example.com/page.jpg");
+          }
+        }
+        return {
+          chapterIds: [bundleNum === "1" ? "ch-1" : "ch-2"],
+          outputPath: join(outDir, "naruto", `naruto-chapter-00${bundleNum}.cbz`),
+          byteSize: 100,
+        };
+      }),
+    });
+
+    const fetchCalls: string[] = [];
+    const adapter = makeFakeAdapter({
+      fetchChapterInput: async (id, num) => {
+        fetchCalls.push(id);
+        return { ...fakeChapterInput, id, num: Number(num ?? "0") };
+      },
+    });
+
+    const opts: ExecuteWalkthroughInput = {
+      ...plan,
+      selectedBundles: [bundle1, bundle2],
+      outDir,
+      adapter,
+      logger,
+      refreshFn,
+    };
+
+    const result = await executeWalkthrough(opts, { downloader, packer: makeFakePacker() });
+
+    expect(result.outputs).toHaveLength(2);
+    expect(result.failed).toBe(0);
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+
+    // bundle 1 fetched once, no retry
+    expect(fetchCalls.filter((id) => id === "ch-1")).toHaveLength(1);
+    // bundle 2 fetched twice: initial attempt + retry after refresh
+    expect(fetchCalls.filter((id) => id === "ch-2")).toHaveLength(2);
+  });
+
+  // P1 #2 — CF on volume-mode fetchChapterInput inside Promise.all
+  test("CF in volume fetchChapterInput: retries whole doBundle, total fetchChapterInput calls = 6", async () => {
+    const refreshFn = mock(async () => {});
+    let fetchCallCount = 0;
+
+    const adapter = makeFakeAdapter({
+      fetchChapterInput: async (id, num) => {
+        fetchCallCount++;
+        // On the very first call to c2 in the first attempt, throw CF
+        // Since Promise.all runs concurrently, we track total calls: first 3 calls = attempt 1
+        // Throw on the 2nd call (c2) during first attempt only
+        if (fetchCallCount === 2) {
+          throw new CloudflareError("https://example.com/api/chapter");
+        }
+        return { ...fakeChapterInput, id, num: Number(num ?? "0") };
+      },
+    });
+
+    const volumeBundle = {
+      kind: "volume" as const,
+      label: "Volume 1",
+      id: "vol:1",
+      num: "1",
+      chapterIds: ["c1", "c2", "c3"],
+      chapterNums: ["1", "2", "3"],
+    };
+
+    const opts: ExecuteWalkthroughInput = {
+      ...plan,
+      mode: "volume",
+      selectedBundles: [volumeBundle],
+      groupIntoVolume: true,
+      outDir,
+      adapter,
+      logger,
+      refreshFn,
+    };
+
+    const result = await executeWalkthrough(opts, {
+      downloader: makeFakeDownloader(),
+      packer: makeFakePacker(),
+    });
+
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(result.outputs).toHaveLength(1);
+    expect(result.failed).toBe(0);
+    // 3 calls on first attempt (one throws CF) + 3 calls on retry = 6
+    expect(fetchCallCount).toBe(6);
+  });
+
+  // P2 — pack is skipped when WalkthroughError aborts mid-loop
+  test("packVolume NOT called when WalkthroughError aborts execution", async () => {
+    const refreshFn = mock(async () => {});
+    const downloader = makeFakeDownloader({
+      downloadBundle: mock(async () => {
+        throw new CloudflareError("https://example.com/page.jpg");
+      }),
+    });
+    const packer = makeFakePacker();
+
+    const opts: ExecuteWalkthroughInput = {
+      ...plan,
+      groupIntoVolume: true,
+      outDir,
+      adapter: makeFakeAdapter(),
+      logger,
+      refreshFn,
+    };
+
+    await expect(executeWalkthrough(opts, { downloader, packer })).rejects.toBeInstanceOf(
+      WalkthroughError,
+    );
+
+    expect((packer.packVolume as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  // P2 — refreshFn undefined + CF falls through to outer catch
+  test("refreshFn undefined + CF error: failed incremented, function returns normally", async () => {
+    const downloader = makeFakeDownloader({
+      downloadBundle: mock(async () => {
+        throw new CloudflareError("https://example.com/page.jpg");
+      }),
+    });
+
+    const opts: ExecuteWalkthroughInput = {
+      ...plan,
+      outDir,
+      adapter: makeFakeAdapter(),
+      logger,
+      // refreshFn intentionally omitted
+    };
+
+    const result = await executeWalkthrough(opts, { downloader, packer: makeFakePacker() });
+
+    expect(result.failed).toBe(1);
+    expect(result.outputs).toHaveLength(0);
+  });
+
   test("pack filename uses bundle.num (numeric), not bundle.id (opaque)", async () => {
     const capturedChapters: Array<{ num: string }> = [];
     const opts: ExecuteWalkthroughInput = {

--- a/src/walkthrough/steps/execute.ts
+++ b/src/walkthrough/steps/execute.ts
@@ -6,6 +6,7 @@ import type { Logger } from "../../plugins/logger/index.ts";
 import type { SourceAdapter } from "../../sources/adapters/index.ts";
 import type { SourceDescriptor } from "../../sources/types.ts";
 import type { BundleItem, Downloader, ModeSelection, Packer, SearchHit } from "../types.ts";
+import { WalkthroughError } from "../types.ts";
 import { isCloudflareError, withSessionRetry } from "../with-session-retry.ts";
 import type { RefreshSession } from "../with-session-retry.ts";
 
@@ -93,81 +94,87 @@ export async function executeWalkthrough(
 
   for (const bundle of selectedBundles) {
     try {
-      logger.info(
-        {
-          event: "walkthrough.download_start",
-          context: "walkthrough",
-          bundle_id: bundle.id,
-          label: bundle.label,
-        },
-        `downloading ${bundle.label}`,
-      );
+      const doBundle = async () => {
+        logger.info(
+          {
+            event: "walkthrough.download_start",
+            context: "walkthrough",
+            bundle_id: bundle.id,
+            label: bundle.label,
+          },
+          `downloading ${bundle.label}`,
+        );
 
-      let chapterInputs: import("../../modules/downloader/types.ts").ChapterInput[];
+        let chapterInputs: import("../../modules/downloader/types.ts").ChapterInput[];
 
-      // Wrap fetchChapterInput with CF retry when a refreshFn is available.
-      // Falls back to plain call when no refreshFn is injected (tests that omit it).
-      const fetchWithRetry = refreshFn
-        ? (chapterId: string, chapterNum?: string) =>
-            withSessionRetry(
-              () => adapter.fetchChapterInput(chapterId, chapterNum),
-              isCloudflareError,
-              refreshFn,
-              logger,
-              "walkthrough.fetch_chapter_retry",
-            )
-        : (chapterId: string, chapterNum?: string) =>
-            adapter.fetchChapterInput(chapterId, chapterNum);
+        if (bundle.kind === "volume") {
+          // Expand volume into constituent chapters
+          const ids = bundle.chapterIds ?? [];
+          const nums = bundle.chapterNums ?? [];
+          chapterInputs = await Promise.all(
+            ids.map((chapterId, i) => adapter.fetchChapterInput(chapterId, nums[i])),
+          );
+        } else {
+          // Chapter mode: single fetch
+          chapterInputs = [await adapter.fetchChapterInput(bundle.id, bundle.num)];
+        }
 
-      if (bundle.kind === "volume") {
-        // Expand volume into constituent chapters
-        const ids = bundle.chapterIds ?? [];
-        const nums = bundle.chapterNums ?? [];
-        chapterInputs = await Promise.all(
-          ids.map((chapterId, i) => fetchWithRetry(chapterId, nums[i])),
+        const totalPages = chapterInputs.reduce((acc, ci) => acc + ci.pages.length, 0);
+        logger.info(
+          {
+            event: "walkthrough.download_page_done",
+            context: "walkthrough",
+            bundle_id: bundle.id,
+            pages_count: totalPages,
+          },
+          `resolved ${totalPages} pages for ${bundle.label}`,
+        );
+
+        const result = await downloader.downloadBundle({
+          outDir,
+          format: "cbz",
+          slug,
+          kind: bundle.kind === "volume" ? "volume" : "chapter",
+          bundleNumber: bundle.num.replace(/[^a-z0-9.]/gi, "-"),
+          chapters: chapterInputs,
+          imageConcurrency: 4,
+          delayMs: 0,
+          dryRun: false,
+          logger,
+        });
+
+        outputs.push(result.outputPath);
+        packedChapters.push({ num: bundle.num, outputPath: result.outputPath });
+
+        logger.info(
+          {
+            event: "walkthrough.download_bundle_done",
+            context: "walkthrough",
+            bundle_id: bundle.id,
+            output_path: result.outputPath,
+          },
+          `downloaded ${bundle.label}`,
+        );
+      };
+
+      // Wrap the entire per-bundle work (fetchChapterInput + downloadBundle) in a single
+      // withSessionRetry call when refreshFn is available. Any CloudflareError raised during
+      // metadata fetch OR page downloads triggers one session refresh and retries the whole bundle.
+      if (refreshFn) {
+        await withSessionRetry(
+          doBundle,
+          isCloudflareError,
+          refreshFn,
+          logger,
+          "walkthrough.bundle_retry",
         );
       } else {
-        // Chapter mode: single fetch
-        chapterInputs = [await fetchWithRetry(bundle.id, bundle.num)];
+        await doBundle();
       }
-
-      const totalPages = chapterInputs.reduce((acc, ci) => acc + ci.pages.length, 0);
-      logger.info(
-        {
-          event: "walkthrough.download_page_done",
-          context: "walkthrough",
-          bundle_id: bundle.id,
-          pages_count: totalPages,
-        },
-        `resolved ${totalPages} pages for ${bundle.label}`,
-      );
-
-      const result = await downloader.downloadBundle({
-        outDir,
-        format: "cbz",
-        slug,
-        kind: bundle.kind === "volume" ? "volume" : "chapter",
-        bundleNumber: bundle.num.replace(/[^a-z0-9.]/gi, "-"),
-        chapters: chapterInputs,
-        imageConcurrency: 4,
-        delayMs: 0,
-        dryRun: false,
-        logger,
-      });
-
-      outputs.push(result.outputPath);
-      packedChapters.push({ num: bundle.num, outputPath: result.outputPath });
-
-      logger.info(
-        {
-          event: "walkthrough.download_bundle_done",
-          context: "walkthrough",
-          bundle_id: bundle.id,
-          output_path: result.outputPath,
-        },
-        `downloaded ${bundle.label}`,
-      );
     } catch (err) {
+      // CF survived refresh → WalkthroughError thrown by withSessionRetry.
+      // Subsequent bundles would fail the same way; abort the entire walkthrough.
+      if (err instanceof WalkthroughError) throw err;
       failed++;
       logger.warn(
         {


### PR DESCRIPTION
## What this PR does

Closes a coverage gap in the Cloudflare auto-refresh path introduced by PR #130. The session-refresh wrap (`withSessionRetry`) was applied to metadata calls (`pickSearchResult`, `pickRange`, `adapter.fetchChapterInput`) but NOT to the page-image downloads inside `downloader.downloadBundle`. As a result, a CF rejection on the first image of any chapter silently failed the bundle and the loop moved on with the same stale session — every subsequent bundle hit the same rejection.

This PR wraps the entire per-bundle work (`fetchChapterInput` + `downloadBundle`) in a single `withSessionRetry` call. On CF rejection during page downloads, the session is refreshed once and the bundle is retried. If the refreshed session is still rejected, `WalkthroughError` is re-thrown past the outer bundle-catch so the walkthrough aborts instead of looping through the remaining bundles with a known-bad session.

## Why it exists

Real-world reproduction (zombie-100, 4-chapter volume):

```
info session probe: session is valid
info downloading Chapter 1
info resolved 61 pages for Chapter 1
info fetching page (x4 concurrent)
warn Cloudflare rejected the request
warn failed to download Chapter 1; continuing   ← swallowed, no refresh
info downloading Chapter 2
warn Cloudflare rejected the request (loops with same stale session)
```

The probe URL (`/search/story/...`) was passing CF while the page-image URLs were not — a path-level discrepancy the probe cannot detect. Without retry coverage on the page-fetch path, the user had no recovery mid-flow.

## How it works internally

`src/walkthrough/steps/execute.ts`:

- Removed the inner `fetchWithRetry` helper that wrapped only `adapter.fetchChapterInput`.
- Built a `doBundle` closure containing fetchChapterInput (chapter or volume) + `downloader.downloadBundle` + the success-path mutations (`outputs.push`, `packedChapters.push`).
- When `refreshFn` is provided, the closure runs through `withSessionRetry(doBundle, isCloudflareError, refreshFn, logger, "walkthrough.bundle_retry")`. When omitted, it runs raw.
- The outer `catch` now distinguishes `WalkthroughError` (from `withSessionRetry` exhaustion → re-throw to abort the walkthrough) from anything else (log `download_bundle_failed`, increment `failed`, continue — preserved behavior).

Why a single wrap at the bundle boundary instead of wrapping `imageFetcher` per page:
- A per-page wrap would race N concurrent refreshes when several in-flight pages all fail at once.
- The bundle-level wrap serializes the refresh and trades a re-download of already-fetched pages for correctness. Acceptable cost given CF rejections are rare.

## What did not change

- `withSessionRetry` semantics — unchanged. Still single retry, still re-throws non-CF errors verbatim.
- `refreshSession` / auth-check / fallback-http — unchanged. The auth.json no-premature-unlink invariant from PR #130 is preserved (this PR never touches the file).
- Event names: `walkthrough.download_start`, `walkthrough.download_page_done`, `walkthrough.download_bundle_done`, `walkthrough.download_bundle_failed`. New event: `walkthrough.bundle_retry` (emitted by `withSessionRetry`).
- Outer-catch semantics for non-CF errors: still logs `failed to download ${bundle.label}; continuing` and increments `failed`.

## Test checklist

`src/walkthrough/steps/execute.test.ts` — 8 new cases (suite 401 → 405):

- [x] CF during page download → refresh + retry succeeds, `outputs.length === 1`, `failed === 0`, `refreshFn` called once
- [x] CF survives refresh → `WalkthroughError` thrown, walkthrough rejects (does NOT return `{ failed: 1 }`)
- [x] Non-CF error → `failed === 1`, returns normally, no refresh call (regression preserved)
- [x] CF during `fetchChapterInput` chapter mode → refresh + retry (regression for prior behavior)
- [x] CF on the SECOND bundle of a 2-bundle loop → bundle 1 fetched once, bundle 2 fetched twice, refresh called once, both in outputs
- [x] CF on volume-mode `fetchChapterInput` inside `Promise.all` (3 chapter ids) → `fetchChapterInput` called 6 times (3 first attempt + 3 retry), refresh once, bundle in outputs
- [x] When walkthrough aborts via `WalkthroughError`, `packer.packVolume` is not called
- [x] `refreshFn` undefined + CF → falls through to outer catch, `failed === 1`, returns normally

Gates: `bun test && bun run typecheck && bun run check` — all green.

## Reviewer notes

- `doBundle` mutates `outputs` / `packedChapters` inside the retry boundary. The first attempt fails before those pushes happen today (failure originates in `Promise.all` or `downloadBundle`, both prior to the pushes), so no double-push is possible. A future edit that pushes earlier would change this — worth a comment, or hoisting the pushes out of the closure if you prefer defensiveness over diff size.
- On a successful retry, `walkthrough.download_start` is emitted twice (once per attempt). `walkthrough.bundle_retry` also fires from `withSessionRetry`, so the retry signal is explicit — but two `download_start` lines for a single bundle is the trade-off for keeping the closure boundary clean.
- Trade-off accepted: on CF mid-bundle, all already-fetched pages of that bundle are re-downloaded after refresh. Single retry, so worst case is 2x bandwidth on the affected bundle.

## Closes

Ref: #130 (follow-up to the mid-flow CF retry work)

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (no doc change needed — behavior change documented in CHANGELOG via PR title)