### PR TITLE
chore(walkthrough): include page number and chapter in fetch log

### DIFF
--- a/src/integrations/mangakakalot/client/index.ts
+++ b/src/integrations/mangakakalot/client/index.ts
@@ -36,7 +36,7 @@ export function createMangakakalotClient(opts: {
   const { http, logger } = opts;
 
   async function fetchHtml(url: string, extraHeaders?: Record<string, string>): Promise<string> {
-    logger.info({ event: "mangakakalot.fetch", context: "mangakakalot", url }, "fetching page");
+    logger.info({ event: "mangakakalot.fetch", context: "mangakakalot", url }, "fetching HTML");
     const res = await http.get(url, extraHeaders);
     return res.text();
   }

--- a/src/sources/adapters/mangakakalot.ts
+++ b/src/sources/adapters/mangakakalot.ts
@@ -114,13 +114,22 @@ export function createMangakakalotAdapter(opts: MangakakalotAdapterOptions): Sou
 
     const pages: ImageRef[] = imageRefs.map((ref, i) => ({ url: ref.url, page: i + 1 }));
 
+    const total = pages.length;
+    const chapterNumLabel = chapterNum ?? "?";
     const imageFetcher = async (ref: ImageRef): Promise<Uint8Array> => {
-      logger.info(
-        { event: "walkthrough.fetch_page", context: "walkthrough", url: ref.url },
-        "fetching page",
-      );
-      const res = await http.get(ref.url);
+      const res = await http.get(ref.url); // CloudflareError or short-circuit throws here — no log emitted
       const buf = await res.arrayBuffer();
+      logger.info(
+        {
+          event: "walkthrough.fetch_page",
+          context: "walkthrough",
+          url: ref.url,
+          page: ref.page,
+          total,
+          chapter: chapterNumLabel,
+        },
+        `fetched page ${ref.page}/${total} of chapter ${chapterNumLabel}`,
+      );
       return new Uint8Array(buf);
     };
 


### PR DESCRIPTION
## What this PR does

Two log-quality changes targeted at the image-download path:

1. `src/sources/adapters/mangakakalot.ts` — the `imageFetcher` now logs **after** `http.get` resolves successfully. The human message becomes `fetched page X/N of chapter Y` (past tense), with `page`, `total`, and `chapter` added as structured fields. The `event` string `walkthrough.fetch_page` is unchanged.
2. `src/integrations/mangakakalot/client/index.ts` — the generic `fetchHtml` log message renamed from `"fetching page"` (misleading: it fetches HTML for search and chapter list) to `"fetching HTML"`. `event: "mangakakalot.fetch"` unchanged.

## Why it exists

After PR #134 made `fallback-http`'s `http.get` short-circuit instantly when CloudFlare is latched, the downloader's semaphore drains all queued image-fetch tasks in microseconds. Each task was emitting `info fetching page` BEFORE calling `http.get`, so a single CF detection produced a burst of ~60 identical `fetching page` lines in roughly 5 ms — burying the cURL paste prompt and making the user think the program had frozen.

Real log from a 61-page chapter:

```
18:43:53.020 warn Cloudflare rejected the request
18:43:53.021 warn Cloudflare rejected; refreshing session and retrying
18:43:53.021–025 info fetching page (×60 — entire semaphore queue drains via short-circuit)
? No valid session found. Paste a cURL command...   ← prompt visible only at the bottom
```

The user reported "não sei dizer se travou" — could not tell if the program was frozen, since the prompt was hidden under the burst.

This PR also addresses an unrelated UX gripe ("não dá pra saber a página que tá fazendo fetching") by adding the page index, total, and chapter to the log.

## How it works internally

In `mangakakalot.ts`, the `imageFetcher` closure captures `total = pages.length` and `chapterNumLabel = chapterNum ?? "?"` from the surrounding scope. The log is emitted only after `await http.get(ref.url)` returns successfully — when `http.get` rejects (with `CloudflareError`, network error, or the new short-circuit throw), the `await` propagates the rejection and the log line is unreachable.

Result on a clean run: one `fetched page X/N of chapter Y` line per successful page, at the ~1 Hz cadence imposed by the fallback-http throttle. On a CF-rejection cascade: zero `fetched page` lines, only the legitimate `Cloudflare rejected the request` from the actual 403 and the `Cloudflare rejected; refreshing session and retrying` from `withSessionRetry`.

`mangakakalot/client/index.ts` change is a single string rename — no behavior change.

## What did not change

- `event` field `walkthrough.fetch_page` preserved — structured-log consumers / dashboards keep working.
- `event` field `mangakakalot.fetch` preserved.
- `fallback-http` short-circuit semantics from PR #134 — unchanged.
- `withSessionRetry`, `executeWalkthrough`, downloader semaphore — unchanged.
- No new tests added; no existing test relied on the old message strings.

## Test checklist

- [x] `bun test` — 410 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean
- [x] grep confirmed no test asserts the changed strings (`"fetching page"` / `walkthrough.fetch_page` message)
- [ ] Manual smoke: real run on a chapter with a stale session — confirm the post-CF burst is gone and prompt is visible

## Reviewer notes

- Inline comment at `mangakakalot.ts:120` (`// CloudflareError or short-circuit throws here — no log emitted`) is a guardrail comment so a future edit doesn't accidentally move the log before the `await`. Drop it if you prefer the function to speak for itself.
- The deeper architectural fix (AbortSignal propagated through `downloader.downloadBundle` so queued tasks are cancelled rather than drained-via-short-circuit) is still deferred. This PR just makes the drain silent.

## Closes

Follow-up to #134.

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (no doc change needed — log message cosmetic)