### PR TITLE
feat(walkthrough): prompt for volume number before packing

### DIFF
--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -1,4 +1,4 @@
 // Public API for pack primitives used by the walkthrough.
 export { fetchCover } from "./cover.ts";
-export { packVolume } from "./pack.ts";
+export { buildVolumeFilename, packVolume } from "./pack.ts";
 export type { PackedChapter, PackVolumeInput, PackVolumeResult } from "./types.ts";

--- a/src/walkthrough/index.ts
+++ b/src/walkthrough/index.ts
@@ -12,6 +12,7 @@ import { pickRange } from "./steps/range-picker.ts";
 import { pickSearchResult } from "./steps/search-results-picker.ts";
 import { pickSource } from "./steps/source-picker.ts";
 import { promptTitle } from "./steps/title-prompt.ts";
+import { promptVolumeName } from "./steps/volume-name-prompt.ts";
 import type {
   SessionProbeClientFactory,
   WalkthroughCancelled,
@@ -141,6 +142,12 @@ export async function runWalkthrough(
     // volume mode always packs
     const groupIntoVolume = mode === "volume" ? true : await promptPack();
 
+    // Step 7b — volume name (chapter mode + groupIntoVolume only; volume mode uses bundle.num)
+    const volumeName =
+      mode === "chapter" && groupIntoVolume
+        ? await promptVolumeName({ logger: opts.logger })
+        : null;
+
     // Step 8 — cover URL (only when packing)
     const coverUrl = groupIntoVolume ? await promptCoverUrl({ logger: opts.logger }) : null;
 
@@ -151,6 +158,7 @@ export async function runWalkthrough(
       mode,
       selectedBundles,
       groupIntoVolume,
+      volumeName,
       coverUrl,
     };
 
@@ -162,6 +170,7 @@ export async function runWalkthrough(
         mode,
         selectedBundles,
         groupIntoVolume,
+        volumeName,
         coverUrl,
         outDir,
         adapter,

--- a/src/walkthrough/steps/execute.test.ts
+++ b/src/walkthrough/steps/execute.test.ts
@@ -20,6 +20,7 @@ const plan: WalkthroughResult = {
   mode: "chapter",
   selectedBundles: [{ kind: "chapter", label: "Chapter 1", id: "hit-1-ch-1", num: "1" }],
   groupIntoVolume: false,
+  volumeName: null,
   coverUrl: null,
 };
 

--- a/src/walkthrough/steps/execute.ts
+++ b/src/walkthrough/steps/execute.ts
@@ -1,6 +1,6 @@
 import { downloadBundle as realDownloadBundle } from "../../modules/downloader/index.ts";
 import type { PackedChapter } from "../../pack/index.ts";
-import { fetchCover, packVolume as realPackVolume } from "../../pack/index.ts";
+import { buildVolumeFilename, fetchCover, packVolume as realPackVolume } from "../../pack/index.ts";
 import type { Logger } from "../../plugins/logger/index.ts";
 import type { SourceAdapter } from "../../sources/adapters/index.ts";
 import type { SourceDescriptor } from "../../sources/types.ts";
@@ -15,6 +15,8 @@ export interface ExecuteWalkthroughInput {
   mode: ModeSelection;
   selectedBundles: BundleItem[];
   groupIntoVolume: boolean;
+  /** Optional user-supplied volume number/name; null = auto-derive from chapter range. */
+  volumeName?: string | null;
   coverUrl: string | null;
   outDir: string;
   adapter: SourceAdapter;
@@ -64,6 +66,7 @@ export async function executeWalkthrough(
     mode,
     selectedBundles,
     groupIntoVolume,
+    volumeName,
     coverUrl,
     outDir,
     adapter,
@@ -207,11 +210,14 @@ export async function executeWalkthrough(
         }
       }
 
+      const customName = volumeName ? buildVolumeFilename(slug, volumeName) : undefined;
+
       const packResult = await packer.packVolume({
         slug,
         outDir,
         chapters: packedChapters,
         cover,
+        customName,
         logger,
       });
 

--- a/src/walkthrough/steps/volume-name-prompt.test.ts
+++ b/src/walkthrough/steps/volume-name-prompt.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createLogger } from "../../plugins/logger/index.ts";
+
+const logger = createLogger({ level: "info", format: "human", write: () => {} });
+
+describe("promptVolumeName", () => {
+  test("empty input returns null (keeps auto-generated name)", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async () => "",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptVolumeName } = await import("./volume-name-prompt.ts");
+    expect(await promptVolumeName({ logger })).toBeNull();
+  });
+
+  test("whitespace-only input returns null", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async () => "   ",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptVolumeName } = await import("./volume-name-prompt.ts");
+    expect(await promptVolumeName({ logger })).toBeNull();
+  });
+
+  test("plain number returns the trimmed string", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async () => "  1  ",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptVolumeName } = await import("./volume-name-prompt.ts");
+    expect(await promptVolumeName({ logger })).toBe("1");
+  });
+
+  test("descriptive name with spaces is accepted", async () => {
+    mock.module("../prompts.ts", () => ({
+      input: async () => "special edition",
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptVolumeName } = await import("./volume-name-prompt.ts");
+    expect(await promptVolumeName({ logger })).toBe("special edition");
+  });
+
+  test("path separator rejected twice then returns null", async () => {
+    let calls = 0;
+    const warnEvents: string[] = [];
+    const warnLogger = createLogger({ level: "info", format: "human", write: () => {} });
+    const origWarn = warnLogger.warn.bind(warnLogger);
+    (warnLogger as { warn: typeof warnLogger.warn }).warn = (
+      fields: Record<string, unknown>,
+      msg: string,
+    ) => {
+      if (typeof fields.event === "string") warnEvents.push(fields.event);
+      origWarn(fields, msg);
+    };
+
+    mock.module("../prompts.ts", () => ({
+      input: async () => {
+        calls++;
+        return "../escape";
+      },
+      select: async () => "",
+      checkbox: async () => [],
+      confirm: async () => false,
+      editor: async () => "",
+    }));
+    const { promptVolumeName } = await import("./volume-name-prompt.ts");
+    const result = await promptVolumeName({ logger: warnLogger });
+    expect(result).toBeNull();
+    expect(calls).toBe(2);
+    expect(warnEvents).toContain("walkthrough.volume_name_invalid");
+  });
+});

--- a/src/walkthrough/steps/volume-name-prompt.ts
+++ b/src/walkthrough/steps/volume-name-prompt.ts
@@ -1,0 +1,46 @@
+import type { Logger } from "../../plugins/logger/index.ts";
+import { input } from "../prompts.ts";
+
+const MAX_RETRIES = 2;
+
+function isUnsafeName(value: string): boolean {
+  if (value.includes("/") || value.includes("\\")) return true;
+  return value.split(/[\\/]/).some((s) => s === "..");
+}
+
+export interface VolumeNamePromptOptions {
+  logger: Logger;
+}
+
+/**
+ * Step 7b (chapter mode + groupIntoVolume only): ask the user for a volume
+ * number or custom name. Empty input keeps the chapter-range-derived default.
+ */
+export async function promptVolumeName(opts: VolumeNamePromptOptions): Promise<string | null> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const raw = await input({
+      message: "Volume number or name? (Enter to keep chapter range)",
+      default: "",
+    });
+
+    const trimmed = raw.trim();
+    if (trimmed === "") return null;
+
+    if (!isUnsafeName(trimmed)) return trimmed;
+
+    const remaining = MAX_RETRIES - attempt - 1;
+    if (remaining > 0) {
+      opts.logger.warn(
+        {
+          event: "walkthrough.volume_name_invalid",
+          context: "walkthrough",
+          attempt: attempt + 1,
+          name_input: trimmed,
+        },
+        "Volume name cannot contain '/', '\\', or '..'; try again",
+      );
+    }
+  }
+
+  return null;
+}

--- a/src/walkthrough/types.ts
+++ b/src/walkthrough/types.ts
@@ -97,6 +97,11 @@ export interface WalkthroughResult {
   mode: ModeSelection;
   selectedBundles: BundleItem[];
   groupIntoVolume: boolean;
+  /**
+   * User-supplied volume number/name for the packed cbz, chapter mode only.
+   * null = use the chapter-range-derived default.
+   */
+  volumeName: string | null;
   coverUrl: string | null;
 }
 

--- a/src/walkthrough/walkthrough.test.ts
+++ b/src/walkthrough/walkthrough.test.ts
@@ -76,6 +76,7 @@ describe("runWalkthrough — full happy path", () => {
       input: async () => {
         inputCall++;
         if (inputCall === 1) return "Naruto"; // title
+        if (inputCall === 2) return ""; // volume name (keep default)
         return "https://example.com/cover.jpg"; // cover URL
       },
       select: async () => {
@@ -116,6 +117,46 @@ describe("runWalkthrough — full happy path", () => {
     for (const ch of chapters) {
       expect(Number.isNaN(Number(ch.num))).toBe(false);
     }
+  });
+
+  test("mode=chapter + group=true + custom volume name → packer receives buildVolumeFilename stem", async () => {
+    let inputCall = 0;
+    let selectCall = 0;
+    mock.module("./prompts.ts", () => ({
+      input: async () => {
+        inputCall++;
+        if (inputCall === 1) return "Naruto"; // title
+        if (inputCall === 2) return "1"; // volume name
+        return ""; // cover URL skipped
+      },
+      select: async () => {
+        selectCall++;
+        if (selectCall === 1) return "mangadex";
+        if (selectCall === 2) return "mock-1";
+        return "chapter";
+      },
+      checkbox: async () => ["mock-1-ch-1"],
+      confirm: async () => true,
+      editor: async () => "",
+    }));
+
+    selectCall = 0;
+    inputCall = 0;
+    const fakeDownloader = makeFakeDownloader();
+    const fakePacker = makeFakePacker();
+    const { runWalkthrough } = await import("./index.ts");
+    const result = await runWalkthrough({
+      logger,
+      outDir,
+      adapterFactory: fakeAdapterFactory,
+      executeDeps: { downloader: fakeDownloader, packer: fakePacker },
+    });
+    if ("cancelled" in result) throw new Error("Unexpected cancellation");
+    if ("ok" in result) throw new Error(`Unexpected failure: ${result.reason}`);
+    expect(result.volumeName).toBe("1");
+    const packCall = (fakePacker.packVolume as ReturnType<typeof mock>).mock.calls[0];
+    const customName = (packCall as [{ customName?: string }])[0].customName;
+    expect(customName).toBe("naruto-volume-1.cbz");
   });
 
   test("mode=volume (auto-pack) → downloader called per volume, packer called once per volume", async () => {


### PR DESCRIPTION
## What this PR does

Adds a missing prompt in the chapter-mode walkthrough so the user can name the packed volume instead of always getting the auto-derived chapter-range filename.

- New step `src/walkthrough/steps/volume-name-prompt.ts` — asks `Volume number or name? (Enter to keep chapter range)`. Empty input returns `null` (keep auto default); `/`, `\`, `..` are rejected with one retry and then fall back to `null` (matches the cover-prompt's max-2-retries pattern).
- `src/walkthrough/index.ts:144` — fires the prompt only when `mode === "chapter" && groupIntoVolume`. Volume mode is unchanged: the downloader already names the cbz with `bundle.num` directly.
- `src/walkthrough/steps/execute.ts` — receives `volumeName`, and when present builds `customName = buildVolumeFilename(slug, volumeName)` before calling `packer.packVolume`. Empty / null keeps the existing `defaultVolumeName(slug, sorted)` path inside `pack.ts`.
- `src/pack/index.ts` — re-exports `buildVolumeFilename` (was internal to `pack.ts`).
- `WalkthroughResult` gains `volumeName: string | null` so the assembled plan reflects what the user typed.

## Why it exists

Live walkthrough on `zombie-100`, chapters 1–3.5, group-into-volume = yes:

```
✔ Select chapters to download: [1] Chapter 1, [2] Chapter 2, [3] Chapter 3, [4] Chapter 3.5
✔ Group these chapters into a single volume? Yes
? Cover image URL? (Enter to skip)
```

The walkthrough jumped straight from the group-into-volume confirm to the cover URL — there was no opportunity to say "this is Volume 1." The packer fell back to `defaultVolumeName()` and produced `zombie-100-volume-001-3.5.cbz` instead of `zombie-100-volume-1.cbz`.

The `customName` field on `PackVolumeInput` already existed (and is exercised by the `--pack <name>` CLI tests in `src/pack/pack.test.ts`), but the walkthrough never set it. This PR closes that gap.

## How it works internally

`src/walkthrough/steps/volume-name-prompt.ts` mirrors `cover-prompt.ts`:

- One `input` call with `default: ""`.
- Trim → empty → return `null` (keep auto).
- Otherwise validate against `/`, `\`, and `..` segments. On invalid input, emit `walkthrough.volume_name_invalid` warn and re-prompt up to `MAX_RETRIES = 2`. After that, return `null` so the walkthrough doesn't dead-end the user.

`src/walkthrough/index.ts`:

```ts
const volumeName =
  mode === "chapter" && groupIntoVolume
    ? await promptVolumeName({ logger: opts.logger })
    : null;
```

Threads `volumeName` into `WalkthroughResult` and `executeWalkthrough`.

`src/walkthrough/steps/execute.ts` only touches the chapter-mode pack branch:

```ts
const customName = volumeName ? buildVolumeFilename(slug, volumeName) : undefined;
await packer.packVolume({ slug, outDir, chapters: packedChapters, cover, customName, logger });
```

`buildVolumeFilename(slug, "1")` returns `"<slug>-volume-1.cbz"`. `pack.ts:101` already handles the `.cbz` strip (`stem.endsWith(".cbz") ? stem : ${stem}.cbz`), so passing the full filename works without double-extension. Path-traversal rejection in `pack.ts:85-97` remains the authoritative guard; the prompt-side validation is just a UX fast-path.

## What did not change

- Volume mode (`mode === "volume"`): no new prompt. The downloader already produces the final cbz per volume using `bundle.num` from the adapter; adding a prompt here would override an authoritative source name.
- `mode === "chapter" && groupIntoVolume === false`: no new prompt; nothing is packed.
- `pack.ts` — `packVolume` signature, `defaultVolumeName`, `buildVolumeFilename`, and the path-traversal rejection are all untouched. Only `pack/index.ts` is touched to re-export `buildVolumeFilename`.
- `cover-prompt.ts`, `pack-prompt.ts`, `range-picker.ts`, downloader semaphore, `withSessionRetry`, CF latch — all unchanged.
- The `--pack <name>` CLI flag (still only exercised by tests, not wired into `src/index.ts`) — out of scope.

## Test checklist

- [x] `bun test` — 420 pass, 0 fail (was 414 before; +6 new cases).
- [x] `bun run typecheck` — clean.
- [x] `bun run check` — clean.
- [x] New: `volume-name-prompt.test.ts` — empty / whitespace returns `null`; plain number returns trimmed string; spaces in descriptive name accepted; `../escape` is rejected with one retry and emits `walkthrough.volume_name_invalid`.
- [x] New e2e in `walkthrough.test.ts` — `mode=chapter + group=true + custom volume name "1"` asserts `result.volumeName === "1"` AND the packer received `customName: "naruto-volume-1.cbz"`.
- [x] Existing happy-path `walkthrough.test.ts` updated to feed `""` for the new prompt (default-path coverage).
- [x] `execute.test.ts` `plan` fixture updated with `volumeName: null` — keeps existing assertions on `groupIntoVolume`, CF retries, and packer-skipped-on-volume-mode intact.
- [ ] Manual smoke: run `bun start` on `zombie-100`, chapters 1–3.5, group=yes, type `1`, expect `zombie-100-100-things-i-want-to-do-before-i-become-a-zombie/zombie-100-100-things-i-want-to-do-before-i-become-a-zombie-volume-1.cbz`.

## Reviewer notes

- `buildVolumeFilename` is re-exported from `pack/index.ts` rather than reimplementing the `<slug>-volume-<x>.cbz` convention in the walkthrough. Trade-off: the walkthrough now depends on a pack-layer helper. Justification: this convention is already canonical in `pack.ts` and was previously only tested inside that module; exporting it keeps the source of truth in one place.
- Validation lives in both the prompt (`volume-name-prompt.ts:8`) and the packer (`pack.ts:85-97`). The prompt copy is intentional UX: gives the user an immediate retry instead of bubbling a `CliError` from `packVolume` after all downloads finished.
- After `MAX_RETRIES`, the prompt silently falls back to `null` (auto name). This matches `cover-prompt.ts`'s "skip gracefully" stance and was chosen over aborting the walkthrough because the user has already paid the download cost by this point.
- `volumeName` is optional on `ExecuteWalkthroughInput` (`volumeName?: string | null`) so existing test fixtures that pre-date this PR don't have to be touched if they don't care about it. The walkthrough orchestrator always passes it explicitly.

## Closes

Reported in a live walkthrough session: `zombie-100` chapters 1–3.5 grouped into a single volume produced `volume-001-3.5.cbz` with no way to name it `volume-1`.

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` — none needed (walkthrough UX change, no architectural change)