### PR TITLE
fix(walkthrough): respect config.default_out for download path

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for config.default_out → runWalkthrough({ outDir }) wiring.
+ * Uses injectable deps to avoid real DB / TTY interaction.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LoadConfigResult } from "@plugins/config/index.ts";
+import { DEFAULT_CONFIG } from "@plugins/config/index.ts";
+import { main } from "./index.ts";
+import type { RunWalkthroughOptions, WalkthroughFailed } from "./walkthrough/index.ts";
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "scanldr-main-test-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+function makeLoadConfig(
+  overrides: Partial<typeof DEFAULT_CONFIG> = {},
+): () => Promise<LoadConfigResult> {
+  return async () => ({
+    config: {
+      ...DEFAULT_CONFIG,
+      // point db_path at a temp file so openDb doesn't pollute real paths
+      db_path: join(workDir, "test.db"),
+      ...overrides,
+    },
+    source: null,
+  });
+}
+
+// Returns a fake walkthrough that records its options and resolves without calling process.exit.
+// We must NOT return { cancelled: true } because main() calls process.exit(130) on that path.
+// WalkthroughFailed ({ ok: false, reason }) is safe — main() does not exit on that path.
+function makeSpyWalkthrough(spy: {
+  calledWith: RunWalkthroughOptions | null;
+}): (opts: RunWalkthroughOptions) => Promise<WalkthroughFailed> {
+  return async (opts) => {
+    spy.calledWith = opts;
+    return { ok: false, reason: "spy" };
+  };
+}
+
+describe("main() — config.default_out wiring", () => {
+  test("forwards config.default_out to runWalkthrough as outDir", async () => {
+    const spy = { calledWith: null as RunWalkthroughOptions | null };
+
+    await main([], {
+      loadConfigFn: makeLoadConfig({ default_out: "./download" }),
+      runWalkthroughFn: makeSpyWalkthrough(spy),
+    });
+
+    expect(spy.calledWith?.outDir).toBe("./download");
+  });
+
+  test("forwards absolute default_out unchanged", async () => {
+    const spy = { calledWith: null as RunWalkthroughOptions | null };
+    const absPath = "/tmp/my-manga-downloads";
+
+    await main([], {
+      loadConfigFn: makeLoadConfig({ default_out: absPath }),
+      runWalkthroughFn: makeSpyWalkthrough(spy),
+    });
+
+    expect(spy.calledWith?.outDir).toBe(absPath);
+  });
+
+  test("when config has no custom default_out, DEFAULT_CONFIG value is forwarded", async () => {
+    // DEFAULT_CONFIG.default_out = "./download" — the walkthrough internal fallback to cwd()
+    // is only reached when outDir is undefined; here we verify the call shape.
+    const spy = { calledWith: null as RunWalkthroughOptions | null };
+
+    await main([], {
+      loadConfigFn: makeLoadConfig(),
+      runWalkthroughFn: makeSpyWalkthrough(spy),
+    });
+
+    expect(spy.calledWith?.outDir).toBe(DEFAULT_CONFIG.default_out);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,14 @@ export function resolveLogConfig(values: {
   return { level, format };
 }
 
-export async function main(argv: string[]): Promise<void> {
+export interface MainDeps {
+  loadConfigFn?: typeof loadConfig;
+  runWalkthroughFn?: typeof runWalkthrough;
+}
+
+export async function main(argv: string[], deps: MainDeps = {}): Promise<void> {
+  const { loadConfigFn = loadConfig, runWalkthroughFn = runWalkthrough } = deps;
+
   const { values, positionals } = parseArgs({
     args: argv,
     allowPositionals: true,
@@ -74,14 +81,14 @@ export async function main(argv: string[]): Promise<void> {
 
   const { level, format } = resolveLogConfig(values);
 
-  const { config } = await loadConfig();
+  const { config } = await loadConfigFn();
   const db = openDb(config.db_path);
   runMigrations(db);
 
   const traceStore = createTraceStore({ db });
   const logger = createLogger({ level, format }, traceStore);
 
-  const result = await runWalkthrough({ logger });
+  const result = await runWalkthroughFn({ logger, outDir: config.default_out });
   if (typeof result === "object" && "cancelled" in result && result.cancelled) {
     process.exit(130);
   }


### PR DESCRIPTION
## What this PR does

- Threads `config.default_out` (default `"./download"`) into `runWalkthrough({ outDir })` in `src/index.ts`. This is the production fix — one line.
- Refactors `main()` to accept an optional `MainDeps` object (`loadConfigFn`, `runWalkthroughFn`) so the wire is testable. Defaults preserve production behaviour 1:1; existing callers of `main(argv)` are unaffected.
- Adds `src/index.test.ts` with 3 tests asserting the contract: relative path forwarded, absolute path forwarded unchanged, default config value forwarded.

## Why it exists

Regressão da Phase 4 do épico #116 (commit `15aa8f3`). O comando legado `runDownload` era o único consumidor de `config.default_out`; quando ele foi removido, ninguém reconectou o campo ao novo walkthrough. Resultado: artefatos `.cbz` caem em `<cwd>/<slug>/` em vez de `./download/<slug>/`.

Ref: #138

## How it works internally

`src/index.ts:90`:

```ts
const result = await runWalkthroughFn({ logger, outDir: config.default_out });
```

O fallback para `process.cwd()` continua em `src/walkthrough/index.ts:69` — ele só dispara quando `outDir` é `undefined`. Como `loadConfig()` sempre devolve `default_out` populado (default ou override via `scanldr.json`), o fallback raramente é exercitado em produção, mas permanece para callers programáticos do walkthrough.

`MainDeps` fica no próprio `index.ts` por ser o entrypoint da CLI (único arquivo flat permitido em `src/`, sem `src/types.ts`).

## What did not change

- `src/walkthrough/index.ts` — fallback para `process.cwd()` mantido intencionalmente.
- `src/plugins/config/index.ts` — defaults inalterados.
- Nenhuma flag de CLI nova (`--out-dir`) — fora de escopo da issue.

## Test checklist

- [x] `bun test` — 423 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` (Biome) — clean
- [x] AC: caminho relativo (`./download`) repassado ao walkthrough
- [x] AC: caminho absoluto repassado sem mutação
- [x] AC: wire `loadConfig().default_out → runWalkthrough({ outDir })` explicitamente asserido
- [x] AC: fallback para o default da config preserva o comportamento atual

## Reviewer notes

- `MainDeps` poderia ser inline (`deps: { ... } = {}`) em vez de interface nomeada — escolhi nomear porque facilita a inspeção do shape em tooling. Flip se preferir inline.
- Inspector apontou que a AC "fallback quando `default_out` ausente/inválido" é estruturalmente garantida pelo validador em `plugins/config/index.ts:105-112` (rejeita não-string ou vazio em tempo de `loadConfig`). O `main()` nunca recebe `default_out` inválido, então não há teste explícito no nível do entrypoint — coberto pelo validador.

## Closes

Ref: #138

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (if applicable) — N/A