### PR TITLE
fix(walkthrough): use english label for chapter mode option

### DIFF
--- a/src/walkthrough/steps/mode-picker.ts
+++ b/src/walkthrough/steps/mode-picker.ts
@@ -6,7 +6,7 @@ export async function pickMode(): Promise<ModeSelection> {
   const result = await select<ModeSelection>({
     message: "Download mode:",
     choices: [
-      { name: "[1] Capítulo", value: "chapter" },
+      { name: "[1] Chapter", value: "chapter" },
       { name: "[2] Volume", value: "volume" },
     ],
   });


### PR DESCRIPTION
## What this PR does

Replaces the Portuguese label `"[1] Capítulo"` with `"[1] Chapter"` in the download-mode picker.

## Why it exists

Every other user-facing string in the walkthrough is English (`"Download mode:"`, `"[2] Volume"`, `"Select manga:"`, etc.). This one Portuguese label slipped through and was visibly inconsistent in the prompt.

## How it works internally

Single-line change in `src/walkthrough/steps/mode-picker.ts`:

```ts
- { name: "[1] Capítulo", value: "chapter" },
+ { name: "[1] Chapter",  value: "chapter" },
```

The `value: "chapter"` is unchanged, so no downstream code (pack mode, range picker, execute step) is affected.

## What did not change

- `value: "chapter"` — the internal mode identifier
- `"[2] Volume"` choice (already English)
- All other walkthrough steps and tests

## Test checklist

- [x] `bun test` — 414 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run check` — biome clean
- [x] Grep verified: no other `Capítulo`/`Capitulo` occurrences remain
- [x] No test asserts on the literal `"[1] Capítulo"` string

## Reviewer notes

Cosmetic-only change. Zero behavioral impact.

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (N/A)