### PR TITLE
fix(fallback-http): skip CF body peek for binary content-types

### DIFF
--- a/src/integrations/fallback-http/fallback-http.test.ts
+++ b/src/integrations/fallback-http/fallback-http.test.ts
@@ -866,6 +866,41 @@ test("200 with real manga HTML is returned to caller without throwing", async ()
 });
 
 // ---------------------------------------------------------------------------
+// Test 21b: Binary response (image/webp) is returned byte-perfect — no UTF-8 mangling
+// ---------------------------------------------------------------------------
+
+test("200 with image/webp content-type returns binary body unchanged", async () => {
+  const { logger } = makeLogger();
+  const path = await writeAuth(tmpDir, VALID_SESSION);
+
+  // WebP magic bytes + bytes that are invalid UTF-8 (would become EF BF BD if decoded as text)
+  const original = new Uint8Array([
+    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x80, 0xff, 0xc0, 0xef,
+    0xbf, 0xbe, 0xaa, 0xbb, 0xcc, 0xdd,
+  ]);
+
+  const fakeFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response> =
+    async () =>
+      new Response(original, {
+        status: 200,
+        headers: { "content-type": "image/webp" },
+      });
+
+  const client = await createFallbackHttp({
+    authPath: path,
+    logger,
+    fetch: fakeFetch,
+    sleep: async () => {},
+    now: () => 0,
+  });
+
+  const res = await client.getAnonymous("https://cdn.example.com/page.webp");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  expect(buf.length).toBe(original.length);
+  expect(Array.from(buf)).toEqual(Array.from(original));
+});
+
+// ---------------------------------------------------------------------------
 // Test 22: Short-circuit after 403 — second call skips HTTP (fetch called once)
 // ---------------------------------------------------------------------------
 

--- a/src/integrations/fallback-http/service.ts
+++ b/src/integrations/fallback-http/service.ts
@@ -193,6 +193,14 @@ export async function createFallbackHttp(opts: FallbackHttpOptions): Promise<Fal
 
       // 200 with CF challenge HTML — treat symmetrically with 403.
       if (res && res.status >= 200 && res.status < 300) {
+        const contentType = res.headers.get("content-type") ?? "";
+        // CF challenge pages are HTML. Binary responses (images, etc.) must never
+        // be decoded as text — doing so corrupts bytes not valid in UTF-8.
+        const isTextual =
+          /^(text\/|application\/(json|xml|xhtml\+xml))/i.test(contentType) || contentType === "";
+        if (!isTextual) {
+          return res;
+        }
         const body = await peekCfBody(res);
         if (body !== null && isCfChallengeHtml(body)) {
           logger.warn(


### PR DESCRIPTION
## What this PR does

Gates the Cloudflare-challenge body inspection in `fallback-http`'s `dispatch` behind a `Content-Type` check. Binary responses (e.g. `image/webp`, `image/jpeg`, `application/octet-stream`) are now returned untouched; only textual/empty content-types go through `peekCfBody` + `rebuildResponse`.

## Why it exists

Every image inside a CBZ packed by `scanldr` was corrupted — hex dumps of the extracted pages showed `EF BF BD` (UTF-8 replacement character `U+FFFD`) scattered through WebP `RIFF` headers and payloads, making them unrenderable.

Root cause: `dispatch` unconditionally called `peekCfBody(res)` (which is `res.text()`) on every 200 response to scan for CF challenge HTML, then wrapped the resulting **string** into `new Response(body, ...)`. When the mangakakalot image fetcher later called `res.arrayBuffer()`, the bytes were reconstructed from a UTF-8-decoded string — every byte that wasn't valid UTF-8 had been replaced with `U+FFFD`, which serialized back as `EF BF BD`. The CDN's bytes were destroyed before they ever reached the zip writer.

## How it works internally

In `src/integrations/fallback-http/service.ts:194-216`:

```ts
if (res && res.status >= 200 && res.status < 300) {
  const contentType = res.headers.get("content-type") ?? "";
  const isTextual =
    contentType === "" ||
    /^(text\/|application\/(json|xml|xhtml\+xml))/i.test(contentType);
  if (!isTextual) {
    // Binary response — return as-is (no peek, no rebuild).
    return res;
  }
  const body = await peekCfBody(res);
  // ...CF challenge check + rebuildResponse for textual bodies (unchanged)
}
```

- Empty/missing `Content-Type` is conservatively treated as textual, preserving the existing CF check for endpoints that don't advertise their type. CF challenges are always served as `text/html` in practice (covered by existing Tests 20/21).
- Binary content-types fall straight through to a `return res` and the caller's `res.arrayBuffer()` sees pristine bytes.

## What did not change

- `helpers.ts` (magic-byte detection) — already correct.
- `downloader/service.ts` / adapters — bytes were always correct downstream; only the upstream `Response` rebuild was corrupting them.
- `isCfChallengeHtml` and `peekCfBody` — unchanged.
- CF challenge handling for HTML 200 responses — Test 20 still passes unchanged.

## Test checklist

- [x] New Test 21b feeds an `image/webp` Response containing bytes that are invalid UTF-8 (`0x80 0xFF 0xC0 0xEF 0xBF 0xBE ...`); asserts byte-for-byte equality via `Array.from(buf)).toEqual(Array.from(original))`.
- [x] All 424 tests pass; typecheck clean; biome clean.
- [ ] Manual: re-pack volume 1 of the affected title; open the resulting `.cbz` and confirm pages render.

## Reviewer notes

- The textual matcher currently whitelists `text/*`, `application/json`, `application/xml`, `application/xhtml+xml`. Variants like `application/ld+json` or `application/*+xml` would fall into the binary path and skip CF detection. CF challenges are always `text/html` today, so this is safe — but if we ever proxy a CF-protected JSON-LD endpoint, we may want to widen the regex to `application/(.*\+)?(json|xml)`.
- The implementation deliberately does not magic-byte sniff the body as a fallback. Reasoning: real CDNs always set image content-types; sniffing the body would re-introduce the round-trip risk we're fixing.

## Closes

Ref: image corruption reported on `feat/walkthrough-volume-name-prompt` branch testing (zombie-100 volume 1)

### ✅ Checklist

- [x] Tested locally (`bun test && bun run typecheck && bun run check`)
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in \`docs/\` — N/A (internal HTTP client behavior; no API surface change)