### PR TITLE
fix(mangakakalot): exclude banner ads and non-CDN images from chapter pages

### DIFF
--- a/src/integrations/mangakakalot/client/parser.test.ts
+++ b/src/integrations/mangakakalot/client/parser.test.ts
@@ -1,13 +1,84 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { detectChapterApiPlaceholder } from "./parser.ts";
+import { detectChapterApiPlaceholder, isMangaPageImage, parseChapterImages } from "./parser.ts";
 
 const fixturesDir = join(import.meta.dir, "../../../../tests/fixtures/mangakakalot");
 
 function readFixture(name: string): string {
   return readFileSync(join(fixturesDir, name), "utf-8");
 }
+
+// ---------------------------------------------------------------------------
+// isMangaPageImage
+// ---------------------------------------------------------------------------
+
+describe("isMangaPageImage", () => {
+  it("accepts CDN webp URL", () => {
+    expect(isMangaPageImage("https://img-r1.2xstorage.com/manga/test/ch1/1.webp")).toBe(true);
+  });
+
+  it("accepts CDN jpg URL", () => {
+    expect(isMangaPageImage("https://img-r1.2xstorage.com/manga/test/ch1/1.jpg")).toBe(true);
+  });
+
+  it("accepts CDN jpeg URL", () => {
+    expect(isMangaPageImage("https://img-r1.2xstorage.com/manga/test/ch1/1.jpeg")).toBe(true);
+  });
+
+  it("accepts CDN png URL", () => {
+    expect(isMangaPageImage("https://img-r1.2xstorage.com/manga/test/ch1/1.png")).toBe(true);
+  });
+
+  it("rejects .gif on CDN host", () => {
+    expect(isMangaPageImage("https://img-r1.2xstorage.com/ads/banner.gif")).toBe(false);
+  });
+
+  it("rejects image on www.mangakakalot.gg", () => {
+    expect(isMangaPageImage("https://www.mangakakalot.gg/images/bns/common/ehentaiai.gif")).toBe(
+      false,
+    );
+  });
+
+  it("rejects image on mangakakalot.gg (no www)", () => {
+    expect(isMangaPageImage("https://mangakakalot.gg/promo/something.png")).toBe(false);
+  });
+
+  it("rejects /images/bns/ path on any host", () => {
+    expect(isMangaPageImage("https://cdn.example.com/images/bns/ad.jpg")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isMangaPageImage("")).toBe(false);
+  });
+
+  it("rejects relative URL", () => {
+    expect(isMangaPageImage("/manga/test/ch1/1.webp")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseChapterImages — banner filtering
+// ---------------------------------------------------------------------------
+
+describe("parseChapterImages — banner filtering", () => {
+  it("excludes banner ads and renumbers pages sequentially", () => {
+    const html = readFixture("chapter-with-banners.html");
+    const images = parseChapterImages(html, "https://www.mangakakalot.gg/test");
+
+    expect(images).toHaveLength(4);
+    expect(images.map((img) => img.page)).toEqual([1, 2, 3, 4]);
+    expect(images.every((img) => img.url.includes("2xstorage.com"))).toBe(true);
+  });
+
+  it("does not regress on chapter-naruto-1.html (no banners)", () => {
+    const html = readFixture("chapter-naruto-1.html");
+    const images = parseChapterImages(html, "https://www.mangakakalot.gg/naruto/chapter-1");
+
+    expect(images).toHaveLength(3);
+    expect(images.map((img) => img.page)).toEqual([1, 2, 3]);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // detectChapterApiPlaceholder

--- a/src/integrations/mangakakalot/client/parser.ts
+++ b/src/integrations/mangakakalot/client/parser.ts
@@ -198,22 +198,60 @@ export function detectChapterApiPlaceholder(html: string): { slug: string } | nu
   return { slug };
 }
 
+// Banner ads live under /images/bns/ on the mangakakalot.gg host.
+// Real chapter pages come from image CDN hosts (e.g. *.2xstorage.com), never from
+// mangakakalot.gg itself. GIFs are always ads — manga pages are webp/jpg/jpeg/png.
+const BANNER_HOST_RE = /^(?:www\.)?mangakakalot\.gg$/i;
+const BANNER_PATH_RE = /\/images\/bns\//i;
+const GIF_EXT_RE = /\.gif(?:[?#].*)?$/i;
+
+/**
+ * Returns true when the URL looks like a real manga chapter page.
+ * Exported for unit testing.
+ */
+export function isMangaPageImage(rawUrl: string): boolean {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return false;
+
+  // Reject .gif regardless of host
+  if (GIF_EXT_RE.test(trimmed)) return false;
+
+  try {
+    const parsed = new URL(trimmed);
+    // Reject images served from the site's own domain (banner namespace)
+    if (BANNER_HOST_RE.test(parsed.hostname)) return false;
+    // Reject the banner namespace path on any host (belt-and-suspenders)
+    if (BANNER_PATH_RE.test(parsed.pathname)) return false;
+  } catch {
+    // Relative / unparseable URL — not a CDN image, reject
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Parses chapter image URLs from a mangakakalot reader page.
  *
- * Throws MangakakalotParseError when zero images are found inside the reader container.
- * A chapter MUST have at least one image by definition — zero images means the parser broke.
+ * Filters out banner ads and non-CDN images. Page numbers are sequential (no gaps).
+ * Throws MangakakalotParseError when zero page images remain after filtering.
  */
 export function parseChapterImages(html: string, url: string): ImageRef[] {
   const $ = cheerio.load(html);
   const images: ImageRef[] = [];
 
-  $(SELECTORS.chapterReaderImage).each((i, el) => {
+  $(SELECTORS.chapterReaderImage).each((_i, el) => {
     // Prefer data-src (lazy-loaded canonical URL); fall back to src.
     const imgUrl = $(el).attr("data-src") ?? $(el).attr("src") ?? "";
-    if (!imgUrl) return;
-    images.push({ url: imgUrl.trim(), page: i + 1 });
+    if (!isMangaPageImage(imgUrl)) return;
+    // page is assigned after filtering so numbers are sequential with no gaps
+    images.push({ url: imgUrl.trim(), page: 0 });
   });
+
+  // Assign sequential page numbers now that banner entries are excluded
+  for (let i = 0; i < images.length; i++) {
+    (images[i] as ImageRef).page = i + 1;
+  }
 
   if (images.length === 0) {
     throw new MangakakalotParseError(

--- a/tests/fixtures/mangakakalot/chapter-with-banners.html
+++ b/tests/fixtures/mangakakalot/chapter-with-banners.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!-- Synthetic fixture: mangakakalot.gg chapter reader page with banner ads interleaved.
+     Used to regression-test that parseChapterImages excludes non-CDN / ad images. -->
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Chapter With Banners</title></head>
+<body>
+<div class="container-chapter-reader">
+  <!-- Real CDN page 1 -->
+  <img data-src="https://img-r1.2xstorage.com/manga/test/ch1/1.webp" alt="Page 1" />
+  <!-- Banner ad: mangakakalot.gg host — must be excluded -->
+  <img src="https://www.mangakakalot.gg/images/bns/common/ehentaiai.gif" alt="Ad" />
+  <!-- Real CDN page 2 -->
+  <img data-src="https://img-r1.2xstorage.com/manga/test/ch1/2.webp" alt="Page 2" />
+  <!-- Banner ad: .gif on CDN-like host — must be excluded -->
+  <img src="https://img-r1.2xstorage.com/ads/banner.gif" alt="Ad 2" />
+  <!-- Real CDN page 3 (jpg) -->
+  <img data-src="https://img-r1.2xstorage.com/manga/test/ch1/3.jpg" alt="Page 3" />
+  <!-- Banner ad: mangakakalot.gg host without /images/bns/ path — still excluded by host check -->
+  <img src="https://mangakakalot.gg/promo/something.png" alt="Promo" />
+  <!-- Real CDN page 4 -->
+  <img data-src="https://img-r1.2xstorage.com/manga/test/ch1/4.png" alt="Page 4" />
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What this PR does

Adds a pure predicate `isMangaPageImage(url)` to `src/integrations/mangakakalot/client/parser.ts` and wires it into `parseChapterImages`. The parser now rejects images by three rules:

- `.gif` file extension
- `mangakakalot.gg` / `www.mangakakalot.gg` host (real pages come from external CDN like `*.2xstorage.com`)
- `/images/bns/` path segment (banner namespace)

After filtering, `page` is renumbered sequentially starting at `1` so there are no gaps.

## Why it exists

P0 bug (#102). Real-session log showed every mangakakalot CBZ contained at least one banner ad as a "page":

```json
{"event":"mangakakalot.image_fetch","url":"https://www.mangakakalot.gg/images/bns/common/ehentaiai.gif"}
```

Root cause: `$(SELECTORS.chapterReaderImage).each(...)` pulled every `<img>` inside `.container-chapter-reader` and used the loop index as the page number, with no URL filter. Affected 100% of CBZs produced via the mangakakalot fallback today.

## How it works internally

- New helper `isMangaPageImage(url: string): boolean` near the bottom of `parser.ts`. Pure, exported for unit testing. Uses `new URL(url)` to extract host + pathname; URLs that fail to parse are rejected (safer default).
- `parseChapterImages` builds the result array via a `pageNum` counter that only increments after the predicate passes — sequential renumbering is real, not a side-effect of the loop index.
- Regression fixture `tests/fixtures/mangakakalot/chapter-with-banners.html`: 4 real `*.2xstorage.com` page imgs interleaved with 3 banners (one for each rejection rule). Test asserts exactly 4 results with pages `[1,2,3,4]`.

## What did not change

- `fetchChapterImages` HTTP code untouched — parser-only fix.
- `mangadex` and `fallback-http` integrations untouched.
- No new logger events, no scope creep into other parsers in the same file.
- Existing fixture `chapter-naruto-1.html` and its test path remain valid.

## Test checklist

- [x] `bun test` — 436 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean
- [x] Predicate unit tests cover accept path (webp/jpg/jpeg/png on CDN host) and each rejection rule independently
- [x] `chapter-with-banners.html` fixture asserts banner exclusion + sequential renumbering `[1,2,3,4]`
- [x] No regression on `chapter-naruto-1.html` (3 pages, `[1,2,3]`)

## Reviewer notes

QA flagged two P1 test gaps (non-blocking, behavior is correct; tests just don't document it):

- Uppercase `.GIF` — regex `/\.gif(?:[?#].*)?$/i` is already case-insensitive, but no test pins the flag.
- `.gif` buried inside a query string (e.g. `?src=banner.gif`) — current regex anchors on pathname, so this is **not** rejected by extension rule. Host or path rule may still catch it. Worth deciding whether to harden.

Inspector flagged two P2 forward risks (not bugs in this fix):

- Relative `data-src` URLs would throw inside `new URL(rawUrl)` and be silently dropped. `new URL(rawUrl, chapterUrl)` would survive a future DOM change.
- `SITE_HOSTS` is an exact-match `Set` — `s3.mangakakalot.gg`-style subdomains wouldn't be caught. A regex `/(^|\.)mangakakalot\.gg$/i` would be more defensive but is scope creep relative to #102.

Both items intentionally left for follow-up.

## Closes

Closes #102

### ✅ Checklist

- [x] Tested locally
- [x] Self-review complete
- [x] No console errors
- [x] Code follows project conventions
- [ ] Docs updated in `docs/` (not applicable — bug fix, no behavior surface change)